### PR TITLE
Converted TrafficIdentifer to an Enum

### DIFF
--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
@@ -12,7 +12,8 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
  */
 public final class IPTag extends Tag {
     /** Default traffic identifier. */
-    public static final String DEFAULT_TRAFFIC_IDENTIFIER = "DEFAULT";
+    public static final TrafficIdentifer DEFAULT_TRAFFIC_IDENTIFIER =
+            TrafficIdentifer.DEFAULT;
     private static final boolean DEFAULT_STRIP_SDP = false;
     private static final Integer DEFAULT_PORT = null;
 
@@ -21,7 +22,7 @@ public final class IPTag extends Tag {
     /** Indicates whether the SDP header should be removed. */
     private final boolean stripSDP;
     /** The identifier for traffic transmitted using this tag. */
-    private final String trafficIdentifier;
+    private final TrafficIdentifer trafficIdentifier;
     /** The coordinates where users of this tag should send packets to. */
     private final ChipLocation destination;
 
@@ -122,7 +123,7 @@ public final class IPTag extends Tag {
      */
     public IPTag(InetAddress boardAddress, ChipLocation destination, int tagID,
             InetAddress targetAddress, Integer port, boolean stripSDP,
-            String trafficIdentifier) {
+            TrafficIdentifer trafficIdentifier) {
         super(boardAddress, tagID, port);
         this.destination = destination;
         this.ipAddress = targetAddress;
@@ -143,7 +144,7 @@ public final class IPTag extends Tag {
     }
 
     /** @return The identifier of traffic using this tag. */
-    public String getTrafficIdentifier() {
+    public TrafficIdentifer getTrafficIdentifier() {
         return trafficIdentifier;
     }
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/TrafficIdentifer.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/TrafficIdentifer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ */
+package uk.ac.manchester.spinnaker.machine.tags;
+
+/**
+ * The types of traffic an IpTag can handle.
+ *
+ * @author Christian-B
+ */
+public enum TrafficIdentifer {
+
+    /** Default if not provided.
+     *  @see <a href=
+     * "https://github.com/SpiNNakerManchester/SpiNNMachine/blob/master/spinn_machine/tags/iptag.py">
+     * Python IPTag</a>
+     */
+    DEFAULT("DEFAULT"),
+    /** Used to identify buffered traffic.
+     *
+     *  @see <a href=
+     * "https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/blob/master/spinn_front_end_common/interface/buffer_management/recording_utilities.py">
+     * Python Recording Utilities</a>
+     */
+    BUFFERED("BufferTraffic");
+
+    /** Label used in Python. */
+    public final String label;
+
+    /**
+     * Main Constructor.
+     *
+     * @param label Python label.
+     */
+    TrafficIdentifer(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Finds a TrafficIdentier based on the label.
+     * @param label The label to check for. Currently case sensitive.
+     *
+     * @return The TrafficIdentifer with this label
+     * @throws IllegalArgumentException If this is an unexpected label.
+     */
+    public static TrafficIdentifer bylabel(String label) {
+        for (TrafficIdentifer ti: TrafficIdentifer.values()) {
+            if (ti.label.equals(label)) {
+                return ti;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No TrafficIdentifer with label " + label);
+    }
+}


### PR DESCRIPTION
fixes fact that traffic Identier is a String used in equals statements to type

Things to do in this repository
===============================
- [y ] javadoc correct.
- [ in later PR] test case(s).
