### PR TITLE
JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+  - openjdk11
 cache:
   directories:
     - $HOME/.m2

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
@@ -21,20 +21,20 @@ public class BootConnection extends UDPConnection<BootMessage>
 
 	/**
 	 * @param localHost
-	 *            The local host to bind to. If <tt>null</tt>
-	 *            defaults to bind to all interfaces, unless remoteHost is
-	 *            specified, in which case binding is done to the IP address
-	 *            that will be used to send packets.
+	 *            The local host to bind to. If {@code null} defaults to bind to
+	 *            all interfaces, unless remoteHost is specified, in which case
+	 *            binding is done to the IP address that will be used to send
+	 *            packets.
 	 * @param localPort
 	 *            The local port to bind to, between 1025 and 65535. If
-	 *            <tt>null</tt>, defaults to a random unused local port
+	 *            {@code null}, defaults to a random unused local port
 	 * @param remoteHost
-	 *            The remote host to send packets to. If
-	 *            <tt>null</tt>, the socket will be available for listening
-	 *            only, and will throw and exception if used for sending
+	 *            The remote host to send packets to. If {@code null}, the
+	 *            socket will be available for listening only, and will throw
+	 *            and exception if used for sending
 	 * @param remotePort
-	 *            The remote port to send packets to. If <tt>null</tt>, a
-	 *            default value is used.
+	 *            The remote port to send packets to. If {@code null}, a default
+	 *            value is used.
 	 * @throws IOException
 	 *             If there is an error setting up the communication channel
 	 */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
@@ -59,7 +59,7 @@ public class ConnectionListener<MessageType> extends Thread
 	 *            The maximum number of threads to use to do the listening.
 	 * @param timeout
 	 *            How long to wait in the OS for a message to arrive; if
-	 *            <tt>null</tt>, wait indefinitely.
+	 *            {@code null}, wait indefinitely.
 	 */
 	public ConnectionListener(Listenable<MessageType> connection,
 			int numProcesses, Integer timeout) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
@@ -71,7 +71,7 @@ public class EIEIOConnection
 	 *            and exception if used for sending.
 	 * @param remotePort
 	 *            The remote port to send packets to. If remoteHost is
-	 *            <tt>null</tt>, this is ignored. If remoteHost is specified,
+	 *            {@code null}, this is ignored. If remoteHost is specified,
 	 *            this must also be specified as non-zero for the connection to
 	 *            allow sending.
 	 * @throws IOException

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
@@ -28,7 +28,7 @@ public class IPAddressConnection extends UDPConnection<InetAddress> {
 	}
 
 	/**
-	 * @return The IP address, or <tt>null</tt> if none was forthcoming.
+	 * @return The IP address, or {@code null} if none was forthcoming.
 	 */
 	public final InetAddress receiveIPAddress() {
 		return receiveIPAddress(null);
@@ -36,8 +36,8 @@ public class IPAddressConnection extends UDPConnection<InetAddress> {
 
 	/**
 	 * @param timeout
-	 *            How long to wait for an IP address; <tt>null</tt> for forever.
-	 * @return The IP address, or <tt>null</tt> if none was forthcoming.
+	 *            How long to wait for an IP address; {@code null} for forever.
+	 * @return The IP address, or {@code null} if none was forthcoming.
 	 */
 	public InetAddress receiveIPAddress(Integer timeout) {
 		try {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -37,7 +37,7 @@ public class SCPConnection extends SDPConnection
 	 *            The remote host to send messages to.
 	 * @param remotePort
 	 *            The optional remote port number to send messages to. If
-	 *            <tt>null</tt>, the default remote port is used.
+	 *            {@code null}, the default remote port is used.
 	 * @throws IOException
 	 *             If anything goes wrong with socket setup.
 	 */
@@ -51,10 +51,10 @@ public class SCPConnection extends SDPConnection
 	 *
 	 * @param localHost
 	 *            The optional host of the local interface to
-	 *            listen on; use <tt>null</tt> to listen on all local
+	 *            listen on; use {@code null} to listen on all local
 	 *            interfaces.
 	 * @param localPort
-	 *            The optional local port to listen on; use <tt>null</tt> to
+	 *            The optional local port to listen on; use {@code null} to
 	 *            pick a random port.
 	 * @param remoteHost
 	 *            The remote host to send messages to.
@@ -71,16 +71,16 @@ public class SCPConnection extends SDPConnection
 	 *
 	 * @param localHost
 	 *            The optional host of the local interface to
-	 *            listen on; use <tt>null</tt> to listen on all local
+	 *            listen on; use {@code null} to listen on all local
 	 *            interfaces.
 	 * @param localPort
-	 *            The optional local port to listen on; use <tt>null</tt> to
+	 *            The optional local port to listen on; use {@code null} to
 	 *            pick a random port.
 	 * @param remoteHost
 	 *            The remote host to send messages to.
 	 * @param remotePort
 	 *            The optional remote port number to send messages to. If
-	 *            <tt>null</tt>, the default remote port is used.
+	 *            {@code null}, the default remote port is used.
 	 * @throws IOException
 	 *             If anything goes wrong with socket setup.
 	 */
@@ -113,7 +113,7 @@ public class SCPConnection extends SDPConnection
 	 *            The remote host nto send messages to.
 	 * @param remotePort
 	 *            The optional remote port number to send messages to. If
-	 *            <tt>null</tt>, the default remote port is used.
+	 *            {@code null}, the default remote port is used.
 	 * @throws IOException
 	 *             If anything goes wrong with socket setup.
 	 */
@@ -129,10 +129,10 @@ public class SCPConnection extends SDPConnection
 	 *            The location of the chip on the board with this remoteHost
 	 * @param localHost
 	 *            The optional host name of the local interface to
-	 *            listen on; use <tt>null</tt> to listen on all local
+	 *            listen on; use {@code null} to listen on all local
 	 *            interfaces.
 	 * @param localPort
-	 *            The optional local port to listen on; use <tt>null</tt> to
+	 *            The optional local port to listen on; use {@code null} to
 	 *            pick a random port.
 	 * @param remoteHost
 	 *            The remote host to send messages to.
@@ -151,16 +151,16 @@ public class SCPConnection extends SDPConnection
 	 *            The location of the chip on the board with this remoteHost
 	 * @param localHost
 	 *            The optional host of the local interface to
-	 *            listen on; use <tt>null</tt> to listen on all local
+	 *            listen on; use {@code null} to listen on all local
 	 *            interfaces.
 	 * @param localPort
-	 *            The optional local port to listen on; use <tt>null</tt> to
+	 *            The optional local port to listen on; use {@code null} to
 	 *            pick a random port.
 	 * @param remoteHost
 	 *            The remote host to send messages to.
 	 * @param remotePort
 	 *            The optional remote port number to send messages to. If
-	 *            <tt>null</tt>, the default remote port is used.
+	 *            {@code null}, the default remote port is used.
 	 * @throws IOException
 	 *             If anything goes wrong with socket setup.
 	 */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -207,10 +207,10 @@ public class SCPRequestPipeline {
 	 *            The connection over which the communication is to take place
 	 * @param numChannels
 	 *            The number of requests to send before checking for responses.
-	 *            (If <tt>null</tt>, this will be determined automatically.)
+	 *            (If {@code null}, this will be determined automatically.)
 	 * @param intermediateChannelWaits
 	 *            The number of outstanding responses to wait for before
-	 *            continuing sending requests. (If <tt>null</tt>, this will be
+	 *            continuing sending requests. (If {@code null}, this will be
 	 *            determined automatically.)
 	 * @param numRetries
 	 *            The number of times to resend any packet for any reason before
@@ -252,7 +252,7 @@ public class SCPRequestPipeline {
 	 * @param callback
 	 *            A callback function to call when the response has been
 	 *            received; takes an SCPResponse as a parameter, or a
-	 *            <tt>null</tt> if the response doesn't need to be processed.
+	 *            {@code null} if the response doesn't need to be processed.
 	 * @param errorCallback
 	 *            A callback function to call when an error is found when
 	 *            processing the message; takes the original SCPRequest, and the

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -43,10 +43,10 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 	 *            that is connected to the Ethernet connector on the SpiNNaker
 	 *            board, or even on the same board.
 	 * @param localHost
-	 *            The local host address to bind to, or <tt>null</tt> to bind to
+	 *            The local host address to bind to, or {@code null} to bind to
 	 *            all relevant local addresses.
 	 * @param localPort
-	 *            The local port to bind to, or <tt>null</tt> to pick a random
+	 *            The local port to bind to, or {@code null} to pick a random
 	 *            free port.
 	 * @param remoteHost
 	 *            The address of the SpiNNaker board to route UDP packets to.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -91,7 +91,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	 *            and will throw and exception if used for sending.
 	 * @param remotePort
 	 *            The remote port to send packets to. If remoteHost is
-	 *            <tt>null</tt>, this is ignored. If remoteHost is specified,
+	 *            {@code null}, this is ignored. If remoteHost is specified,
 	 *            this must also be specified as non-zero for the connection to
 	 *            allow sending.
 	 * @throws IOException
@@ -171,7 +171,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 
 	/**
 	 * @return The remote IP address to which the connection is connected, or
-	 *         <tt>null</tt> if it is not connected.
+	 *         {@code null} if it is not connected.
 	 */
 	@Override
 	public InetAddress getRemoteIPAddress() {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootReceiver.java
@@ -26,7 +26,7 @@ public interface BootReceiver extends SocketHolder {
 	 *
 	 * @param timeout
 	 *            The time in seconds to wait for the message to arrive; if
-	 *            <tt>null</tt>, will wait forever, or until the connection is
+	 *            {@code null}, will wait forever, or until the connection is
 	 *            closed.
 	 * @return the received packet
 	 * @throws IOException

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOReceiver.java
@@ -26,7 +26,7 @@ public interface EIEIOReceiver extends Connection {
 	 *
 	 * @param timeout
 	 *            The time in seconds to wait for the message to arrive; if
-	 *            <tt>null</tt>, will wait forever, or until the connection is
+	 *            {@code null}, will wait forever, or until the connection is
 	 *            closed
 	 * @return an EIEIO message
 	 * @throws IOException

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
@@ -35,10 +35,10 @@ public interface SCPSender extends Connection {
 	 * <p>
 	 * Messages must have the following properties:
 	 * <ul>
-	 * <li><i>sourcePort</i> is <tt>null</tt> or 7
-	 * <li><i>sourceCpu</i> is <tt>null</tt> or 31
-	 * <li><i>sourceChipX</i> is <tt>null</tt> or 0
-	 * <li><i>sourceChipY</i> is <tt>null</tt> or 0
+	 * <li><i>sourcePort</i> is {@code null} or 7
+	 * <li><i>sourceCpu</i> is {@code null} or 31
+	 * <li><i>sourceChipX</i> is {@code null} or 0
+	 * <li><i>sourceChipY</i> is {@code null} or 0
 	 * </ul>
 	 * <i>tag</i> in the message is optional; if not set, the default set in the
 	 * constructor will be used.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
@@ -216,7 +216,7 @@ public interface AbstractIO extends AutoCloseable {
 	 *            The value to repeat
 	 * @param size
 	 *            Number of bytes to fill from current position, or
-	 *            <tt>null</tt> to fill to the end
+	 *            {@code null} to fill to the end
 	 * @param type
 	 *            The type of the repeat value
 	 * @throws Exception

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/MulticastMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/MulticastMessage.java
@@ -8,7 +8,7 @@ public class MulticastMessage {
 	/** The key of the packet. */
 	public final int key;
 	/**
-	 * The payload of the packet if there is one, or <tt>null</tt> otherwise.
+	 * The payload of the packet if there is one, or {@code null} otherwise.
 	 */
 	public final Integer payload;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessage.java
@@ -11,7 +11,7 @@ import uk.ac.manchester.spinnaker.messages.SerializableMessage;
 public class BootMessage implements SerializableMessage {
 	private static final short BOOT_MESSAGE_VERSION = 1;
 	private static final int BOOT_PACKET_SIZE = 256 * 4;
-	/** The payload data (or <tt>null</tt> if there is none). */
+	/** The payload data (or {@code null} if there is none). */
 	public final ByteBuffer data;
 	/** The operation of this packet. */
 	public final BootOpCode opcode;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootOpCode.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootOpCode.java
@@ -31,7 +31,7 @@ public enum BootOpCode {
 	/**
 	 * @param opcode
 	 *            The opcode to convert.
-	 * @return The converted opcode, or <tt>null</tt> if it was unrecognised.
+	 * @return The converted opcode, or {@code null} if it was unrecognised.
 	 */
 	public static BootOpCode get(int opcode) {
 		return MAP.get(opcode);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
@@ -53,7 +53,7 @@ public enum EIEIOCommandID implements EIEIOCommand {
 	 *
 	 * @param command
 	 *            the encoded command
-	 * @return the ID, or <tt>null</tt> if the encoded form was unrecognised.
+	 * @return the ID, or {@code null} if the encoded form was unrecognised.
 	 */
 	public static EIEIOCommand get(int command) {
 		EIEIOCommandID id = MAP.get(command);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIODataMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIODataMessage.java
@@ -242,7 +242,7 @@ public class EIEIODataMessage implements EIEIOMessage<EIEIODataMessage.Header>,
 		public final EIEIOType eieioType;
 		/** The tag on the message. */
 		public final byte tag;
-		/** The prefix on the message, or <tt>null</tt> for no prefix. */
+		/** The prefix on the message, or {@code null} for no prefix. */
 		public final Short prefix;
 		/** How to apply the prefix. */
 		public final EIEIOPrefix prefixType;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/BMPConnectionData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/BMPConnectionData.java
@@ -24,7 +24,7 @@ public class BMPConnectionData {
 	/** The IP address of the BMP. */
 	public final InetAddress ipAddress;
 	/**
-	 * The port number associated with the BMP connection, or <tt>null</tt> for
+	 * The port number associated with the BMP connection, or {@code null} for
 	 * the default.
 	 */
 	public final Integer portNumber;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipSummaryInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipSummaryInfo.java
@@ -20,7 +20,7 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 public final class ChipSummaryInfo {
     /** The state of the cores on the chip (list of one per core). */
     public final List<CPUState> coreStates;
-    /** The IP address of the Ethernet if up, or <tt>null</tt> if not. */
+    /** The IP address of the Ethernet if up, or {@code null} if not. */
     public final InetAddress ethernetIPAddress;
     /** Determines if the Ethernet connection is available on this chip. */
     public final boolean isEthernetAvailable;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
@@ -238,7 +238,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static DefaultRoutingStatus get(int value) {
 			return MAP.get(value);
@@ -289,7 +289,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value, without the shift.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static Destination get(int value) {
 			return MAP.get(value);
@@ -339,7 +339,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value, without the shift.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static EmergencyRoutingStatus get(int value) {
 			return MAP.get(value);
@@ -380,7 +380,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value, without the shift.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static PacketType get(int value) {
 			return MAP.get(value);
@@ -417,7 +417,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value, without the shift.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static PayloadStatus get(int value) {
 			return MAP.get(value);
@@ -454,7 +454,7 @@ public class DiagnosticFilter {
 		/**
 		 * @param value
 		 *            The encoded value, without the shift.
-		 * @return The decoded value, or <tt>null</tt> if the decoding failed.
+		 * @return The decoded value, or {@code null} if the decoding failed.
 		 */
 		static Source get(int value) {
 			return MAP.get(value);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
@@ -10,10 +10,10 @@ public class HeapElement {
 	public final int size;
 	/** True if the block is free. */
 	public final boolean isFree;
-	/** The tag of the block if allocated, or <tt>null</tt> if not. */
+	/** The tag of the block if allocated, or {@code null} if not. */
 	public final Integer tag;
 	/**
-	 * The application ID of the block if allocated, or <tt>null</tt> if not.
+	 * The application ID of the block if allocated, or {@code null} if not.
 	 */
 	public final Integer appID;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
@@ -46,7 +46,7 @@ public final class FloodFillStart extends SCPRequest<CheckOKResponse> {
 	 *            The number of blocks of data that will be sent, between 0 and
 	 *            255
 	 * @param chip
-	 *            The chip to load the data on to, or <tt>null</tt> to load data
+	 *            The chip to load the data on to, or {@code null} to load data
 	 *            onto all chips.
 	 */
 	public FloodFillStart(byte nearestNeighbourID, int numBlocks,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequest.java
@@ -27,15 +27,15 @@ public abstract class SCPRequest<T extends SCPResponse>
 	static final CoreLocation DEFAULT_MONITOR_CORE =
 			new CoreLocation(DEFAULT_DEST_X_COORD, DEFAULT_DEST_Y_COORD, 0);
 
-	/** The first argument, or <tt>null</tt> if no first argument. */
+	/** The first argument, or {@code null} if no first argument. */
 	public final Integer argument1;
-	/** The second argument, or <tt>null</tt> if no second argument. */
+	/** The second argument, or {@code null} if no second argument. */
 	public final Integer argument2;
-	/** The third argument, or <tt>null</tt> if no third argument. */
+	/** The third argument, or {@code null} if no third argument. */
 	public final Integer argument3;
-	/** The data, or <tt>null</tt> if no data this way. */
+	/** The data, or {@code null} if no data this way. */
 	public final byte[] data;
-	/** The data as a buffer, or <tt>null</tt> if no data this way. */
+	/** The data as a buffer, or {@code null} if no data this way. */
 	public final ByteBuffer dataBuffer;
 	/** The SCP request header of the message. */
 	public final SCPRequestHeader scpRequestHeader;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResult.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResult.java
@@ -57,7 +57,7 @@ public enum SCPResult {
 	 *
 	 * @param value
 	 *            The value to decode
-	 * @return The decoded value, or <tt>null</tt> if unrecognised.
+	 * @return The decoded value, or {@code null} if unrecognised.
 	 */
 	public static SCPResult get(short value) {
 		return MAP.get(value);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
@@ -54,7 +54,7 @@ public class SCPResultMessage {
 	 *            The type of requests.
 	 * @param requestStore
 	 *            The store of requests.
-	 * @return The correlated request, or <tt>null</tt> if no correlation
+	 * @return The correlated request, or {@code null} if no correlation
 	 *         exists.
 	 */
 	public <T> T pickRequest(Map<Integer, T> requestStore) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
@@ -246,7 +246,7 @@ public class SDPHeader implements SerializableMessage {
 		this.tag = tag;
 	}
 
-	/** Possible values of the <tt>flags</tt> field. */
+	/** Possible values of the {@code flags} field. */
 	public enum Flag {
 		/** Indicates that a reply is not expected. */
 		REPLY_NOT_EXPECTED(0x07),

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/GetMachineProcess.java
@@ -74,10 +74,10 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @param ignoreLinksMap
 	 *            The link blacklist.
 	 * @param maxCoreID
-	 *            The maximum core ID, or <tt>null</tt> for the system's
+	 *            The maximum core ID, or {@code null} for the system's
 	 *            standard limit. For debugging.
 	 * @param maxSDRAMSize
-	 *            The maximum SDRAM size, or <tt>null</tt> for the system's
+	 *            The maximum SDRAM size, or {@code null} for the system's
 	 *            standard limit. For debugging.
 	 */
     public GetMachineProcess(

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/Process.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/Process.java
@@ -5,13 +5,12 @@ import static java.lang.String.format;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import javax.xml.ws.Holder;
-
 import uk.ac.manchester.spinnaker.connections.SCPErrorHandler;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResponse;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
+import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 /** An abstract process for talking to SpiNNaker efficiently. */
 public abstract class Process {
@@ -134,7 +133,7 @@ public abstract class Process {
 	protected final <T extends SCPResponse> T synchronousCall(
 			SCPRequest<T> request, SCPErrorHandler errorCallback)
 			throws IOException, Exception {
-		Holder<T> holder = new Holder<>();
+		ValueHolder<T> holder = new ValueHolder<>();
 		sendRequest(request, response -> holder.value = response,
 				errorCallback);
 		finish();
@@ -158,7 +157,7 @@ public abstract class Process {
 	 */
 	protected final <T extends SCPResponse> T synchronousCall(
 			SCPRequest<T> request) throws IOException, Exception {
-		Holder<T> holder = new Holder<>();
+		ValueHolder<T> holder = new ValueHolder<>();
 		sendRequest(request, response -> holder.value = response,
 				this::receiveError);
 		finish();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/Process.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/Process.java
@@ -134,11 +134,10 @@ public abstract class Process {
 			SCPRequest<T> request, SCPErrorHandler errorCallback)
 			throws IOException, Exception {
 		ValueHolder<T> holder = new ValueHolder<>();
-		sendRequest(request, response -> holder.value = response,
-				errorCallback);
+		sendRequest(request, holder::setValue, errorCallback);
 		finish();
 		checkForError();
-		return holder.value;
+		return holder.getValue();
 	}
 
 	/**
@@ -158,11 +157,10 @@ public abstract class Process {
 	protected final <T extends SCPResponse> T synchronousCall(
 			SCPRequest<T> request) throws IOException, Exception {
 		ValueHolder<T> holder = new ValueHolder<>();
-		sendRequest(request, response -> holder.value = response,
-				this::receiveError);
+		sendRequest(request, holder::setValue, this::receiveError);
 		finish();
 		checkForError();
-		return holder.value;
+		return holder.getValue();
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadRouterDiagnosticsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadRouterDiagnosticsProcess.java
@@ -45,9 +45,9 @@ public class ReadRouterDiagnosticsProcess
 		int[] reg = new int[NUM_REGISTERS];
 
 		sendRequest(new ReadMemory(chip, ROUTER_CONTROL_REGISTER, REGISTER),
-				response -> cr.value = response.data.getInt());
+				response -> cr.setValue(response.data.getInt()));
 		sendRequest(new ReadMemory(chip, ROUTER_ERROR_STATUS, REGISTER),
-				response -> es.value = response.data.getInt());
+				response -> es.setValue(response.data.getInt()));
 		sendRequest(
 				new ReadMemory(chip, ROUTER_REGISTERS,
 						NUM_REGISTERS * REGISTER),
@@ -55,6 +55,6 @@ public class ReadRouterDiagnosticsProcess
 
 		finish();
 		checkForError();
-		return new RouterDiagnostics(cr.value, es.value, reg);
+		return new RouterDiagnostics(cr.getValue(), es.getValue(), reg);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadRouterDiagnosticsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/ReadRouterDiagnosticsProcess.java
@@ -2,13 +2,12 @@ package uk.ac.manchester.spinnaker.processes;
 
 import java.io.IOException;
 
-import javax.xml.ws.Holder;
-
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.selectors.ConnectionSelector;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.RouterDiagnostics;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
+import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 /** A process for reading the diagnostic data block from a SpiNNaker router. */
 public class ReadRouterDiagnosticsProcess
@@ -41,8 +40,8 @@ public class ReadRouterDiagnosticsProcess
 	 */
 	public RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
 			throws IOException, Exception {
-		Holder<Integer> cr = new Holder<>();
-		Holder<Integer> es = new Holder<>();
+		ValueHolder<Integer> cr = new ValueHolder<>();
+		ValueHolder<Integer> es = new ValueHolder<>();
 		int[] reg = new int[NUM_REGISTERS];
 
 		sendRequest(new ReadMemory(chip, ROUTER_CONTROL_REGISTER, REGISTER),

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
@@ -100,14 +100,13 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 		 */
 		RequestPipeline requestPipeline = new RequestPipeline(
 				connectionSelector.getNextConnection(request));
-		requestPipeline.sendRequest(request,
-				response -> holder.value = response);
+		requestPipeline.sendRequest(request, holder::setValue);
 		requestPipeline.finish();
 		if (exception != null) {
 			throw new Exception(errorRequest.sdpHeader.getDestination(),
 					exception);
 		}
-		return holder.value;
+		return holder.getValue();
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
@@ -212,8 +212,7 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 		 * @param callback
 		 *            A callback function to call when the response has been
 		 *            received; takes an SCPResponse as a parameter, or a
-		 *            <tt>null</tt> if the response doesn't need to be
-		 *            processed.
+		 *            {@code null} if the response doesn't need to be processed.
 		 * @throws IOException
 		 *             If things go really wrong.
 		 */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/processes/SendSingleBMPCommandProcess.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import javax.xml.ws.Holder;
-
 import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
@@ -33,6 +31,7 @@ import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequestHeader;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 import uk.ac.manchester.spinnaker.processes.Process.Exception;
+import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 /**
  * A process for handling communicating with the BMP.
@@ -94,7 +93,7 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 	 *             If the other side responds with a failure code
 	 */
 	public R execute(BMPRequest<R> request) throws IOException, Exception {
-		Holder<R> holder = new Holder<>();
+		ValueHolder<R> holder = new ValueHolder<>();
 		/*
 		 * If no pipeline built yet, build one on the connection selected for
 		 * it.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/PropertyBasedDeserialiser.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/PropertyBasedDeserialiser.java
@@ -58,7 +58,7 @@ public class PropertyBasedDeserialiser<T> extends StdDeserializer<T> {
 	 *
 	 * @param elementNames
 	 *            The element names available to us.
-	 * @return The class, or <tt>null</tt> if nothing matches (i.e., if we've
+	 * @return The class, or {@code null} if nothing matches (i.e., if we've
 	 *         gone through the iterator and had no matches).
 	 */
 	private Class<? extends T> getTargetClass(Iterator<String> elementNames) {
@@ -80,7 +80,7 @@ public class PropertyBasedDeserialiser<T> extends StdDeserializer<T> {
 	 *            The parser to get the JSON object from.
 	 * @param context
 	 *            ignored
-	 * @return A Java object (probably a POJO), or <tt>null</tt> if the
+	 * @return A Java object (probably a POJO), or {@code null} if the
 	 *         properties of the JSON object don't identify which Java class we
 	 *         should use for deserialization.
 	 * @throws IOException

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
@@ -50,7 +50,7 @@ public interface SpallocAPI {
 	 *
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return the server's version.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -71,8 +71,7 @@ public interface SpallocAPI {
 	 *            location (three args).
 	 * @param kwargs
 	 *            Additional arguments required. Must include the key
-	 *            <tt>owner</tt>. Values can be boxed primitive types or
-	 *            strings.
+	 *            {@code owner}. Values can be boxed primitive types or strings.
 	 * @return the ID of the created job.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -93,11 +92,10 @@ public interface SpallocAPI {
 	 *            location (three args).
 	 * @param kwargs
 	 *            Additional arguments required. Must include the key
-	 *            <tt>owner</tt>. Values can be boxed primitive types or
-	 *            strings.
+	 *            {@code owner}. Values can be boxed primitive types or strings.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return the ID of the created job.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -132,7 +130,7 @@ public interface SpallocAPI {
 	 *            The job to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -166,7 +164,7 @@ public interface SpallocAPI {
 	 *            The job to get the state of.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return a description of the job's state.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -201,7 +199,7 @@ public interface SpallocAPI {
 	 *            The job whose machine you want to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return a description of the machine.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -236,7 +234,7 @@ public interface SpallocAPI {
 	 *            The job to request about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -269,7 +267,7 @@ public interface SpallocAPI {
 	 *            The job to request about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -306,7 +304,7 @@ public interface SpallocAPI {
 	 *            Why the job is to be destroyed.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -322,8 +320,8 @@ public interface SpallocAPI {
 	 * Enable or disable notifications of changes in job state.
 	 *
 	 * @param jobID
-	 *            The job to request (or cancel requests) about, or
-	 *            <tt>null</tt> to be notified/not notified about all jobs.
+	 *            The job to request (or cancel requests) about, or {@code null}
+	 *            to be notified/not notified about all jobs.
 	 * @param enable
 	 *            True to enable notifications, false to disable them.
 	 * @see JobsChangedNotification
@@ -341,13 +339,13 @@ public interface SpallocAPI {
 	 * Enable or disable notifications of changes in job state.
 	 *
 	 * @param jobID
-	 *            The job to request (or cancel requests) about, or
-	 *            <tt>null</tt> to be notified/not notified about all jobs.
+	 *            The job to request (or cancel requests) about, or {@code null}
+	 *            to be notified/not notified about all jobs.
 	 * @param enable
 	 *            True to enable notifications, false to disable them.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @see JobsChangedNotification
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -365,7 +363,7 @@ public interface SpallocAPI {
 	 *
 	 * @param machineName
 	 *            The machine to request (or cancel requests) about, or
-	 *            <tt>null</tt> to be notified/not notified about all machines
+	 *            {@code null} to be notified/not notified about all machines
 	 *            (known to spalloc).
 	 * @param enable
 	 *            True to enable notifications, false to disable them.
@@ -385,11 +383,11 @@ public interface SpallocAPI {
 	 *
 	 * @param machineName
 	 *            The machine to request (or cancel requests) about, or
-	 *            <tt>null</tt> to be notified/not notified about all machines
+	 *            {@code null} to be notified/not notified about all machines
 	 *            (known to spalloc).
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @param enable
 	 *            True to enable notifications, false to disable them.
 	 * @see MachinesChangedNotification
@@ -424,7 +422,7 @@ public interface SpallocAPI {
 	 *
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return A list of allocated/queued jobs in order of creation from oldest
 	 *         (first) to newest (last). This is unmodifiable.
 	 * @throws SpallocServerException
@@ -457,7 +455,7 @@ public interface SpallocAPI {
 	 *
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
+	 *            or {@code null} to wait forever.
 	 * @return The list of machines known to the system in order of priority
 	 *         from highest (first) to lowest (last). This is unmodifiable.
 	 * @throws SpallocServerException
@@ -477,7 +475,7 @@ public interface SpallocAPI {
 	 *            the name of the machine containing the board.
 	 * @param coords
 	 *            the logical location of the board.
-	 * @return the physical location, or <tt>null</tt> if the logical location
+	 * @return the physical location, or {@code null} if the logical location
 	 *         doesn't map to a real board.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -499,8 +497,8 @@ public interface SpallocAPI {
 	 *            the logical location of the board.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return the physical location, or <tt>null</tt> if the logical location
+	 *            or {@code null} to wait forever.
+	 * @return the physical location, or {@code null} if the logical location
 	 *         doesn't map to a real board.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -520,7 +518,7 @@ public interface SpallocAPI {
 	 *            the name of the machine containing the board.
 	 * @param coords
 	 *            the physical location of the board.
-	 * @return the logical location, or <tt>null</tt> if the physical location
+	 * @return the logical location, or {@code null} if the physical location
 	 *         doesn't map to a real board.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -542,8 +540,8 @@ public interface SpallocAPI {
 	 *            the physical location of the board.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return the logical location, or <tt>null</tt> if the physical location
+	 *            or {@code null} to wait forever.
+	 * @return the logical location, or {@code null} if the physical location
 	 *         doesn't map to a real board.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -564,8 +562,8 @@ public interface SpallocAPI {
 	 *            The job to ask about.
 	 * @param chip
 	 *            The coordinates of the chip to ask about.
-	 * @return A description of the chip's location, or <tt>null</tt> if it
-	 *         can't be found.
+	 * @return A description of the chip's location, or {@code null} if it can't
+	 *         be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws IOException
@@ -585,9 +583,9 @@ public interface SpallocAPI {
 	 *            The coordinates of the chip to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return A description of the chip's location, or <tt>null</tt> if it
-	 *         can't be found.
+	 *            or {@code null} to wait forever.
+	 * @return A description of the chip's location, or {@code null} if it can't
+	 *         be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -606,8 +604,8 @@ public interface SpallocAPI {
 	 *            The machine to ask about.
 	 * @param chip
 	 *            The coordinates of the chip to ask about.
-	 * @return A description of the chip's location, or <tt>null</tt> if it
-	 *         can't be found.
+	 * @return A description of the chip's location, or {@code null} if it can't
+	 *         be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws IOException
@@ -627,9 +625,9 @@ public interface SpallocAPI {
 	 *            The coordinates of the chip to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return A description of the chip's location, or <tt>null</tt> if it
-	 *         can't be found.
+	 *            or {@code null} to wait forever.
+	 * @return A description of the chip's location, or {@code null} if it can't
+	 *         be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
 	 * @throws SpallocProtocolTimeoutException
@@ -648,7 +646,7 @@ public interface SpallocAPI {
 	 *            The machine to ask about.
 	 * @param coords
 	 *            The physical coordinates of the board to ask about.
-	 * @return A description of the board's location, or <tt>null</tt> if it
+	 * @return A description of the board's location, or {@code null} if it
 	 *         can't be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -669,8 +667,8 @@ public interface SpallocAPI {
 	 *            The physical coordinates of the board to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return A description of the board's location, or <tt>null</tt> if it
+	 *            or {@code null} to wait forever.
+	 * @return A description of the board's location, or {@code null} if it
 	 *         can't be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -690,7 +688,7 @@ public interface SpallocAPI {
 	 *            The machine to ask about.
 	 * @param coords
 	 *            The logical coordinates of the board to ask about.
-	 * @return A description of the board's location, or <tt>null</tt> if it
+	 * @return A description of the board's location, or {@code null} if it
 	 *         can't be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -711,8 +709,8 @@ public interface SpallocAPI {
 	 *            The logical coordinates of the board to ask about.
 	 * @param timeout
 	 *            How long to wait for the request to complete, in milliseconds,
-	 *            or <tt>null</tt> to wait forever.
-	 * @return A description of the board's location, or <tt>null</tt> if it
+	 *            or {@code null} to wait forever.
+	 * @return A description of the board's location, or {@code null} if it
 	 *         can't be found.
 	 * @throws SpallocServerException
 	 *             if the server returns an exception response.
@@ -747,11 +745,10 @@ public interface SpallocAPI {
 	 *
 	 * @param timeout
 	 *            The number of seconds to wait before timing out or
-	 *            <tt>null</tt> if this function should try again forever. If
+	 *            {@code null} if this function should try again forever. If
 	 *            negative, only responses already-received will be returned; if
 	 *            no responses are available, in this case the function does not
-	 *            raise a ProtocolTimeoutError but returns <tt>null</tt>
-	 *            instead.
+	 *            raise a ProtocolTimeoutError but returns {@code null} instead.
 	 * @return The notification sent by the server.
 	 * @see JobsChangedNotification
 	 * @see MachinesChangedNotification

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocConnection.java
@@ -135,7 +135,7 @@ public abstract class SpallocConnection implements Closeable {
 	 *            thread; cached for efficiency).
 	 * @param timeout
 	 *            The socket's timeout.
-	 * @return The socket, or <tt>null</tt> if the connection failed.
+	 * @return The socket, or {@code null} if the connection failed.
 	 * @throws IOException
 	 *             if something really bad goes wrong.
 	 */
@@ -251,7 +251,7 @@ public abstract class SpallocConnection implements Closeable {
 	 *
 	 * @param timeout
 	 *            The number of milliseconds to wait before timing out or
-	 *            <tt>null</tt> if this function should try again forever.
+	 *            {@code null} if this function should try again forever.
 	 * @return The unpacked response from the line received.
 	 * @throws SpallocProtocolTimeoutException
 	 *             If a timeout occurs.
@@ -286,7 +286,7 @@ public abstract class SpallocConnection implements Closeable {
 	 *            The command to serialise.
 	 * @param timeout
 	 *            The number of milliseconds to wait before timing out or
-	 *            <tt>null</tt> if this function should try again forever.
+	 *            {@code null} if this function should try again forever.
 	 * @throws SpallocProtocolTimeoutException
 	 *             If a timeout occurs.
 	 * @throws IOException
@@ -318,7 +318,7 @@ public abstract class SpallocConnection implements Closeable {
 	 * Format a request to be ready to go to the server.
 	 *
 	 * @param command
-	 *            The request to format for sending. Not <tt>null</tt>.
+	 *            The request to format for sending. Not {@code null}.
 	 * @return The text to send to the server. Will have a newline added.
 	 * @throws IOException
 	 *             If formatting goes wrong.
@@ -330,9 +330,9 @@ public abstract class SpallocConnection implements Closeable {
 	 * Parse a response line from the server.
 	 *
 	 * @param line
-	 *            The line to parse. Not <tt>null</tt>. Has the terminating
+	 *            The line to parse. Not {@code null}. Has the terminating
 	 *            newline removed.
-	 * @return The parsed response, or <tt>null</tt> for a generic "that's
+	 * @return The parsed response, or {@code null} for a generic "that's
 	 *         unexpected".
 	 * @throws IOException
 	 *             If parsing completely fails.
@@ -346,7 +346,7 @@ public abstract class SpallocConnection implements Closeable {
 	 *            The command to send.
 	 * @param timeout
 	 *            The number of milliseconds to wait before timing out or
-	 *            <tt>null</tt> if this function should wait forever.
+	 *            {@code null} if this function should wait forever.
 	 * @return The result string returned by the server.
 	 * @throws SpallocServerException
 	 *             If the server sends an error.
@@ -430,8 +430,8 @@ public abstract class SpallocConnection implements Closeable {
 		}
 	}
 
-    @Override
+	@Override
 	public String toString() {
-        return addr + " dead: " + dead + "  " + defaultTimeout;
-    }
+		return addr + " dead: " + dead + "  " + defaultTimeout;
+	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
@@ -64,13 +64,13 @@ import uk.ac.manchester.spinnaker.spalloc.messages.WhereIs;
  *
  * <pre>
  * try (SpallocJob j = new SpallocJob(Arrays.asList(6), null)) {
- * 	myApplication.boot(j.getHostname(), j.getDimensions());
- * 	myApplication.run(j.getHostname());
+ *     myApplication.boot(j.getHostname(), j.getDimensions());
+ *     myApplication.run(j.getHostname());
  * }
  * </pre>
  *
  * In this example a six-board machine is requested and the
- * <tt>try</tt>-with-resources context is entered once the allocation has been
+ * {@code try}-with-resources context is entered once the allocation has been
  * made and the allocated boards are fully powered on. When control leaves the
  * block, the job is destroyed and the boards shut down by the server ready for
  * another job.
@@ -89,13 +89,13 @@ import uk.ac.manchester.spinnaker.spalloc.messages.WhereIs;
  * <b>Note:</b> <blockquote class="note"> More complex applications may wish to
  * log the following properties of their job to support later debugging efforts:
  * <ul>
- * <li><tt>ID</tt> &mdash; May be used to query the state of the job and find
- * out its fate if cancelled or destroyed. The <i>spalloc-job</i> command can be
+ * <li>{@code ID} &mdash; May be used to query the state of the job and find out
+ * its fate if cancelled or destroyed. The <i>spalloc-job</i> command can be
  * used to discover the state/fate of the job and <i>spalloc-where-is</i> may be
  * used to find out what boards problem chips reside on.
- * <li><tt>machineName</tt> and <tt>boards</tt> together give a complete record
- * of the hardware used by the job. The <i>spalloc-where-is</i> command may be
- * used to find out the physical locations of the boards used.
+ * <li>{@code machineName} and {@code boards} together give a complete record of
+ * the hardware used by the job. The <i>spalloc-where-is</i> command may be used
+ * to find out the physical locations of the boards used.
  * </ul>
  * </blockquote>
  */
@@ -145,7 +145,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *
 	 * @param filename
 	 *            the base filename (without a path) to load the configuration
-	 *            from. This is expected to be a <tt>.ini</tt> file.
+	 *            from. This is expected to be a {@code .ini} file.
 	 * @see Configuration
 	 */
 	public static void setConfigurationSource(String filename) {
@@ -179,37 +179,37 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * email address.</dd>
 	 * <dt>{@value JobConstants#KEEPALIVE_PROPERTY} ({@link Number})</dt>
 	 * <dd>The number of seconds after which the server may consider the job
-	 * dead if this client cannot communicate with it. If <tt>null</tt>, no
+	 * dead if this client cannot communicate with it. If {@code null}, no
 	 * timeout will be used and the job will run until explicitly destroyed. Use
 	 * with extreme caution.</dd>
 	 * <dt>{@value JobConstants#MACHINE_PROPERTY} ({@link String})</dt>
 	 * <dd>Specify the name of a machine which this job must be executed on. If
-	 * <tt>null</tt>, the first suitable machine available will be used,
-	 * according to the tags selected below. Must be <tt>null</tt> when
+	 * {@code null}, the first suitable machine available will be used,
+	 * according to the tags selected below. Must be {@code null} when
 	 * {@value JobConstants#TAGS_PROPERTY} are given.</dd>
 	 * <dt>{@value JobConstants#TAGS_PROPERTY} ({@link String}[])</dt>
 	 * <dd>The set of tags which any machine running this job must have. If
-	 * <tt>null</tt> is supplied, only machines with the <tt>"default"</tt> tag
+	 * {@code null} is supplied, only machines with the {@code "default"} tag
 	 * will be used. If {@value JobConstants#MACHINE_PROPERTY} is given, this
-	 * argument must be <tt>null</tt>.</dd>
+	 * argument must be {@code null}.</dd>
 	 * <dt>{@value JobConstants#MIN_RATIO_PROPERTY} ({@link Double})</dt>
 	 * <dd>The aspect ratio (h/w) which the allocated region must be 'at least
-	 * as square as'. Set to <tt>0.0</tt> for any allowable shape, <tt>1.0</tt>
-	 * to be exactly square etc. Ignored when allocating single boards or
-	 * specific rectangles of triads.</dd>
+	 * as square as'. Set to {@code 0.0} for any allowable shape, {@code 1.0} to
+	 * be exactly square etc. Ignored when allocating single boards or specific
+	 * rectangles of triads.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_BOARDS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken or unreachable boards to allow in the
-	 * allocated region. If <tt>null</tt>, any number of dead boards is
+	 * allocated region. If {@code null}, any number of dead boards is
 	 * permitted, as long as the board on the bottom-left corner is alive.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_LINKS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken links allow in the allocated region.
 	 * When {@value JobConstants#REQUIRE_TORUS_PROPERTY} is true this includes
 	 * wrap-around links, otherwise peripheral links are not counted. If
-	 * <tt>null</tt>, any number of broken links is allowed.</dd>
+	 * {@code null}, any number of broken links is allowed.</dd>
 	 * <dt>{@value JobConstants#REQUIRE_TORUS_PROPERTY} ({@link Boolean})</dt>
-	 * <dd>If <tt>true</tt>, only allocate blocks with torus connectivity. In
+	 * <dd>If {@code true}, only allocate blocks with torus connectivity. In
 	 * general this will only succeed for requests to allocate an entire
-	 * machine. Must be <tt>false</tt> (or not supplied) when allocating
+	 * machine. Must be {@code false} (or not supplied) when allocating
 	 * boards.</dd>
 	 * </dl>
 	 *
@@ -250,37 +250,37 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * email address.</dd>
 	 * <dt>{@value JobConstants#KEEPALIVE_PROPERTY} ({@link Number})</dt>
 	 * <dd>The number of seconds after which the server may consider the job
-	 * dead if this client cannot communicate with it. If <tt>null</tt>, no
+	 * dead if this client cannot communicate with it. If {@code null}, no
 	 * timeout will be used and the job will run until explicitly destroyed. Use
 	 * with extreme caution.</dd>
 	 * <dt>{@value JobConstants#MACHINE_PROPERTY} ({@link String})</dt>
 	 * <dd>Specify the name of a machine which this job must be executed on. If
-	 * <tt>null</tt>, the first suitable machine available will be used,
-	 * according to the tags selected below. Must be <tt>null</tt> when
+	 * {@code null}, the first suitable machine available will be used,
+	 * according to the tags selected below. Must be {@code null} when
 	 * {@value JobConstants#TAGS_PROPERTY} are given.</dd>
 	 * <dt>{@value JobConstants#TAGS_PROPERTY} ({@link String}[])</dt>
 	 * <dd>The set of tags which any machine running this job must have. If
-	 * <tt>null</tt> is supplied, only machines with the <tt>"default"</tt> tag
+	 * {@code null} is supplied, only machines with the {@code "default"} tag
 	 * will be used. If {@value JobConstants#MACHINE_PROPERTY} is given, this
-	 * argument must be <tt>null</tt>.</dd>
+	 * argument must be {@code null}.</dd>
 	 * <dt>{@value JobConstants#MIN_RATIO_PROPERTY} ({@link Double})</dt>
 	 * <dd>The aspect ratio (h/w) which the allocated region must be 'at least
-	 * as square as'. Set to <tt>0.0</tt> for any allowable shape, <tt>1.0</tt>
-	 * to be exactly square etc. Ignored when allocating single boards or
-	 * specific rectangles of triads.</dd>
+	 * as square as'. Set to {@code 0.0} for any allowable shape, {@code 1.0} to
+	 * be exactly square etc. Ignored when allocating single boards or specific
+	 * rectangles of triads.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_BOARDS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken or unreachable boards to allow in the
-	 * allocated region. If <tt>null</tt>, any number of dead boards is
+	 * allocated region. If {@code null}, any number of dead boards is
 	 * permitted, as long as the board on the bottom-left corner is alive.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_LINKS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken links allow in the allocated region.
 	 * When {@value JobConstants#REQUIRE_TORUS_PROPERTY} is true this includes
 	 * wrap-around links, otherwise peripheral links are not counted. If
-	 * <tt>null</tt>, any number of broken links is allowed.</dd>
+	 * {@code null}, any number of broken links is allowed.</dd>
 	 * <dt>{@value JobConstants#REQUIRE_TORUS_PROPERTY} ({@link Boolean})</dt>
-	 * <dd>If <tt>true</tt>, only allocate blocks with torus connectivity. In
+	 * <dd>If {@code true}, only allocate blocks with torus connectivity. In
 	 * general this will only succeed for requests to allocate an entire
-	 * machine. Must be <tt>false</tt> (or not supplied) when allocating
+	 * machine. Must be {@code false} (or not supplied) when allocating
 	 * boards.</dd>
 	 * </dl>
 	 *
@@ -320,37 +320,37 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * email address.</dd>
 	 * <dt>{@value JobConstants#KEEPALIVE_PROPERTY} ({@link Number})</dt>
 	 * <dd>The number of seconds after which the server may consider the job
-	 * dead if this client cannot communicate with it. If <tt>null</tt>, no
+	 * dead if this client cannot communicate with it. If {@code null}, no
 	 * timeout will be used and the job will run until explicitly destroyed. Use
 	 * with extreme caution.</dd>
 	 * <dt>{@value JobConstants#MACHINE_PROPERTY} ({@link String})</dt>
 	 * <dd>Specify the name of a machine which this job must be executed on. If
-	 * <tt>null</tt>, the first suitable machine available will be used,
-	 * according to the tags selected below. Must be <tt>null</tt> when
+	 * {@code null}, the first suitable machine available will be used,
+	 * according to the tags selected below. Must be {@code null} when
 	 * {@value JobConstants#TAGS_PROPERTY} are given.</dd>
 	 * <dt>{@value JobConstants#TAGS_PROPERTY} ({@link String}[])</dt>
 	 * <dd>The set of tags which any machine running this job must have. If
-	 * <tt>null</tt> is supplied, only machines with the <tt>"default"</tt> tag
+	 * {@code null} is supplied, only machines with the {@code "default"} tag
 	 * will be used. If {@value JobConstants#MACHINE_PROPERTY} is given, this
-	 * argument must be <tt>null</tt>.</dd>
+	 * argument must be {@code null}.</dd>
 	 * <dt>{@value JobConstants#MIN_RATIO_PROPERTY} ({@link Double})</dt>
 	 * <dd>The aspect ratio (h/w) which the allocated region must be 'at least
-	 * as square as'. Set to <tt>0.0</tt> for any allowable shape, <tt>1.0</tt>
-	 * to be exactly square etc. Ignored when allocating single boards or
-	 * specific rectangles of triads.</dd>
+	 * as square as'. Set to {@code 0.0} for any allowable shape, {@code 1.0} to
+	 * be exactly square etc. Ignored when allocating single boards or specific
+	 * rectangles of triads.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_BOARDS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken or unreachable boards to allow in the
-	 * allocated region. If <tt>null</tt>, any number of dead boards is
+	 * allocated region. If {@code null}, any number of dead boards is
 	 * permitted, as long as the board on the bottom-left corner is alive.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_LINKS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken links allow in the allocated region.
 	 * When {@value JobConstants#REQUIRE_TORUS_PROPERTY} is true this includes
 	 * wrap-around links, otherwise peripheral links are not counted. If
-	 * <tt>null</tt>, any number of broken links is allowed.</dd>
+	 * {@code null}, any number of broken links is allowed.</dd>
 	 * <dt>{@value JobConstants#REQUIRE_TORUS_PROPERTY} ({@link Boolean})</dt>
-	 * <dd>If <tt>true</tt>, only allocate blocks with torus connectivity. In
+	 * <dd>If {@code true}, only allocate blocks with torus connectivity. In
 	 * general this will only succeed for requests to allocate an entire
-	 * machine. Must be <tt>false</tt> (or not supplied) when allocating
+	 * machine. Must be {@code false} (or not supplied) when allocating
 	 * boards.</dd>
 	 * </dl>
 	 *
@@ -387,37 +387,37 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * email address.</dd>
 	 * <dt>{@value JobConstants#KEEPALIVE_PROPERTY} ({@link Number})</dt>
 	 * <dd>The number of seconds after which the server may consider the job
-	 * dead if this client cannot communicate with it. If <tt>null</tt>, no
+	 * dead if this client cannot communicate with it. If {@code null}, no
 	 * timeout will be used and the job will run until explicitly destroyed. Use
 	 * with extreme caution.</dd>
 	 * <dt>{@value JobConstants#MACHINE_PROPERTY} ({@link String})</dt>
 	 * <dd>Specify the name of a machine which this job must be executed on. If
-	 * <tt>null</tt>, the first suitable machine available will be used,
-	 * according to the tags selected below. Must be <tt>null</tt> when
+	 * {@code null}, the first suitable machine available will be used,
+	 * according to the tags selected below. Must be {@code null} when
 	 * {@value JobConstants#TAGS_PROPERTY} are given.</dd>
 	 * <dt>{@value JobConstants#TAGS_PROPERTY} ({@link String}[])</dt>
 	 * <dd>The set of tags which any machine running this job must have. If
-	 * <tt>null</tt> is supplied, only machines with the <tt>"default"</tt> tag
+	 * {@code null} is supplied, only machines with the {@code "default"} tag
 	 * will be used. If {@value JobConstants#MACHINE_PROPERTY} is given, this
-	 * argument must be <tt>null</tt>.</dd>
+	 * argument must be {@code null}.</dd>
 	 * <dt>{@value JobConstants#MIN_RATIO_PROPERTY} ({@link Double})</dt>
 	 * <dd>The aspect ratio (h/w) which the allocated region must be 'at least
-	 * as square as'. Set to <tt>0.0</tt> for any allowable shape, <tt>1.0</tt>
-	 * to be exactly square etc. Ignored when allocating single boards or
-	 * specific rectangles of triads.</dd>
+	 * as square as'. Set to {@code 0.0} for any allowable shape, {@code 1.0} to
+	 * be exactly square etc. Ignored when allocating single boards or specific
+	 * rectangles of triads.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_BOARDS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken or unreachable boards to allow in the
-	 * allocated region. If <tt>null</tt>, any number of dead boards is
+	 * allocated region. If {@code null}, any number of dead boards is
 	 * permitted, as long as the board on the bottom-left corner is alive.</dd>
 	 * <dt>{@value JobConstants#MAX_DEAD_LINKS_PROPERTY} ({@link Integer})</dt>
 	 * <dd>The maximum number of broken links allow in the allocated region.
 	 * When {@value JobConstants#REQUIRE_TORUS_PROPERTY} is true this includes
 	 * wrap-around links, otherwise peripheral links are not counted. If
-	 * <tt>null</tt>, any number of broken links is allowed.</dd>
+	 * {@code null}, any number of broken links is allowed.</dd>
 	 * <dt>{@value JobConstants#REQUIRE_TORUS_PROPERTY} ({@link Boolean})</dt>
-	 * <dd>If <tt>true</tt>, only allocate blocks with torus connectivity. In
+	 * <dd>If {@code true}, only allocate blocks with torus connectivity. In
 	 * general this will only succeed for requests to allocate an entire
-	 * machine. Must be <tt>false</tt> (or not supplied) when allocating
+	 * machine. Must be {@code false} (or not supplied) when allocating
 	 * boards.</dd>
 	 * </dl>
 	 *
@@ -480,7 +480,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * Conditions the arguments for spalloc.
 	 *
 	 * @param kwargs
-	 *            The arguments supplied by the caller. May be <tt>null</tt>.
+	 *            The arguments supplied by the caller. May be {@code null}.
 	 * @param defaults
 	 *            The set of defaults read from the configuration file.
 	 * @return The actual arguments to give to spalloc.
@@ -907,7 +907,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 * Wait for a state change and keep the job alive.
 	 *
 	 * @param finishTime
-	 *            when our timeout expires, or <tt>null</tt> for never
+	 *            when our timeout expires, or {@code null} for never
 	 * @return True if the state has changed, or false on timeout
 	 * @throws SpallocServerException
 	 * @throws IOException

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
@@ -51,7 +51,7 @@ public interface SpallocJobAPI {
 	 * @param powerOn
 	 *            true to power on the boards, false to power off. If the boards
 	 *            are already turned on, setting power to true will reset them.
-	 *            If <tt>null</tt>, this method does nothing.
+	 *            If {@code null}, this method does nothing.
 	 * @throws IOException
 	 *             If communications fail.
 	 * @throws SpallocServerException
@@ -98,7 +98,7 @@ public interface SpallocJobAPI {
 	Boolean getPower() throws IOException, SpallocServerException;
 
 	/**
-	 * @return The reason for destruction of the job, or <tt>null</tt> if there
+	 * @return The reason for destruction of the job, or {@code null} if there
 	 *         is no reason (perhaps because the job isn't destroyed). Note that
 	 *         you should use {@link #getState()} to determine if the job is
 	 *         destroyed, not this method.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Utils.java
@@ -16,10 +16,10 @@ abstract class Utils {
 	 * Convert a timestamp into how long to wait for it.
 	 *
 	 * @param timestamp
-	 *            the time of expiry, or <tt>null</tt> for a timestamp that is
+	 *            the time of expiry, or {@code null} for a timestamp that is
 	 *            never expired.
 	 * @return the number of milliseconds remaining to wait for the timestamp to
-	 *         expire, or <tt>null</tt> for "wait indefinitely".
+	 *         expire, or {@code null} for "wait indefinitely".
 	 */
 	static Integer timeLeft(Long timestamp) {
 		if (timestamp == null) {
@@ -32,7 +32,7 @@ abstract class Utils {
 	 * Check if a timestamp has been reached.
 	 *
 	 * @param timestamp
-	 *            the time of expiry, or <tt>null</tt> for a timestamp that is
+	 *            the time of expiry, or {@code null} for a timestamp that is
 	 *            never expired.
 	 * @return true if the timestamp has been passed.
 	 */
@@ -44,9 +44,9 @@ abstract class Utils {
 	 * Convert a delay (in milliseconds) into a timestamp.
 	 *
 	 * @param delay
-	 *            how long the timeout is, in milliseconds, or <tt>null</tt> for
+	 *            how long the timeout is, in milliseconds, or {@code null} for
 	 *            infinite.
-	 * @return when the timeout expires, or <tt>null</tt> for "never".
+	 * @return when the timeout expires, or {@code null} for "never".
 	 */
 	static Long makeTimeout(Integer delay) {
 		if (delay == null) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/CreateJobCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/CreateJobCommand.java
@@ -30,8 +30,7 @@ public class CreateJobCommand extends Command<Integer> {
 	 *            location (three args).
 	 * @param kwargs
 	 *            Additional arguments required. Must include the key
-	 *            <tt>owner</tt>. Values can be boxed primitive types or
-	 *            strings.
+	 *            {@code owner}. Values can be boxed primitive types or strings.
 	 */
 	public CreateJobCommand(List<Integer> args, Map<String, Object> kwargs) {
 		super("create_job");

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/State.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/State.java
@@ -20,6 +20,6 @@ public enum State {
 	POWER,
 	/** SpallocJob is running (or at least ready to run). */
 	READY,
-	/** SpallocJob has terminated, see the <tt>reason</tt> property for why. */
+	/** SpallocJob has terminated, see the {@code reason} property for why. */
 	DESTROYED;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -288,7 +288,7 @@ public class Transceiver extends UDPTransceiver
 	 * @param host
 	 *            The host IP address of the board
 	 * @param numberOfBoards
-	 *            a number of boards expected to be supported, or <tt>null</tt>,
+	 *            a number of boards expected to be supported, or {@code null},
 	 *            which defaults to a single board
 	 * @param ignoreChips
 	 *            An optional set of chips to ignore in the machine. Requests
@@ -439,11 +439,11 @@ public class Transceiver extends UDPTransceiver
 	 * @param ignoreLinks
 	 *            Blacklisted links.
 	 * @param maxCoreID
-	 *            If not <tt>null</tt>, the maximum core ID to allow.
+	 *            If not {@code null}, the maximum core ID to allow.
 	 * @param scampConnections
 	 *            Descriptions of SCP connections to create.
 	 * @param maxSDRAMSize
-	 *            If not <tt>null</tt>, the maximum SDRAM size to allow.
+	 *            If not {@code null}, the maximum SDRAM size to allow.
 	 * @throws IOException
 	 *             if networking fails
 	 * @throws Exception
@@ -554,9 +554,9 @@ public class Transceiver extends UDPTransceiver
 	 * Get the connections for talking to a board.
 	 *
 	 * @param connection
-	 *            directly gives the connection to use. May be <tt>null</tt>
+	 *            directly gives the connection to use. May be {@code null}
 	 * @param boardAddress
-	 *            the address of the board to talk to. May be <tt>null</tt>
+	 *            the address of the board to talk to. May be {@code null}
 	 * @return List of length 1 or 0 (the latter only if the search for the
 	 *         given board address fails).
 	 */
@@ -889,7 +889,7 @@ public class Transceiver extends UDPTransceiver
 	 *
 	 * @param chip
 	 *            The coordinates of the chip
-	 * @return connection or <tt>null</tt> if there is no such connection
+	 * @return connection or {@code null} if there is no such connection
 	 */
 	private SCPConnection searchForProxies(HasChipLocation chip) {
 		for (SCPConnection connection : scampConnections) {
@@ -1887,7 +1887,7 @@ public class Transceiver extends UDPTransceiver
 	public static final class ConnectionDescriptor {
 		/** What host to talk to. */
 		private InetAddress hostname;
-		/** What port to talk to, or <tt>null</tt> for default. */
+		/** What port to talk to, or {@code null} for default. */
 		private Integer portNumber;
 		/** What chip to talk to. */
 		private ChipLocation chip;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -192,7 +192,7 @@ public interface TransceiverInterface {
 	 * Determines if the board can be contacted.
 	 *
 	 * @param connection
-	 *            The connection which is to be tested. If <tt>null</tt>, all
+	 *            The connection which is to be tested. If {@code null}, all
 	 *            connections will be tested, and the board will be considered
 	 *            to be connected if any one connection works.
 	 * @return True if the board can be contacted, False otherwise
@@ -409,10 +409,10 @@ public interface TransceiverInterface {
 	 *
 	 * @param coreSubsets
 	 *            A set of chips and cores from which to get the information. If
-	 *            <tt>null</tt>, the information from all of the cores on all of
+	 *            {@code null}, the information from all of the cores on all of
 	 *            the chips on the board are obtained.
 	 * @return An iterable of the CPU information for the selected cores, or all
-	 *         cores if <tt>coreSubsets</tt> is <tt>null</tt>.
+	 *         cores if {@code coreSubsets} is {@code null}.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws Exception
@@ -494,7 +494,7 @@ public interface TransceiverInterface {
 	 * @param coreSubsets
 	 *            A set of chips and cores from which to get the buffers.
 	 * @return An iterable of the buffers, which may not be in the order of
-	 *         <tt>coreSubsets</tt>
+	 *         {@code coreSubsets}
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws Exception
@@ -1048,7 +1048,7 @@ public interface TransceiverInterface {
 	/**
 	 * Execute a set of binaries that make up a complete application on
 	 * specified cores, wait for them to be ready and then start all of the
-	 * binaries. Note this will get the binaries into <tt>c_main()</tt> but will
+	 * binaries. Note this will get the binaries into {@code c_main()} but will
 	 * not signal the barrier.
 	 *
 	 * @param executableTargets
@@ -2280,7 +2280,7 @@ public interface TransceiverInterface {
 	 *            is when each application is in one of these states
 	 * @param timeout
 	 *            The amount of time to wait in milliseconds for the cores to
-	 *            reach one of the states, or <tt>null</tt> to wait for an
+	 *            reach one of the states, or {@code null} to wait for an
 	 *            unbounded amount of time.
 	 * @param timeBetweenPolls
 	 *            Time between checking the state, in milliseconds
@@ -2446,7 +2446,7 @@ public interface TransceiverInterface {
 	 *
 	 * @param boardAddress
 	 *            The IP address of the Ethernet connection on the board
-	 * @return A connection for the given IP address, or <tt>null</tt> if no
+	 * @return A connection for the given IP address, or {@code null} if no
 	 *         such connection exists
 	 */
 	SCPConnection locateSpinnakerConnection(InetAddress boardAddress);
@@ -2456,7 +2456,7 @@ public interface TransceiverInterface {
 	 *
 	 * @param tag
 	 *            The tag to set up; note its board address can be
-	 *            <tt>null</tt>, in which case, the tag will be assigned to all
+	 *            {@code null}, in which case, the tag will be assigned to all
 	 *            boards
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
@@ -2470,7 +2470,7 @@ public interface TransceiverInterface {
 	 *
 	 * @param tag
 	 *            The reverse tag to set up; note its board address can be
-	 *            <tt>null</tt>, in which case, the tag will be assigned to all
+	 *            {@code null}, in which case, the tag will be assigned to all
 	 *            boards
 	 * @throws IOException
 	 *             If anything goes wrong with networking.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
@@ -30,7 +30,7 @@ public abstract class UDPTransceiver implements AutoCloseable {
 	private static final Logger log = getLogger(UDPTransceiver.class);
 	/**
 	 * A map of port -> map of IP address -> (connection, listener) for UDP
-	 * connections. Note listener might be <tt>null</tt> if the connection has
+	 * connections. Note listener might be {@code null} if the connection has
 	 * not been listened to before.
 	 * <p>
 	 * Used to keep track of what connection is listening on what port to ensure
@@ -40,7 +40,7 @@ public abstract class UDPTransceiver implements AutoCloseable {
 			new DefaultMap<>(HashMap::new);
 	/**
 	 * A map of class -> list of (connection, listener) for UDP connections that
-	 * are listenable. Note that listener might be <tt>null</tt> if the
+	 * are listenable. Note that listener might be {@code null} if the
 	 * connection has not be listened to before.
 	 */
 	private final Map<Class<?>, List<Pair<?>>> connectionsByClass =

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
@@ -48,7 +48,7 @@ public abstract class Utils {
 	}
 
 	/**
-	 * Get the address of the <tt>vcpu_t</tt> structure for the given core.
+	 * Get the address of the {@code vcpu_t} structure for the given core.
 	 *
 	 * @param p
 	 *            The core number
@@ -59,7 +59,7 @@ public abstract class Utils {
 	}
 
 	/**
-	 * Get the address of the <tt>vcpu_t</tt> structure for the given core.
+	 * Get the address of the {@code vcpu_t} structure for the given core.
 	 *
 	 * @param core
 	 *            The core

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/IntegrationTests.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/IntegrationTests.java
@@ -5,13 +5,17 @@
  */
 package uk.ac.manchester.spinnaker.spalloc;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+
 import uk.ac.manchester.spinnaker.spalloc.SpallocClient;
-import uk.ac.manchester.spinnaker.spalloc.SpallocJob;
 import uk.ac.manchester.spinnaker.spalloc.exceptions.JobDestroyedException;
 import uk.ac.manchester.spinnaker.spalloc.exceptions.SpallocServerException;
 import uk.ac.manchester.spinnaker.spalloc.messages.JobDescription;
@@ -25,58 +29,62 @@ import uk.ac.manchester.spinnaker.spalloc.messages.Notification;
  * @author micro
  */
 public class IntegrationTests {
-	// TODO Convert to test (that doesn't print to System.out)
-    public static void main(String[] callargs) throws IOException, SpallocServerException, JobDestroyedException {
-        String hostname = "spinnaker.cs.man.ac.uk";
-        int port = 22244;
-        Integer timeout = 1000;
-        List<Integer> args = new ArrayList<>();
-        args.add(1);
-        args.add(1);
-        Map<String, Object> kwargs = new HashMap<>();
-        kwargs.put("owner", "Christian testing ok to kill");
-        kwargs.put("keepalive", "10");
-        kwargs.put("max_dead_boards","2");
-        SpallocClient client = new SpallocClient(hostname, port, timeout);
-        System.out.println(client);
-        try (AutoCloseable c = client.withConnection()) {
-            System.out.println(client);
-            int id = client.createJob(args, kwargs, timeout);
-            System.out.println("New job: " + id);
-            List<JobDescription> jobs = client.listJobs(timeout);
-            for (JobDescription job:jobs) {
-                System.out.println(job);
-            }
-            List<Machine> machines = client.listMachines(timeout);
-            for (Machine machine:machines) {
-                System.out.println(machine);
-            }
-            JobState state = client.getJobState(id);
-            System.out.println(state);
-            JobMachineInfo machineInfo = client.getJobMachineInfo(id, null);
-            System.out.println(machineInfo);
-            client.notifyMachine(machineInfo.getMachineName(), true, null);
-            client.notifyJob(id, true, timeout);
-            Notification notification = client.waitForNotification(50000);
-            System.out.println(notification);
-            state = client.getJobState(id);
-            System.out.println(state);
-            notification = client.waitForNotification(15000);
-            System.out.println(notification);
-            notification = client.waitForNotification(15000);
-            System.out.println(notification);
-            state = client.getJobState(id);
-            System.out.println(state);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+	private static final Logger log = getLogger(IntegrationTests.class);
 
-//        System.out.println(aJob.getHostname());
-//        System.out.println(aJob.getID());
-        //System.out.println(test.getMachineName());
-        //System.out.println(test.getPower());
-        //System.out.println(test.getState());
-        //System.out.println(test.getDimensions());
-        //System.out.println(test.getDestroyReason());
-    }
+	public static void main(String[] callargs)
+			throws IOException, SpallocServerException, JobDestroyedException {
+		String hostname = "spinnaker.cs.man.ac.uk";
+		int port = 22244;
+		Integer timeout = 1000;
+		List<Integer> args = new ArrayList<>();
+		args.add(1);
+		args.add(1);
+		Map<String, Object> kwargs = new HashMap<>();
+		kwargs.put("owner", "Christian testing ok to kill");
+		kwargs.put("keepalive", "10");
+		kwargs.put("max_dead_boards", "2");
+		try (SpallocClient client =
+				new SpallocClient(hostname, port, timeout)) {
+			log.info(client.toString());
+			try (AutoCloseable c = client.withConnection()) {
+				log.info(client.toString());
+				int id = client.createJob(args, kwargs, timeout);
+				log.info("New job: " + id);
+				List<JobDescription> jobs = client.listJobs(timeout);
+				for (JobDescription job : jobs) {
+					log.info(job.toString());
+				}
+				List<Machine> machines = client.listMachines(timeout);
+				for (Machine machine : machines) {
+					log.info(machine.toString());
+				}
+				JobState state = client.getJobState(id);
+				log.info(state.toString());
+				JobMachineInfo machineInfo = client.getJobMachineInfo(id, null);
+				log.info(machineInfo.toString());
+				client.notifyMachine(machineInfo.getMachineName(), true, null);
+				client.notifyJob(id, true, timeout);
+				Notification notification = client.waitForNotification(50000);
+				log.info("notify:" + notification);
+				state = client.getJobState(id);
+				log.info(state.toString());
+				notification = client.waitForNotification(15000);
+				log.info("notify:" + notification);
+				notification = client.waitForNotification(15000);
+				log.info("notify:" + notification);
+				state = client.getJobState(id);
+				log.info(state.toString());
+			} catch (Exception ex) {
+				log.error("problem in testing", ex);
+			}
+
+			// log.info(aJob.getHostname());
+			// log.info(aJob.getID());
+			// log.info(test.getMachineName());
+			// log.info(test.getPower());
+			// log.info(test.getState());
+			// log.info(test.getDimensions());
+			// log.info(test.getDestroyReason());
+		}
+	}
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/IntegrationTests.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/IntegrationTests.java
@@ -25,12 +25,13 @@ import uk.ac.manchester.spinnaker.spalloc.messages.Notification;
  * @author micro
  */
 public class IntegrationTests {
+	// TODO Convert to test (that doesn't print to System.out)
     public static void main(String[] callargs) throws IOException, SpallocServerException, JobDestroyedException {
         String hostname = "spinnaker.cs.man.ac.uk";
         int port = 22244;
         Integer timeout = 1000;
         List<Integer> args = new ArrayList<>();
-        args.add(1);    
+        args.add(1);
         args.add(1);
         Map<String, Object> kwargs = new HashMap<>();
         kwargs.put("owner", "Christian testing ok to kill");
@@ -69,7 +70,7 @@ public class IntegrationTests {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
-        
+
 //        System.out.println(aJob.getHostname());
 //        System.out.println(aJob.getID());
         //System.out.println(test.getMachineName());

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
@@ -1,6 +1,11 @@
 package uk.ac.manchester.spinnaker.spalloc;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.IOException;
+
+import org.slf4j.Logger;
+
 import uk.ac.manchester.spinnaker.spalloc.messages.Command;
 import uk.ac.manchester.spinnaker.spalloc.messages.CreateJobCommand;
 import uk.ac.manchester.spinnaker.spalloc.messages.GetBoardAtPositionCommand;
@@ -22,6 +27,7 @@ import uk.ac.manchester.spinnaker.spalloc.messages.WhereIsMachineChipCommand;
  * @author Christian
  */
 public class MockConnectedClient extends SpallocClient {
+	private static final Logger log = getLogger(MockConnectedClient.class);
 
     static final String LIST_JOBS_R = "["
             + "{\"job_id\":47224,"
@@ -134,7 +140,7 @@ public class MockConnectedClient extends SpallocClient {
                 actual = true;
             } catch (Exception ex) {
                 actual = false;
-                throw new RuntimeException("Connect fail using mock", ex);
+                log.warn("Connect fail using mock", ex);
             }
         }
     }
@@ -146,7 +152,7 @@ public class MockConnectedClient extends SpallocClient {
                 return super.call(command, timeout);
             } catch (Exception ex) {
                 actual = false;
-                throw new RuntimeException("Call fail using mock", ex);
+                log.warn("Call fail using mock", ex);
             }
         }
         if (command.getClass() == ListJobsCommand.class) {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
@@ -18,7 +18,7 @@ import uk.ac.manchester.spinnaker.spalloc.messages.WhereIsMachineChipCommand;
 /**
  * A possibly Mock Client that if it can not create an actual connection
  *      provides a number of canned replies.
- * 
+ *
  * @author Christian
  */
 public class MockConnectedClient extends SpallocClient {
@@ -78,26 +78,26 @@ public class MockConnectedClient extends SpallocClient {
             + "\"dead_boards\":[],"
             + "\"dead_links\":[]}"
         + "]";
-    
+
     public static final int MOCK_ID = 9999;
-    
-    static final String JOB_MACHINE_INFO_R = 
+
+    static final String JOB_MACHINE_INFO_R =
             "{\"connections\":[[[0,0],\"10.11.223.33\"]],"
             + "\"width\":8,"
             + "\"machine_name\":\"Spin24b-223\","
             + "\"boards\":[[0,0,2]],"
             + "\"height\":8}";
-    
-    static final String STATE_POWER_R = 
+
+    static final String STATE_POWER_R =
             "{\"state\":2,"
             + "\"power\":true,"
             + "\"keepalive\":60.0,"
             + "\"reason\":null,"
             + "\"start_time\":1.537284307847865E9,"
             + "\"keepalivehost\":\"86.82.216.229\"}";
-            
-    
-    static final String WHERE_IS_R = 
+
+
+    static final String WHERE_IS_R =
             "{\"job_chip\":[1,1],"
             + "\"job_id\":9999,"
             + "\"chip\":[5,9],"
@@ -105,27 +105,27 @@ public class MockConnectedClient extends SpallocClient {
             + "\"machine\":\"Spin24b-223\","
             + "\"board_chip\":[1,1],"
             + "\"physical\":[0,0,4]}";
-    
+
     static final String POSITION_R = "[0,0,8]";
-    
+
      static final String AT_R = "[0,0,1]";
-            
+
     /**
      * The version as it comes from spalloc.
-     * 
+     *
      * Note the quotes in the String are as being returned by spalloc.
      */
     static final String VERSION = "\"1.0.0\"";
-    
-    
+
+
     private boolean actual;
- 
+
     public MockConnectedClient(int timeout) {
         super("spinnaker.cs.man.ac.uk", 22244, timeout);
         //super("127.0.0.0", 22244, timeout);
         actual = true;
     }
-    
+
     @Override
     public void connect(Integer timeout) throws IOException {
         if (actual) {
@@ -134,11 +134,11 @@ public class MockConnectedClient extends SpallocClient {
                 actual = true;
             } catch (Exception ex) {
                 actual = false;
-                System.out.println("Connect fail using mock");
+                throw new RuntimeException("Connect fail using mock", ex);
             }
         }
     }
-    
+
     @Override
     protected String call(Command<?> command, Integer timeout) {
         if (actual) {
@@ -146,8 +146,7 @@ public class MockConnectedClient extends SpallocClient {
                 return super.call(command, timeout);
             } catch (Exception ex) {
                 actual = false;
-                ex.printStackTrace();
-                System.out.println("Call fail using mock");
+                throw new RuntimeException("Call fail using mock", ex);
             }
         }
         if (command.getClass() == ListJobsCommand.class) {
@@ -161,11 +160,11 @@ public class MockConnectedClient extends SpallocClient {
         }
         if (command.getClass() == GetJobMachineInfoCommand.class) {
             return JOB_MACHINE_INFO_R;
-        }        
+        }
         if (command.getClass() ==GetJobStateCommand.class) {
             return STATE_POWER_R;
         }
-        if (command.getClass() == WhereIsJobChipCommand.class 
+        if (command.getClass() == WhereIsJobChipCommand.class
                 || command.getClass() == WhereIsMachineBoardLogicalCommand.class
                 || command.getClass() == WhereIsMachineBoardPhysicalCommand.class
                 || command.getClass() == WhereIsMachineChipCommand.class) {
@@ -185,8 +184,8 @@ public class MockConnectedClient extends SpallocClient {
 
     /**
      * Specifies if an actual connection is being used.
-     * @return 
-     *      True if real replies are being obtained, 
+     * @return
+     *      True if real replies are being obtained,
      *      False if canned replies are being used.
      */
     public boolean isActual() {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
@@ -30,7 +30,7 @@ abstract class SupportUtils {
 				started.fire();
 				s.connect();
 			} catch (Exception e) {
-				problem.value = e;
+				problem.setValue(e);
 				main.interrupt();
 			}
 		});
@@ -38,8 +38,8 @@ abstract class SupportUtils {
 		try {
 			started.await();
 		} catch (InterruptedException e) {
-			if (problem.value != null) {
-				throw problem.value;
+			if (problem.getValue() != null) {
+				throw problem.getValue();
 			}
 			throw e;
 		}

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
@@ -4,9 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 
-import javax.xml.ws.Holder;
-
 import uk.ac.manchester.spinnaker.utils.OneShotEvent;
+import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 abstract class SupportUtils {
 	private SupportUtils() {
@@ -24,7 +23,7 @@ abstract class SupportUtils {
 	static Thread backgroundAccept(MockServer s) throws Exception {
 		OneShotEvent started = new OneShotEvent();
 		Thread main = Thread.currentThread();
-		Holder<Exception> problem = new Holder<>();
+		ValueHolder<Exception> problem = new ValueHolder<>();
 		Thread t = new Thread(() -> {
 			try {
 				s.listen();

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -69,6 +69,7 @@ import uk.ac.manchester.spinnaker.utils.InetFactory;
  * @author Donal Fellows
  */
 public class TransceiverITCase {
+	// TODO Stop printing to System.out
 	static BoardTestConfiguration board_config;
 	private static SpallocJob job;
 

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -13,6 +13,7 @@ import static java.util.stream.Collectors.toSet;
 import static java.util.stream.IntStream.range;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.model.DiagnosticFilter.Destination.LINK_0;
 import static uk.ac.manchester.spinnaker.messages.model.DiagnosticFilter.Destination.LINK_1;
 import static uk.ac.manchester.spinnaker.messages.model.DiagnosticFilter.Destination.LINK_2;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
 
 import testconfig.BoardTestConfiguration;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
@@ -69,7 +71,8 @@ import uk.ac.manchester.spinnaker.utils.InetFactory;
  * @author Donal Fellows
  */
 public class TransceiverITCase {
-	// TODO Stop printing to System.out
+	private static final Logger log = getLogger(TransceiverITCase.class);
+ 	// TODO Stop printing to System.out
 	static BoardTestConfiguration board_config;
 	private static SpallocJob job;
 
@@ -498,7 +501,7 @@ public class TransceiverITCase {
 		try {
 			setUpBeforeClass();
 		} catch (TestAbortedException e) {
-			System.err.println("precondition violated: " + e.getMessage());
+			log.error("precondition violated", e);
 			System.exit(1);
 		}
 		try {

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Callable.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Callable.java
@@ -16,7 +16,7 @@ interface Callable {
 	 *
 	 * @param cmd
 	 *            The encoded command word.
-	 * @return Usually <tt>0</tt>. Sometimes a marker to indicate special
+	 * @return Usually {@code 0}. Sometimes a marker to indicate special
 	 *         states (currently just for end-of-specification).
 	 * @throws DataSpecificationException
 	 *             If anything goes wrong in the data specification.

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/FunctionAPI.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/FunctionAPI.java
@@ -31,7 +31,7 @@ public interface FunctionAPI {
 	 * @param index
 	 *            The location in the data specification data stream where the
 	 *            command was read from, for reporting errors to the user.
-	 * @return The operation implementation. Never <tt>null</tt>.
+	 * @return The operation implementation. Never {@code null}.
 	 * @throws UnimplementedDSECommandException
 	 *             If the opcode used is not implemented.
 	 */

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
@@ -50,7 +50,7 @@ public final class MemoryRegionCollection implements Collection<MemoryRegion> {
 	 *
 	 * @param regionID
 	 *            The region ID to retrieve.
-	 * @return The memory region, or <tt>null</tt> if that region is empty.
+	 * @return The memory region, or {@code null} if that region is empty.
 	 */
 	public MemoryRegion get(int regionID) {
 		return regions[regionID];
@@ -60,7 +60,7 @@ public final class MemoryRegionCollection implements Collection<MemoryRegion> {
 	 * Set the region with the given ID.
 	 *
 	 * @param regionID
-	 *            The region ID to set. Must not be <tt>null</tt>.
+	 *            The region ID to set. Must not be {@code null}.
 	 * @param region
 	 *            The region to store.
 	 * @throws RegionInUseException

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Operation.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Operation.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to indicate which methods should be used to implement
  * DSE operations. Methods annotated with this <i>must</i> take no arguments,
- * and <i>must</i> have a return type of either <tt>void</tt> or <tt>int</tt>.
+ * and <i>must</i> have a return type of either {@code void} or {@code int}.
  * The operation calling mechanism treats methods that don't return a value as
  * if they returned zero.
  *
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 public @interface Operation {
 	/**
 	 * Describes what Data Specification operation is implemented by the method
-	 * the annotation is on. This <i>must not</i> be <tt>null</tt>.
+	 * the annotation is on. This <i>must not</i> be {@code null}.
 	 *
 	 * @return The DSE operation descriptor.
 	 */

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/OperationMapper.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/OperationMapper.java
@@ -40,7 +40,7 @@ abstract class OperationMapper {
 	 *            The object containing the method implementations.
 	 * @param opcode
 	 *            The opcode that we want to invoke.
-	 * @return How to invoke that operation, or <tt>null</tt> if that operation
+	 * @return How to invoke that operation, or {@code null} if that operation
 	 *         has no registered implementation.
 	 */
 	static Callable getOperationImpl(FunctionAPI funcs, Commands opcode) {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/HostDataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/HostDataReceiver.java
@@ -100,7 +100,7 @@ public class HostDataReceiver extends Thread {
 
 	/**
 	 * Divide one integer by another with rounding up. For example,
-	 * <tt>ceildiv(5,3) == 2</tt>
+	 * {@code ceildiv(5,3) == 2}
 	 *
 	 * @param numerator
 	 *            The value to be divided.

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
@@ -270,16 +270,16 @@ public class Machine implements Iterable<Chip> {
      * <p>
      * The Chips will be returned in the natural order of their ChipLocation.
      *
-     * @return An <tt>Iterator</tt> over the Chips in this Machine.
+     * @return An iterator over the Chips in this Machine.
      */
     public final Iterator<Chip> iterator() {
         return this.chips.values().iterator();
     }
 
     /**
-     * The number of Chips om this Machine.
+     * The number of Chips on this Machine.
      *
-     * @return The number of Chips om this Machine.
+     * @return The number of Chips on this Machine.
      */
     public final int nChips() {
         return chips.size();

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RoutingEntry.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RoutingEntry.java
@@ -124,7 +124,7 @@ public class RoutingEntry {
      * Removes a processor ID if it existed.
      *
      * @param oldValue The Id of the processor to remove.
-     * @return <tt>true</tt> If this entry contained the specified processor.
+     * @return {@code true} If this entry contained the specified processor.
      */
     public boolean removeProcessorID(Integer oldValue) {
         return processorIDs.remove(oldValue);
@@ -174,7 +174,7 @@ public class RoutingEntry {
      * Removes a link ID/Direction if it existed.
      *
      * @param oldValue The Id of the processor to remove.
-     * @return <tt>true</tt> If this entry contained the specified
+     * @return {@code true} If this entry contained the specified
      *      link/direction.
      */
     public boolean removeLinkID(Direction oldValue) {

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/Reports.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/Reports.java
@@ -37,7 +37,7 @@ public abstract class Reports {
      *            the machine object
      * @param connections
      *            the list of connections to the machine; the elements in the
-     *            list <i>should</i> have <tt>toString()</tt> methods that
+     *            list <i>should</i> have {@code toString()} methods that
      *            produce human-readable output.
      * @throws IOException
      *             when a file cannot be opened for some reason

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
@@ -57,7 +57,7 @@ public final class IPTag extends Tag {
      *            The IP address to which SDP packets with the tag will be sent
      * @param port
      *            The port to which the SDP packets with the tag will be sent,
-     *            or <tt>null</tt> if not yet assigned.
+     *            or {@code null} if not yet assigned.
      */
     public IPTag(InetAddress boardAddress, ChipLocation destination, int tagID,
             InetAddress targetAddress, Integer port) {
@@ -94,7 +94,7 @@ public final class IPTag extends Tag {
      *            The IP address to which SDP packets with the tag will be sent
      * @param port
      *            The port to which the SDP packets with the tag will be sent,
-     *            or <tt>null</tt> if not yet assigned.
+     *            or {@code null} if not yet assigned.
      * @param stripSDP
      *            Indicates whether the SDP header should be removed
      */
@@ -115,7 +115,7 @@ public final class IPTag extends Tag {
      *            The IP address to which SDP packets with the tag will be sent
      * @param port
      *            The port to which the SDP packets with the tag will be sent,
-     *            or <tt>null</tt> if not yet assigned.
+     *            or {@code null} if not yet assigned.
      * @param stripSDP
      *            Indicates whether the SDP header should be removed
      * @param trafficIdentifier

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/Tag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/Tag.java
@@ -38,7 +38,7 @@ public abstract class Tag {
     }
 
     /**
-     * @return The port of the tagID, or <tt>null</tt> if there isn't one yet.
+     * @return The port of the tagID, or {@code null} if there isn't one yet.
      */
     public Integer getPort() {
         return port;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Counter.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Counter.java
@@ -4,7 +4,7 @@
 package uk.ac.manchester.spinnaker.utils;
 
 /**
- * Thin wrapper around an <tt>int</tt> for counting.
+ * Thin wrapper around an {@code int} for counting.
  * <p>
  * This allows the object to be final and therefore passed into inner classes.
  * <p>

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/RawConfigParser.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/RawConfigParser.java
@@ -184,11 +184,11 @@ public class RawConfigParser {
 	}
 
 	/**
-	 * How to decide if a value is to be treated as <tt>null</tt>.
+	 * How to decide if a value is to be treated as {@code null}.
 	 *
 	 * @param value
 	 *            The value to examine
-	 * @return True iff the value is a <tt>null</tt>-equivalent.
+	 * @return True iff the value is a {@code null}-equivalent.
 	 */
 	protected boolean isNone(String value) {
 		return value == null || "None".equalsIgnoreCase(value);
@@ -201,7 +201,7 @@ public class RawConfigParser {
 	 *            The section to look in.
 	 * @param option
 	 *            The option to look at.
-	 * @return The option value, or <tt>null</tt> if it is absent.
+	 * @return The option value, or {@code null} if it is absent.
 	 */
 	public Integer getint(String section, String option) {
 		String value = get(section, option);
@@ -218,7 +218,7 @@ public class RawConfigParser {
 	 *            The section to look in.
 	 * @param option
 	 *            The option to look at.
-	 * @return The option value, or <tt>null</tt> if it is absent.
+	 * @return The option value, or {@code null} if it is absent.
 	 */
 	public Boolean getboolean(String section, String option) {
 		String value = get(section, option);
@@ -235,7 +235,7 @@ public class RawConfigParser {
 	 *            The section to look in.
 	 * @param option
 	 *            The option to look at.
-	 * @return The option value, or <tt>null</tt> if it is absent.
+	 * @return The option value, or {@code null} if it is absent.
 	 */
 	public String get(String section, String option) {
 		Map<String, String> sect = map.get(normaliseSectionName(section));

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
@@ -1,0 +1,32 @@
+package uk.ac.manchester.spinnaker.utils;
+
+/**
+ * A simple class that can optionally hold a single value. <i>This class is
+ * modifiable.</i>
+ *
+ * @author Donal Fellows
+ * @param <T>
+ *            The type of value to hold.
+ */
+public class ValueHolder<T> {
+	/**
+	 * The value held.
+	 */
+	public T value;
+
+	/**
+	 * Create an instance. The initial value held is <tt>null</tt>.
+	 */
+	public ValueHolder() {
+	}
+
+	/**
+	 * Create an instance.
+	 *
+	 * @param value
+	 *            The initial value to hold.
+	 */
+	public ValueHolder(T value) {
+		this.value = value;
+	}
+}

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
@@ -12,7 +12,7 @@ public class ValueHolder<T> {
 	private T value;
 
 	/**
-	 * Create an instance. The initial value held is <tt>null</tt>.
+	 * Create an instance. The initial value held is {@code null}.
 	 */
 	public ValueHolder() {
 	}

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
@@ -9,10 +9,7 @@ package uk.ac.manchester.spinnaker.utils;
  *            The type of value to hold.
  */
 public class ValueHolder<T> {
-	/**
-	 * The value held.
-	 */
-	public T value;
+	private T value;
 
 	/**
 	 * Create an instance. The initial value held is <tt>null</tt>.
@@ -27,6 +24,25 @@ public class ValueHolder<T> {
 	 *            The initial value to hold.
 	 */
 	public ValueHolder(T value) {
+		this.value = value;
+	}
+
+	/**
+	 * Get the value held.
+	 *
+	 * @return The value held.
+	 */
+	public T getValue() {
+		return value;
+	}
+
+	/**
+	 * Set the value to hold.
+	 *
+	 * @param value
+	 *            The new value to hold.
+	 */
+	public void setValue(T value) {
 		this.value = value;
 	}
 }

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterable.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterable.java
@@ -90,10 +90,10 @@ public class ProgressIterable<E> implements Iterable<E>, Closeable {
 	 * Closes all created Iterators and their ProgressBar(s).
 	 * <p>
 	 * This method allows the Iterable to be used in a
-	 * <tt>try</tt>-with-resources statement, which guarantees the ProgressBar
+	 * {@code try}-with-resources statement, which guarantees the ProgressBar
 	 * is closed.
 	 * <p>
-	 * Note: As <tt>hasNext() == false</tt> automatically calls close there is
+	 * Note: As {@code hasNext() == false} automatically calls close there is
 	 * no need to call this method unless you break out of the iterator early.
 	 * <p>
 	 * If the bar is already closed, invoking this method has no effect.

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterator.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterator.java
@@ -85,7 +85,7 @@ public class ProgressIterator<E> implements Iterator<E>, Closeable {
 	/**
 	 * Closes the underlying {@link ProgressBar}.
 	 * <p>
-	 * Note: As <tt>hasNext() == false</tt> automatically calls close there is
+	 * Note: As {@code hasNext() == false} automatically calls close there is
 	 * no need to call this method unless you break out of the iterator early.
 	 * <p>
 	 * If the bar is already closed then invoking this method has no effect.

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterator.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterator.java
@@ -17,19 +17,20 @@ public class TestDoubleMapIterator {
 
     @Test
     public void testSingle() {
-        Map<Double, Map<String, Integer>> aMap = new HashMap();
+        Map<Double, Map<String, Integer>> aMap = new HashMap<>();
 
-        Map<String, Integer> inner = new HashMap();
+        Map<String, Integer> inner = new HashMap<>();
         inner.put("One", 1);
         inner.put("Two", 2);
         inner.put("Three", 3);
         aMap.put(23.2, inner);
 
         DoubleMapIterator<Integer> instance;
-        instance = new DoubleMapIterator(aMap);
+        instance = new DoubleMapIterator<>(aMap);
         int count = 0;
         while (instance.hasNext()) {
             int value = instance.next();
+            assertEquals(value, value); // TODO real test
             count += 1;
         }
         assertEquals(3, count);
@@ -37,25 +38,26 @@ public class TestDoubleMapIterator {
 
     @Test
     public void testMultiple() {
-        Map<Double, Map<String, Integer>> aMap = new HashMap();
+        Map<Double, Map<String, Integer>> aMap = new HashMap<>();
 
-        Map<String, Integer> inner = new HashMap();
+        Map<String, Integer> inner = new HashMap<>();
         inner.put("One", 1);
         inner.put("Two", 2);
         inner.put("Three", 3);
         aMap.put(23.2, inner);
 
-        Map<String, Integer> inner2 = new HashMap();
+        Map<String, Integer> inner2 = new HashMap<>();
         inner2.put("Ten", 10);
         inner2.put("Eleven", 11);
         inner2.put("Twelve", 12);
         aMap.put(43.6, inner2);
 
         DoubleMapIterator<Integer> instance;
-        instance = new DoubleMapIterator(aMap);
+        instance = new DoubleMapIterator<>(aMap);
         int count = 0;
         while (instance.hasNext()) {
             int value = instance.next();
+            assertEquals(value, value); // TODO real test
             count += 1;
         }
         assertEquals(6, count);
@@ -68,13 +70,14 @@ public class TestDoubleMapIterator {
 
     @Test
     public void testEmptyWhole() {
-        Map<Double, Map<String, Integer>> aMap = new HashMap();
+        Map<Double, Map<String, Integer>> aMap = new HashMap<>();
         DoubleMapIterator<Integer> instance;
-        instance = new DoubleMapIterator(aMap);
+        instance = new DoubleMapIterator<>(aMap);
         int count = 0;
         while (instance.hasNext()) {
             int value = instance.next();
-            System.out.println(value);
+            assertEquals(value, value); // TODO real test
+            //System.out.println(value);
             count += 1;
         }
         assertEquals(0, count);
@@ -82,28 +85,29 @@ public class TestDoubleMapIterator {
 
     @Test
     public void testOneEmpty() {
-        Map<Double, Map<String, Integer>> aMap = new HashMap();
+        Map<Double, Map<String, Integer>> aMap = new HashMap<>();
 
-        Map<String, Integer> inner0 = new HashMap();
+        Map<String, Integer> inner0 = new HashMap<>();
         aMap.put(343.2, inner0);
 
-        Map<String, Integer> inner = new HashMap();
+        Map<String, Integer> inner = new HashMap<>();
         inner.put("One", 1);
         inner.put("Two", 2);
         inner.put("Three", 3);
         aMap.put(23.2, inner);
 
-        Map<String, Integer> inner2 = new HashMap();
+        Map<String, Integer> inner2 = new HashMap<>();
         inner2.put("Ten", 10);
         inner2.put("Eleven", 11);
         inner2.put("Twelve", 12);
         aMap.put(43.6, inner2);
 
         DoubleMapIterator<Integer> instance;
-        instance = new DoubleMapIterator(aMap);
+        instance = new DoubleMapIterator<>(aMap);
         int count = 0;
         while (instance.hasNext()) {
             int value = instance.next();
+            assertEquals(value, value); // TODO real test
             count += 1;
         }
         assertEquals(6, count);

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Christian
  */
 public class TestOneShotEvent {
-    
+
 
     public TestOneShotEvent() {
     }
@@ -25,7 +25,7 @@ public class TestOneShotEvent {
             }
         }
     };
-        
+
     Runnable inOrder = new Runnable() {
         @Override
         public void run() {
@@ -38,7 +38,7 @@ public class TestOneShotEvent {
             }
         }
     };
-        
+
     Runnable firer = new Runnable() {
         @Override
         public void run() {
@@ -76,37 +76,33 @@ public class TestOneShotEvent {
             }
         }
     };
-            
-    @Test
-    public void testMultiple() {
-        Thread thanger = new Thread(hanger);
-        thanger.start();
-        Thread tinOrder = new Thread(inOrder);
-        tinOrder.start();
-        Thread tfirer = new Thread(firer);
-        tfirer.start();
-        Thread tmultiple = new Thread(multiple);
-        tmultiple.start();
-        Thread twaiter = new Thread(waiter);
-        twaiter.start();
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException ex) {
-            System.out.println("pop");
-        }
-        assert (thanger.isAlive());
-        thanger.interrupt();
-        assert (!tinOrder.isAlive());
-        assert (!tfirer.isAlive());
-        assert (!tmultiple.isAlive());
-        assert (twaiter.isAlive());
-        event1.fire();
-        try {
-            Thread.sleep(50);
-        } catch (InterruptedException ex) {
-            System.out.println("pop2");
-        }
-        assert (!twaiter.isAlive());
-    }
+
+	@Test
+	public void testMultiple() throws InterruptedException {
+		Thread thanger = new Thread(hanger);
+		thanger.start();
+		Thread tinOrder = new Thread(inOrder);
+		tinOrder.start();
+		Thread tfirer = new Thread(firer);
+		tfirer.start();
+		Thread tmultiple = new Thread(multiple);
+		tmultiple.start();
+		Thread twaiter = new Thread(waiter);
+		twaiter.start();
+
+		Thread.sleep(500);
+
+		assertTrue(thanger.isAlive());
+		thanger.interrupt();
+		assertTrue(!tinOrder.isAlive());
+		assertTrue(!tfirer.isAlive());
+		assertTrue(!tmultiple.isAlive());
+		assertTrue(twaiter.isAlive());
+		event1.fire();
+
+		Thread.sleep(50);
+
+		assertTrue(!twaiter.isAlive());
+	}
 
 }

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
@@ -8,7 +8,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Christian
  */
 public class TestOneShotEvent {
-
+	private static void sleep(int ms) {
+		try {
+			Thread.sleep(ms);
+		} catch (InterruptedException e) {
+			System.err.println("unexpected wake from sleep");
+		}
+	}
 
     public TestOneShotEvent() {
     }
@@ -90,7 +96,7 @@ public class TestOneShotEvent {
 		Thread twaiter = new Thread(waiter);
 		twaiter.start();
 
-		Thread.sleep(500);
+		sleep(500);
 
 		assertTrue(thanger.isAlive());
 		thanger.interrupt();
@@ -100,7 +106,7 @@ public class TestOneShotEvent {
 		assertTrue(twaiter.isAlive());
 		event1.fire();
 
-		Thread.sleep(50);
+		sleep(50);
 
 		assertTrue(!twaiter.isAlive());
 	}

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestBar.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestBar.java
@@ -25,9 +25,8 @@ public class TestBar {
 
     @Test
     public void testBasic() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-        ProgressBar pb = new ProgressBar(5, null);
+		ProgressBar pb = new ProgressBar(5, null,
+				new PrintStream(new ByteArrayOutputStream()));
         for (int i = 0; i < 3 ; i++){
             pb.update();
         }
@@ -43,7 +42,9 @@ public class TestBar {
     @Test
     public void testToMany() {
         String description = "tooMany";
-        ProgressBar pb = new ProgressBar(5, description);
+        @SuppressWarnings("resource")
+		ProgressBar pb = new ProgressBar(5, description,
+				new PrintStream(new ByteArrayOutputStream()));
         for (int i = 0; i < 5 ; i++){
             pb.update();
         }
@@ -56,9 +57,8 @@ public class TestBar {
     @Test
     public void testSimple() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
         String description = "Easiest";
-        ProgressBar pb = new ProgressBar(5, description, ps);
+		ProgressBar pb = new ProgressBar(5, description, new PrintStream(baos));
         for (int i = 0; i < 5 ; i++){
             pb.update();
         }
@@ -73,9 +73,9 @@ public class TestBar {
     @Test
     public void testNoDivSmall() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
         String description = "Thirteen";
-        try (ProgressBar pb = new ProgressBar(13, description, ps);) {
+		try (ProgressBar pb =
+				new ProgressBar(13, description, new PrintStream(baos))) {
             for (int i = 0; i < 13 ; i++){
                 pb.update();
             }
@@ -91,9 +91,10 @@ public class TestBar {
     @Test
     public void testNoDivBig() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
         String description = "Big";
-        ProgressBar pb = new ProgressBar(133, description, ps);
+        @SuppressWarnings("resource")
+		ProgressBar pb =
+				new ProgressBar(133, description, new PrintStream(baos));
         for (int i = 0; i < 133 ; i++){
             pb.update();
         }
@@ -108,9 +109,9 @@ public class TestBar {
     @Test
     public void testStopEarly() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
         String description = "Early";
-        ProgressBar pb = new ProgressBar(10, description, ps);
+		ProgressBar pb =
+				new ProgressBar(10, description, new PrintStream(baos));
         for (int i = 0; i < 3 ; i++){
             pb.update();
         }

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestIterable.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestIterable.java
@@ -6,7 +6,6 @@ package uk.ac.manchester.spinnaker.utils.progress;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import uk.ac.manchester.spinnaker.utils.Counter;
@@ -17,85 +16,84 @@ import uk.ac.manchester.spinnaker.utils.Counter;
  */
 public class TestIterable {
 
-    private static final String PERCENTS =
-            "|0%                          50%                         100%|";
-    private static final String DASHES =
-            " ------------------------------------------------------------";
+	private static final String PERCENTS =
+			"|0%                          50%                         100%|";
+	private static final String DASHES =
+			" ------------------------------------------------------------";
 
+	public TestIterable() {
+	}
 
-    public TestIterable() {
-    }
+	@Test
+	public void testbasic() {
+		String description = "Easiest";
+		@SuppressWarnings("resource")
+		ProgressIterable<Integer> pb = new ProgressIterable<>(
+				Arrays.asList(1, 2, 3, 4, 5), description,
+				new PrintStream(new ByteArrayOutputStream()));
+		int sum = 0;
+		for (int i : pb) {
+			sum += i;
+		}
+		assertEquals(1 + 2 + 3 + 4 + 5, sum);
+	}
 
-    @Test
-    public void testbasic() {
-        String description = "Easiest";
-        ProgressIterable<Integer> pb = new ProgressIterable<>(
-                Arrays.asList(1,2,3,4,5), description);
-        int sum = 0;
-        for (int i:pb){
-            sum += i;
-        }
-        assertEquals(1+2+3+4+5, sum);
-    }
+	@Test
+	public void testSimple() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		String description = "Easiest";
+		@SuppressWarnings("resource")
+		ProgressIterable<Integer> pb =
+				new ProgressIterable<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7),
+						description, new PrintStream(baos));
+		int sum = 0;
+		for (int i : pb) {
+			sum += i;
+		}
+		assertEquals(1 + 2 + 3 + 4 + 5 + 6 + 7, sum);
+		String lines[] = baos.toString().split("\\r?\\n");
+		assertEquals(4, lines.length);
+		assertEquals(description, lines[0]);
+		assertEquals(PERCENTS, lines[1]);
+		assertEquals(DASHES, lines[2]);
+	}
 
-    @Test
-    public void testSimple() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-        String description = "Easiest";
-        ProgressIterable<Integer> pb = new ProgressIterable<>(
-                Arrays.asList(1,2,3,4,5,6,7), description, ps);
-        int sum = 0;
-        for (int i:pb){
-            sum += i;
-        }
-        assertEquals(1+2+3+4+5+6+7, sum);
-        String lines[] = baos.toString().split("\\r?\\n");
-        assertEquals(4, lines.length);
-        assertEquals(description, lines[0]);
-        assertEquals(PERCENTS, lines[1]);
-        assertEquals(DASHES, lines[2]);
-    }
+	@Test
+	public void testStopEarly() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		String description = "Early";
+		try (ProgressIterable<Integer> bar = new ProgressIterable<Integer>(
+				Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), description,
+				new PrintStream(baos))) {
+			for (int i : bar) {
+				if (i == 3) {
+					break;
+				}
+			}
+		}
+		String lines[] = baos.toString().split("\\r?\\n");
+		assertEquals(4, lines.length);
+		assertEquals(description, lines[0]);
+		assertEquals(PERCENTS, lines[1]);
+		assertEquals(60 / 10 * 3 + 1, lines[2].length());
+	}
 
-    @Test
-    public void testStopEarly() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-        String description = "Early";
-        try (ProgressIterable<Integer> bar = new ProgressIterable<Integer>(
-                Arrays.asList(1,2,3,4,5,6,7,8,9,10), description, ps); ) {
-            for (int i:bar) {
-                if (i == 3) {
-                    break;
-                }
-            }
-        }
-        String lines[] = baos.toString().split("\\r?\\n");
-        assertEquals(4, lines.length);
-        assertEquals(description, lines[0]);
-        assertEquals(PERCENTS, lines[1]);
-        assertEquals(60 / 10 * 3 + 1, lines[2].length());
-    }
-
-    @Test
-    public void testForEachRemaining() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-        String description = "Easiest";
-        ProgressIterable<Integer> pb = new ProgressIterable<>(
-                Arrays.asList(1,2,3,4,5), description, ps);
-        Counter sum = new Counter();
-        pb.forEach(i -> {;
-            sum.add(i);
-        });
-        assertEquals(1+2+3+4+5, sum.get());
-        String lines[] = baos.toString().split("\\r?\\n");
-        assertEquals(4, lines.length);
-        assertEquals(description, lines[0]);
-        assertEquals(PERCENTS, lines[1]);
-        assertEquals(DASHES, lines[2]);
-    }
+	@Test
+	public void testForEachRemaining() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		String description = "Easiest";
+		@SuppressWarnings("resource")
+		ProgressIterable<Integer> pb =
+				new ProgressIterable<>(Arrays.asList(1, 2, 3, 4, 5),
+						description, new PrintStream(baos));
+		Counter sum = new Counter();
+		pb.forEach(sum::add);
+		assertEquals(1 + 2 + 3 + 4 + 5, sum.get());
+		String lines[] = baos.toString().split("\\r?\\n");
+		assertEquals(4, lines.length);
+		assertEquals(description, lines[0]);
+		assertEquals(PERCENTS, lines[1]);
+		assertEquals(DASHES, lines[2]);
+	}
 
 }
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.1</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
This allows us to build with Java 11 _as well as_ Java 8. There are three principal changes:

1. Alterations to `.travis.yml` to create a build matrix of `jdk` versions.
2. Altering `<tt>…</tt>` to `{@code …}` in javadoc because the former isn't supported in the HTML5 profile that javadoc now generates.
3. Changing the version of JaCoCo used to one that is also compatible with Java 11. (see jacoco/jacoco#663)
4. Stopping using `javax.xml.ws.Holder` since that's no longer in the main JRE profile (the functionality is replicated approximately in the `uk.ac.manchester.spinnaker.utils.ValueHolder` class).

There have been a few other changes as well, such as reducing uses of `System.out` in attempt to resolve point 3 above.