### PR TITLE
Fix spalloc usage for integration tests

### DIFF
--- a/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
+++ b/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
@@ -1,6 +1,5 @@
 package testconfig;
 
-import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
@@ -107,8 +106,6 @@ public class BoardTestConfiguration {
 		});
 		SpallocJob job =
 				new SpallocJob(spalloc, port, timeout, asList(1), kwargs);
-		sleep(1200);
-		job.setPower(true);
 		job.waitUntilReady(null);
 		remotehost = job.getHostname();
 		try {


### PR DESCRIPTION
So I was using the wrong access pattern for spallocing a board in the integration tests. That's just a bug in the way I was using spalloc _in the test code_, so fixing the test code is the right way forward. (Do something stupid, it doesn't work, so make the world better by doing something less stupid. Rinse and repeat…)