### PR TITLE
Fix broken SCP serialization

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -9,8 +9,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.Constants.MS_PER_S;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
-import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;
-import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -24,7 +22,6 @@ import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 
-import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResponse;
@@ -123,22 +120,11 @@ public class SCPRequestPipeline {
 		Request(SCPRequest<T> request, Consumer<T> callback,
 				SCPErrorHandler errorCallback) {
 			this.request = request;
-			this.requestData = getSCPData(request, connection.getChip());
+			this.requestData = request.getMessageData(connection.getChip());
 			this.callback = callback;
 			this.errorCallback = errorCallback;
 			retryReason = new ArrayList<>();
 			retries = numRetries;
-		}
-
-		private ByteBuffer getSCPData(SCPRequest<T> scpRequest,
-				ChipLocation chip) {
-			ByteBuffer buffer = newMessageBuffer();
-			if (scpRequest.sdpHeader.getFlags() == REPLY_EXPECTED) {
-				scpRequest.updateSDPHeaderForUDPSend(chip);
-			}
-			scpRequest.addToBuffer(buffer);
-			buffer.flip();
-			return buffer;
 		}
 
 		private void send() throws IOException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -3,6 +3,7 @@ package uk.ac.manchester.spinnaker.connections;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.model.SDPReceiver;
 import uk.ac.manchester.spinnaker.connections.model.SDPSender;
@@ -71,7 +72,9 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 	@Override
 	public SDPMessage receiveSDPMessage(Integer timeout)
 			throws IOException, InterruptedIOException {
-		return new SDPMessage(receive());
+		ByteBuffer buffer = receive();
+		buffer.getShort(); // SKIP TWO PADDING BYTES
+		return new SDPMessage(buffer);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -1,12 +1,8 @@
 package uk.ac.manchester.spinnaker.connections;
 
-import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;
-import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
-
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.InetAddress;
-import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.model.SDPReceiver;
 import uk.ac.manchester.spinnaker.connections.model.SDPSender;
@@ -17,7 +13,6 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 /** A UDP socket connection that talks SDP to SpiNNaker. */
 public class SDPConnection extends UDPConnection<SDPMessage>
 		implements SDPReceiver, SDPSender {
-	private static final ChipLocation ONE_WAY_SOURCE = new ChipLocation(0, 0);
 	private ChipLocation chip;
 
 	/**
@@ -70,16 +65,7 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 
 	@Override
 	public void sendSDPMessage(SDPMessage sdpMessage) throws IOException {
-		if (sdpMessage.sdpHeader.getFlags() == REPLY_EXPECTED) {
-			sdpMessage.updateSDPHeaderForUDPSend(chip);
-		} else {
-			sdpMessage.updateSDPHeaderForUDPSend(ONE_WAY_SOURCE);
-		}
-		ByteBuffer buffer = newMessageBuffer();
-		buffer.putShort((short) 0);
-		sdpMessage.addToBuffer(buffer);
-		buffer.flip();
-		send(buffer);
+		send(sdpMessage.getMessageData(chip));
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -67,7 +67,6 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	private boolean receivable;
 	private final ThreadLocal<SelectionKey> selectionKeyFactory;
 
-
 	/**
      * Main constructor any of which could null.
      * <p>
@@ -231,6 +230,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		if (addr == null) {
 			throw new SocketTimeoutException();
 		}
+		buffer.flip();
 		return buffer.order(LITTLE_ENDIAN);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -12,7 +12,6 @@ import static uk.ac.manchester.spinnaker.messages.Constants.IPV4_SIZE;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
 import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_NOT_EXPECTED;
 import static uk.ac.manchester.spinnaker.messages.sdp.SDPPort.RUNNING_COMMAND_SDP_PORT;
-import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
 import java.io.EOFException;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.connections.model.Connection;
 import uk.ac.manchester.spinnaker.connections.model.Listenable;
-import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
@@ -460,8 +458,6 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		return r;
 	}
 
-	private static final ChipLocation ONE_WAY_SOURCE = new ChipLocation(0, 0);
-
 	/**
 	 * Sends a port trigger message using a connection to (hopefully) open a
 	 * port in a NAT and/or firewall to allow incoming packets to be received.
@@ -482,10 +478,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		SDPMessage triggerMessage =
 				new SDPMessage(new SDPHeader(REPLY_NOT_EXPECTED,
 						new CoreLocation(0, 0, 0), RUNNING_COMMAND_SDP_PORT));
-		triggerMessage.updateSDPHeaderForUDPSend(ONE_WAY_SOURCE);
-		ByteBuffer b = newMessageBuffer();
-		triggerMessage.addToBuffer(b);
-		sendTo(b, host, SCP_SCAMP_PORT);
+		sendTo(triggerMessage.getMessageData(null), host, SCP_SCAMP_PORT);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
@@ -1,8 +1,5 @@
 package uk.ac.manchester.spinnaker.connections.model;
 
-import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;
-import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -21,15 +18,7 @@ public interface SCPSender extends Connection {
 	 *         start of the buffer and should end at the <i>position</i>.
 	 */
 	default ByteBuffer getSCPData(SCPRequest<?> scpRequest) {
-		ByteBuffer buffer = newMessageBuffer();
-		if (scpRequest.sdpHeader.getFlags() == REPLY_EXPECTED) {
-			scpRequest.updateSDPHeaderForUDPSend(getChip());
-		}
-		// First two bytes must be zero for SCP send
-		buffer.putShort((short) 0);
-		scpRequest.addToBuffer(buffer);
-		buffer.flip();
-		return buffer;
+		return scpRequest.getMessageData(getChip());
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
@@ -25,6 +25,8 @@ public interface SCPSender extends Connection {
 		if (scpRequest.sdpHeader.getFlags() == REPLY_EXPECTED) {
 			scpRequest.updateSDPHeaderForUDPSend(getChip());
 		}
+		// First two bytes must be zero for SCP send
+		buffer.position(2);
 		scpRequest.addToBuffer(buffer);
 		buffer.flip();
 		return buffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
@@ -26,7 +26,7 @@ public interface SCPSender extends Connection {
 			scpRequest.updateSDPHeaderForUDPSend(getChip());
 		}
 		// First two bytes must be zero for SCP send
-		buffer.position(2);
+		buffer.putShort((short) 0);
 		scpRequest.addToBuffer(buffer);
 		buffer.flip();
 		return buffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
@@ -156,7 +156,7 @@ public class BootMessages {
 		buffer.position(blockID * BOOT_MESSAGE_DATA_BYTES);
 		buffer.limit(buffer.position()
 				+ min(buffer.remaining(), BOOT_MESSAGE_DATA_BYTES));
-		assert buffer.hasRemaining();
+		assert buffer.hasRemaining() : "buffer must have space left";
 		return new BootMessage(FLOOD_FILL_BLOCK, 1, 0, 0, buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
@@ -33,8 +33,8 @@ import uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition;
 /** Represents a set of boot messages to be sent to boot the board. */
 public class BootMessages {
 	private static final int BOOT_MESSAGE_DATA_WORDS = 256;
-	private static final int BOOT_MESSAGE_DATA_BYTES = BOOT_MESSAGE_DATA_WORDS
-			* 4;
+	private static final int BOOT_MESSAGE_DATA_BYTES =
+			BOOT_MESSAGE_DATA_WORDS * 4;
 	private static final int BOOT_IMAGE_MAX_BYTES = 32 * 1024;
 	private static final int BOOT_STRUCT_REPLACE_OFFSET = 384;
 	private static final int BOOT_STRUCT_REPLACE_LENGTH = 128;
@@ -43,16 +43,20 @@ public class BootMessages {
 	private final ByteBuffer bootData;
 	private final int numDataPackets;
 
-	private static void initFlags(SystemVariableBootValues bootVars) {
+	private static SystemVariableBootValues initFlags(
+			SystemVariableBootValues bootVars) {
+		SystemVariableBootValues specific =
+				new SystemVariableBootValues(bootVars);
 		int currentTime = (int) (System.currentTimeMillis() / MS_PER_S);
-		bootVars.setValue(unix_timestamp, currentTime);
-		bootVars.setValue(boot_signature, currentTime);
-		bootVars.setValue(is_root_chip, 1);
+		specific.setValue(unix_timestamp, currentTime);
+		specific.setValue(boot_signature, currentTime);
+		specific.setValue(is_root_chip, 1);
+		return specific;
 	}
 
 	private BootMessages(SystemVariableBootValues bootVariables,
 			Map<SystemVariableDefinition, Object> extraBootValues) {
-		initFlags(bootVariables);
+		bootVariables = initFlags(bootVariables);
 		if (extraBootValues != null) {
 			for (Entry<SystemVariableDefinition, Object> entry : extraBootValues
 					.entrySet()) {
@@ -65,16 +69,16 @@ public class BootMessages {
 		bootData = readBootImage(getClass().getResource(BOOT_IMAGE));
 		arraycopy(buffer.array(), 0, bootData.array(),
 				BOOT_STRUCT_REPLACE_OFFSET, BOOT_STRUCT_REPLACE_LENGTH);
-		numDataPackets = (int) ceil(
-				bootData.limit() / (float) BOOT_MESSAGE_DATA_BYTES);
+		numDataPackets =
+				(int) ceil(bootData.limit() / (float) BOOT_MESSAGE_DATA_BYTES);
 	}
 
 	private static final int WORD_SIZE = 4;
+
 	private static ByteBuffer readBootImage(URL bootImage) {
 		// NB: This data is BIG endian!
-		ByteBuffer buffer = allocate(BOOT_IMAGE_MAX_BYTES + WORD_SIZE)
-				.order(BIG_ENDIAN);
-		buffer.position(0);
+		ByteBuffer buffer =
+				allocate(BOOT_IMAGE_MAX_BYTES + WORD_SIZE).order(BIG_ENDIAN);
 
 		try (DataInputStream is = new DataInputStream(bootImage.openStream())) {
 			while (true) {
@@ -133,8 +137,7 @@ public class BootMessages {
 	 * @param extraBootValues
 	 *            Any additional values to be set during boot
 	 */
-	public BootMessages(
-			Map<SystemVariableDefinition, Object> extraBootValues) {
+	public BootMessages(Map<SystemVariableDefinition, Object> extraBootValues) {
 		this(new SystemVariableBootValues(), extraBootValues);
 	}
 
@@ -162,12 +165,14 @@ public class BootMessages {
 
 	/** @return a stream of message to be sent. */
 	public Stream<BootMessage> getMessages() {
-		Stream<BootMessage> first = singleton(new BootMessage(
-				FLOOD_FILL_START, 0, 0, numDataPackets - 1)).stream();
+		Stream<BootMessage> first = singleton(
+				new BootMessage(FLOOD_FILL_START, 0, 0, numDataPackets - 1))
+						.stream();
 		Stream<BootMessage> mid =
 				range(0, numDataPackets).mapToObj(this::getBootMessage);
-		Stream<BootMessage> last = singleton(
-				new BootMessage(FLOOD_FILL_CONTROL, 1, 0, 0)).stream();
+		Stream<BootMessage> last =
+				singleton(new BootMessage(FLOOD_FILL_CONTROL, 1, 0, 0))
+						.stream();
 		return concat(first, concat(mid, last));
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
@@ -1,9 +1,9 @@
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.Byte.toUnsignedInt;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,9 +33,9 @@ public final class VersionInfo {
 	/** The location of the core where the information was obtained. */
 	public final HasCoreLocation core;
 
-	private static final Charset UTF_8 = Charset.forName("UTF-8");
 	private static final Pattern VERSION_RE = Pattern
-			.compile("^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<revision>\\d+)$");
+			.compile("(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<revision>\\d+)");
+	private static final String NUL = "\u0000";
 
 	private static Version parseVersionString(String versionString) {
 		Matcher m = VERSION_RE.matcher(versionString);
@@ -68,18 +68,18 @@ public final class VersionInfo {
 			versionString = decoded;
 			versionNumber = new Version(vn / H, vn % H, 0);
 		} else {
-			String[] bits = decoded.split("\0", NBITS);
-			if (bits.length != NBITS) {
+			String[] bits = decoded.split(NUL, FULL_BITS);
+			if (bits.length < NAME_BITS || bits.length > FULL_BITS) {
 				throw new IllegalArgumentException(
 						"incorrect version format: " + original);
 			}
-			decoded = bits[0].replaceFirst("[\0]+$", "");
+			decoded = bits[0];
 			versionString = bits[1];
 			versionNumber = parseVersionString(versionString);
 		}
 
-		String[] bits = decoded.split("/", NBITS);
-		if (bits.length != NBITS) {
+		String[] bits = decoded.split("/", NAME_BITS);
+		if (bits.length != NAME_BITS) {
 			throw new IllegalArgumentException(
 					"incorrect version format: " + original);
 		}
@@ -88,6 +88,7 @@ public final class VersionInfo {
 	}
 
 	private static final int H = 100;
-	private static final int NBITS = 2;
+	private static final int FULL_BITS = 3;
+	private static final int NAME_BITS = 2;
 	private static final int MAGIC_VERSION = 0xFFFF;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
@@ -57,7 +57,7 @@ public final class VersionInfo {
 		int y = toUnsignedInt(buffer.get());
 		int x = toUnsignedInt(buffer.get());
 		core = new CoreLocation(x, y, p);
-		buffer.getShort(); // Ignore 2 byes
+		buffer.getShort(); // Ignore 2 bytes
 		int vn = Short.toUnsignedInt(buffer.getShort());
 		buildDate = buffer.getInt();
 
@@ -68,12 +68,12 @@ public final class VersionInfo {
 			versionString = decoded;
 			versionNumber = new Version(vn / H, vn % H, 0);
 		} else {
-			String[] bits = decoded.split("\\|0", NBITS);
+			String[] bits = decoded.split("\0", NBITS);
 			if (bits.length != NBITS) {
 				throw new IllegalArgumentException(
 						"incorrect version format: " + original);
 			}
-			decoded = bits[0].replaceFirst("[|0]+$", "");
+			decoded = bits[0].replaceFirst("[\0]+$", "");
 			versionString = bits[1];
 			versionNumber = parseVersionString(versionString);
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
@@ -25,6 +25,7 @@ public abstract class SCPResponse {
 	protected SCPResponse(ByteBuffer buffer) {
 		assert buffer.position() == 0;
 		assert buffer.order() == LITTLE_ENDIAN;
+		buffer.getShort(); // SKIP TWO PADDING BYTES
 		sdpHeader = new SDPHeader(buffer);
 		result = SCPResult.get(buffer.getShort());
 		sequence = buffer.getShort();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
@@ -23,8 +23,9 @@ public abstract class SCPResponse {
 	 *            the buffer to deserialise from
 	 */
 	protected SCPResponse(ByteBuffer buffer) {
-		assert buffer.position() == 0;
-		assert buffer.order() == LITTLE_ENDIAN;
+		assert buffer.position() == 0 : "buffer.position=" + buffer.position();
+		assert buffer.order() == LITTLE_ENDIAN : "buffer.order="
+				+ buffer.order();
 		buffer.getShort(); // SKIP TWO PADDING BYTES
 		sdpHeader = new SDPHeader(buffer);
 		result = SCPResult.get(buffer.getShort());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
@@ -1,5 +1,6 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_LEN;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_P2P_NOREPLY;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_P2P_TIMEOUT;
@@ -35,10 +36,11 @@ public class SCPResultMessage {
 	 *            without header stripped.
 	 */
 	public SCPResultMessage(ByteBuffer response) {
+		ByteBuffer peek = response.duplicate().order(LITTLE_ENDIAN);
 		// Skip the padding bytes and the SDP header
-		response.get(new byte[SKIP_HEADER_BYTES]);
-		result = SCPResult.get(response.getShort());
-		sequenceNumber = response.getShort();
+		peek.position(SKIP_HEADER_BYTES);
+		result = SCPResult.get(peek.getShort());
+		sequenceNumber = peek.getShort();
 		responseData = response;
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
@@ -12,6 +12,8 @@ import java.util.Set;
 
 /** The low-level format of SCP result message. */
 public class SCPResultMessage {
+	private static final int SDP_HEADER_LENGTH = 8;
+	private static final int SKIP_HEADER_BYTES = 2 + SDP_HEADER_LENGTH;
 	private static final Set<SCPResult> RETRY_CODES = new HashSet<>();
 	static {
 		RETRY_CODES.add(RC_TIMEOUT);
@@ -33,6 +35,8 @@ public class SCPResultMessage {
 	 *            without header stripped.
 	 */
 	public SCPResultMessage(ByteBuffer response) {
+		// Skip the padding bytes and the SDP header
+		response.get(new byte[SKIP_HEADER_BYTES]);
 		result = SCPResult.get(response.getShort());
 		sequenceNumber = response.getShort();
 		responseData = response;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
@@ -91,6 +91,8 @@ public class SDPHeader implements SerializableMessage {
 	 *            The buffer to read from.
 	 */
 	public SDPHeader(ByteBuffer buffer) {
+		// Caller MUST have stripped the leading padding
+		assert buffer.position() == 2;
 		flags = Flag.get(buffer.get());
 		tag = Byte.toUnsignedInt(buffer.get());
 		int dpc = toUnsignedInt(buffer.get());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
@@ -92,7 +92,7 @@ public class SDPHeader implements SerializableMessage {
 	 */
 	public SDPHeader(ByteBuffer buffer) {
 		// Caller MUST have stripped the leading padding
-		assert buffer.position() == 2;
+		assert buffer.position() == 2 : "leading padding must be skipped";
 		flags = Flag.get(buffer.get());
 		tag = Byte.toUnsignedInt(buffer.get());
 		int dpc = toUnsignedInt(buffer.get());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
@@ -1,5 +1,11 @@
 package uk.ac.manchester.spinnaker.messages.sdp;
 
+import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;
+import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
+
+import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
@@ -12,6 +18,7 @@ import uk.ac.manchester.spinnaker.messages.SerializableMessage;
  * @author Donal Fellows
  */
 public abstract class SpinnakerRequest implements SerializableMessage {
+	private static final ChipLocation ONE_WAY_SOURCE = new ChipLocation(0, 0);
 	private static final int SDP_SOURCE_PORT = 7;
 	private static final int SDP_SOURCE_CPU = 31;
 	private static final byte SDP_TAG = (byte) 0xFF;
@@ -37,6 +44,27 @@ public abstract class SpinnakerRequest implements SerializableMessage {
 		sdpHeader.setTag(SDP_TAG);
 		sdpHeader.setSourcePort(SDP_SOURCE_PORT);
 		sdpHeader.setSource(new SDPSource(chip));
+	}
+
+	/**
+	 * Get a buffer holding the actual bytes of the message, ready to send.
+	 *
+	 * @param originatingChip
+	 *            Where the message notionally originates from.
+	 * @return The byte buffer.
+	 */
+	public final ByteBuffer getMessageData(HasChipLocation originatingChip) {
+		ByteBuffer buffer = newMessageBuffer();
+		if (sdpHeader.getFlags() == REPLY_EXPECTED) {
+			updateSDPHeaderForUDPSend(originatingChip);
+		} else {
+			updateSDPHeaderForUDPSend(ONE_WAY_SOURCE);
+		}
+		// First two bytes must be zero for SCP send
+		buffer.putShort((short) 0);
+		addToBuffer(buffer);
+		buffer.flip();
+		return buffer;
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
@@ -72,7 +72,8 @@ public abstract class SpinnakerRequest implements SerializableMessage {
 
 		/** Source for one-way sending. */
 		SDPSource() {
-			x = y = 0;
+			x = 0;
+			y = 0;
 		}
 
 		/** Source for nominated location sending, needed for replies. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadMemoryProcess.java
@@ -1,5 +1,6 @@
 package uk.ac.manchester.spinnaker.processes;
 
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -30,6 +31,7 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	private static class Accumulator {
 		private final ByteBuffer buffer;
 		private boolean done = false;
+		private int maxpos = 0;
 
 		Accumulator(int size) {
 			buffer = allocate(size).order(LITTLE_ENDIAN);
@@ -47,11 +49,12 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 			ByteBuffer b = buffer.duplicate();
 			b.position(position);
 			b.put(otherBuffer);
+			maxpos = max(maxpos, b.position());
 		}
 
 		synchronized ByteBuffer finish() {
 			done = true;
-			buffer.flip();
+			buffer.position(maxpos).flip();
 			return buffer.asReadOnlyBuffer().order(LITTLE_ENDIAN);
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
@@ -7,8 +7,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.Constants.BMP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.Constants.MS_PER_S;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
-import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;
-import static uk.ac.manchester.spinnaker.transceiver.Utils.newMessageBuffer;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -26,7 +24,6 @@ import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.selectors.ConnectionSelector;
-import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
@@ -150,18 +147,8 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 
 			private Request(BMPRequest<R> request, Consumer<R> callback) {
 				this.request = request;
-				this.requestData = getData(connection.getChip());
+				this.requestData = request.getMessageData(connection.getChip());
 				this.callback = callback;
-			}
-
-			private ByteBuffer getData(ChipLocation chip) {
-				ByteBuffer buffer = newMessageBuffer();
-				if (request.sdpHeader.getFlags() == REPLY_EXPECTED) {
-					request.updateSDPHeaderForUDPSend(chip);
-				}
-				request.addToBuffer(buffer);
-				buffer.flip();
-				return buffer;
 			}
 
 			private void send() throws IOException {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
 
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -35,6 +34,7 @@ public class TestUDPConnection {
 	public void testSCPVersionWithBoard() throws Exception {
 		board_config.set_up_remote_board();
 		GetVersion scp_req = new GetVersion(ZERO_CORE);
+		scp_req.scpRequestHeader.issueSequenceNumber();
 		SCPResultMessage result;
         Inet4Address remoteHost = InetFactory.getByName(board_config.remotehost);
 		try (SCPConnection connection = new SCPConnection(remoteHost)) {
@@ -48,11 +48,12 @@ public class TestUDPConnection {
 	@Test
 	public void testSCPReadLinkWoard() throws Exception {
 		board_config.set_up_remote_board();
-		ReadLink scp_link = new ReadLink(ZERO_CHIP, 0, 0x70000000, 250);
+		ReadLink scp_req = new ReadLink(ZERO_CHIP, 0, 0x70000000, 250);
+		scp_req.scpRequestHeader.issueSequenceNumber();
 		SCPResultMessage result;
         Inet4Address remoteHost = InetFactory.getByName(board_config.remotehost);
 		try (SCPConnection connection = new SCPConnection(remoteHost)) {
-			connection.sendSCPRequest(scp_link);
+			connection.sendSCPRequest(scp_req);
 			result = connection.receiveSCPResponse(null);
 		}
 		assertEquals(result.getResult(), RC_OK);
@@ -61,11 +62,12 @@ public class TestUDPConnection {
 	@Test
 	public void testSCPReadMemoryWithBoard() throws Exception {
 		board_config.set_up_remote_board();
-		ReadMemory scp_link = new ReadMemory(ZERO_CHIP, 0x70000000, 256);
+		ReadMemory scp_req = new ReadMemory(ZERO_CHIP, 0x70000000, 256);
+		scp_req.scpRequestHeader.issueSequenceNumber();
 		SCPResultMessage result;
         Inet4Address remoteHost = InetFactory.getByName(board_config.remotehost);
 		try (SCPConnection connection = new SCPConnection(remoteHost)) {
-			connection.sendSCPRequest(scp_link);
+			connection.sendSCPRequest(scp_req);
 			result = connection.receiveSCPResponse(null);
 		}
 		assertEquals(result.getResult(), RC_OK);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestCountState.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestCountState.java
@@ -1,10 +1,11 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag;
 
 class TestCountState {
+	private static final short PADDING = 0;
 
 	@Test
 	void testNewStateRequest() {
@@ -39,7 +41,7 @@ class TestCountState {
         int src_x = 0x7;
         int src_y = 0x0;
 
-        ByteBuffer data = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer data = allocate(18).order(LITTLE_ENDIAN).putShort(PADDING);
         data.put(flags.value);
         data.put((byte) tag);
         data.put((byte) dest_port_cpu);
@@ -80,7 +82,7 @@ class TestCountState {
 		byte src_x = 0x7;
 		byte src_y = 0x0;
 
-		ByteBuffer data = ByteBuffer.allocate(39).order(ByteOrder.LITTLE_ENDIAN);
+		ByteBuffer data = allocate(41).order(LITTLE_ENDIAN).putShort(PADDING);
 		data.put(flags.value).put(tag).put(dest_port_cpu).put(src_port_cpu);
 		data.put(dest_y).put(dest_x).put(src_y).put(src_x);
 		data.putShort(rc.value).putShort(seq).putShort(p2p_addr);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 class TestOKResponse {
+	private static final short PADDING = 0;
+
 	private short encode_addr_tuple(int dest_port, int dest_cpu, int src_port,
 			int src_cpu) {
 		return (short) (dest_port << 13 | dest_cpu << 8 | src_port << 5
@@ -46,7 +48,7 @@ class TestOKResponse {
 		short src_x_y_short = (short) (src_x << 8 | src_y);
 
 		short seq = 103;
-		ByteBuffer bytes = allocate(12).order(LITTLE_ENDIAN);
+		ByteBuffer bytes = allocate(14).order(LITTLE_ENDIAN).putShort(PADDING);
 		bytes.putShort(flag_tag_short).putShort(dest_source_short);
 		bytes.putShort(dest_x_y_short).putShort(src_x_y_short);
 		bytes.putShort(result).putShort(seq).flip();
@@ -79,7 +81,7 @@ class TestOKResponse {
 		short src_x_y_short = (short) (src_x << 8 | src_y);
 
 		short seq = 103;
-		ByteBuffer bytes = allocate(12).order(LITTLE_ENDIAN);
+		ByteBuffer bytes = allocate(14).order(LITTLE_ENDIAN).putShort(PADDING);
 		bytes.putShort(flag_tag_short).putShort(dest_source_short);
 		bytes.putShort(dest_x_y_short).putShort(src_x_y_short);
 		bytes.putShort(result).putShort(seq).flip();

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
@@ -29,7 +29,7 @@ class TestVersion {
 	}
 
 	@Test
-	void testParseVersionResponse() throws UnsupportedEncodingException,
+	void testParseVersionResponseFormat1() throws UnsupportedEncodingException,
 			UnexpectedResponseCodeException {
 		// SCP Stuff
 		short rc = RC_OK.value;
@@ -62,7 +62,47 @@ class TestVersion {
 
 		Response response = new GetVersion.Response(data);
 		assertEquals("sark", response.versionInfo.name);
-		assertEquals("sark/spinnaker", response.versionInfo.versionString);
+		assertEquals("spinnaker", response.versionInfo.hardware);
 		assertEquals(new Version(2, 34, 0), response.versionInfo.versionNumber);
+		assertEquals(new CoreLocation(14, 31, 0), response.versionInfo.core);
+	}
+
+	@Test
+	void testParseVersionResponseFormat2() throws UnsupportedEncodingException,
+			UnexpectedResponseCodeException {
+		// SCP Stuff
+		short rc = RC_OK.value;
+		short seq = 105;
+		short p2p_addr = 1024;
+		byte phys_cpu = 31;
+		byte virt_cpu = 14;
+		short version = -1;
+		short buffer = 250;
+		int build_date = 103117;
+		byte[] ver_string = "SC&MP/SpiNNaker\u00003.2.0".getBytes("ASCII");
+
+		// SDP stuff
+		byte flags = REPLY_NOT_EXPECTED.value;
+		byte tag = 5;
+		byte dest_port_cpu = 0x4f;
+		byte src_port_cpu = 0x6a;
+		byte dest_x = 0x11;
+		byte dest_y = (byte) 0xab;
+		byte src_x = 0x7;
+		byte src_y = 0x0;
+
+		ByteBuffer data = allocate(60).order(LITTLE_ENDIAN).putShort(PADDING);
+		data.put(flags).put(tag).put(dest_port_cpu).put(src_port_cpu);
+		data.put(dest_y).put(dest_x).put(src_y).put(src_x);
+		data.putShort(rc).putShort(seq).putShort(p2p_addr);
+		data.put(phys_cpu).put(virt_cpu).putShort(buffer).putShort(version);
+		data.putInt(build_date).put(ver_string);
+		data.flip();
+
+		Response response = new GetVersion.Response(data);
+		assertEquals("SC&MP", response.versionInfo.name);
+		assertEquals("SpiNNaker", response.versionInfo.hardware);
+		assertEquals(new Version(3, 2, 0), response.versionInfo.versionNumber);
+		assertEquals(new CoreLocation(14, 31, 0), response.versionInfo.core);
 	}
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
@@ -1,7 +1,9 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static java.lang.String.join;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_VER;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
@@ -40,7 +42,7 @@ class TestVersion {
 		short version = 234;
 		short buffer = 250;
 		int build_date = 103117;
-		byte[] ver_string = "sark/spinnaker".getBytes("ASCII");
+		byte[] ver_string = "sark/spinnaker".getBytes(US_ASCII);
 
 		// SDP stuff
 		byte flags = REPLY_NOT_EXPECTED.value;
@@ -79,7 +81,8 @@ class TestVersion {
 		short version = -1;
 		short buffer = 250;
 		int build_date = 103117;
-		byte[] ver_string = "SC&MP/SpiNNaker\u00003.2.0".getBytes("ASCII");
+		byte[] ver_string = join("\u0000", "SC&MP/SpiNNaker", "3.2.0", "")
+				.getBytes(US_ASCII);
 
 		// SDP stuff
 		byte flags = REPLY_NOT_EXPECTED.value;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
@@ -18,6 +18,7 @@ import uk.ac.manchester.spinnaker.messages.model.Version;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion.Response;
 
 class TestVersion {
+	private static final short PADDING = 0;
 
 	@Test
 	void testNewVersionRequest() {
@@ -51,7 +52,7 @@ class TestVersion {
 		byte src_x = 0x7;
 		byte src_y = 0x0;
 
-		ByteBuffer data = allocate(39).order(LITTLE_ENDIAN);
+		ByteBuffer data = allocate(41).order(LITTLE_ENDIAN).putShort(PADDING);
 		data.put(flags).put(tag).put(dest_port_cpu).put(src_port_cpu);
 		data.put(dest_y).put(dest_x).put(src_y).put(src_x);
 		data.putShort(rc).putShort(seq).putShort(p2p_addr);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
@@ -29,16 +29,16 @@ import uk.ac.manchester.spinnaker.spalloc.messages.State;
 import uk.ac.manchester.spinnaker.spalloc.messages.WhereIs;
 
 /**
- * Tests the Spalloc Client ideally using an actual connection 
+ * Tests the Spalloc Client ideally using an actual connection
  *      but with a backup of canned replies if the connection fails/ timesout.
- * 
+ *
  * @author Christian
  */
 public class TestMockClient {
 
         static int timeout = 1000;
         static MockConnectedClient client = new MockConnectedClient(timeout);
-        
+
         @Test
         void testListJobs() throws IOException, SpallocServerException, Exception {
             try (AutoCloseable c = client.withConnection()) {
@@ -48,7 +48,7 @@ public class TestMockClient {
                     jobs.forEach(d -> assertThat("Jobid > 0", d.getJobID(), greaterThan(0)));
                 } else {
                     int[] expectedIDs = { 47224, 47444};
-                    assertArrayEquals(expectedIDs, 
+                    assertArrayEquals(expectedIDs,
                             jobs.stream().mapToInt(j -> j.getJobID()).toArray());
                 }
             }
@@ -87,15 +87,15 @@ public class TestMockClient {
         }
 
         private void checkNotification(int jobId, String machineName) {
-            
+
         }
-        
+
         @Test
         void testJob() throws IOException, SpallocServerException, Exception {
             Notification notification = null;
             try (AutoCloseable c = client.withConnection()) {
                 List<Integer> args = new ArrayList<>();
-                Map<String, Object> kwargs = new HashMap<>();   
+                Map<String, Object> kwargs = new HashMap<>();
                 kwargs.put("owner", "Unittest. OK to kill after 1 minute.");
                 int jobId = client.createJob(args, kwargs, timeout);
                 if (client.isActual()) {
@@ -107,10 +107,10 @@ public class TestMockClient {
                 JobMachineInfo machineInfo = client.getJobMachineInfo(jobId, timeout);
                 String machineName = machineInfo.getMachineName();
                 if (client.isActual()) {
-                    assert(!machineName.isEmpty());
+                    assert !machineName.isEmpty() : "must have a machine name";
                 } else {
                     assertEquals("Spin24b-223", machineName);
-                }          
+                }
                 List<Connection> connections = machineInfo.getConnections();
                 String hostName = connections.get(0).getHostname();
                 if (client.isActual()) {
@@ -129,9 +129,8 @@ public class TestMockClient {
                 }
                 if (client.isActual()) {
                     notification = client.waitForNotification(-1);
-                    //assert (notification.getClass() == JobsChangedNotification.class);
-                    JobsChangedNotification jcn = (JobsChangedNotification)notification;
-                }                
+                    JobsChangedNotification.class.cast(notification);
+                }
                 assertEquals(State.POWER, state.getState());
                 if (client.isActual()) {
                     assertFalse(state.getPower());
@@ -154,7 +153,7 @@ public class TestMockClient {
                 if (client.isActual()) {
                    assertEquals(State.DESTROYED, state.getState());
                 }
-             }   
+             }
         }
 
         @Test
@@ -166,5 +165,5 @@ public class TestMockClient {
                 }
             }
         }
-                
+
  }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestMachine.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestMachine.java
@@ -36,7 +36,7 @@ public class TestMachine {
         assertEquals(0, fromJson.getDeadLinks().size());
         assertNotNull(fromJson.toString());
     }
-    
+
     @Test
     void testAssumedDeadLinks() throws IOException {
         String json = "{\"name\":\"power-monitor\","
@@ -58,17 +58,17 @@ public class TestMachine {
         assertNotNull(fromJson.toString());
     }
 
-    @Test
-    void testNullJson() throws IOException {
-        String json = "{\"name\":null}";
-        ObjectMapper mapper = SpallocClient.createMapper();
-        Machine fromJson = mapper.readValue(json, Machine.class);
-        assertNull(fromJson.getName());
-        assert(fromJson.getTags().isEmpty());
-        assertEquals(0, fromJson.getWidth());
-        assertEquals(0, fromJson.getHeight());
-        assert(fromJson.getDeadBoards().isEmpty());
-        assert(fromJson.getDeadLinks().isEmpty());
-        assertNotNull(fromJson.toString());
-    }
+	@Test
+	void testNullJson() throws IOException {
+		String json = "{\"name\":null}";
+		ObjectMapper mapper = SpallocClient.createMapper();
+		Machine fromJson = mapper.readValue(json, Machine.class);
+		assertNull(fromJson.getName());
+		assert fromJson.getTags().isEmpty() : "must have no tags";
+		assertEquals(0, fromJson.getWidth());
+		assertEquals(0, fromJson.getHeight());
+		assert fromJson.getDeadBoards().isEmpty() : "must have no dead boards";
+		assert fromJson.getDeadLinks().isEmpty() : "must have no dead links";
+		assertNotNull(fromJson.toString());
+	}
 }

--- a/SpiNNaker-comms/src/test/resources/testconfig/test.cfg
+++ b/SpiNNaker-comms/src/test/resources/testconfig/test.cfg
@@ -1,6 +1,6 @@
 [Machine]
-machineName = spinn-2.cs.man.ac.uk
-bmp_names = spinn-2c.cs.man.ac.uk
+machineName = spinn-4.cs.man.ac.uk
+bmp_names = spinn-4c.cs.man.ac.uk
 version = 5
 
 #machineName = 192.168.240.253


### PR DESCRIPTION
Needs two extra leading zero bytes to match [`scamp_connection.py`, line 67](https://github.com/SpiNNakerManchester/SpiNNMan/blob/4d8c85fb878dc7a636ccb23cfc9f00ede90d7303/spinnman/connections/udp_packet_connections/scamp_connection.py#L67).