### PR TITLE
Allow storage to take input data as byte buffers.

### DIFF
--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/Storage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/Storage.java
@@ -1,5 +1,6 @@
 package uk.ac.manchester.spinnaker.storage;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
@@ -29,6 +30,27 @@ public interface Storage {
 			throws StorageException;
 
 	/**
+	 * Stores some bytes in the database. The bytes represent the contents of a
+	 * region of a particular SpiNNaker core.
+	 *
+	 * @param core
+	 *            The core that has the memory region.
+	 * @param region
+	 *            The region ID.
+	 * @param contents
+	 *            The contents to store.
+	 * @return The row ID. (Not currently used elsewhere.)
+	 * @throws StorageException
+	 *             If anything goes wrong.
+	 */
+	default int storeRegionContents(HasCoreLocation core, int region,
+			ByteBuffer contents) throws StorageException {
+		byte[] ary = new byte[contents.remaining()];
+		contents.slice().get(ary);
+		return storeRegionContents(core, region, ary);
+	}
+
+	/**
 	 * Appends some bytes to some already in the database. The bytes represent
 	 * the contents of a region of a particular SpiNNaker core.
 	 *
@@ -43,6 +65,26 @@ public interface Storage {
 	 */
 	void appendRegionContents(HasCoreLocation core, int region, byte[] contents)
 			throws StorageException;
+
+	/**
+	 * Appends some bytes to some already in the database. The bytes represent
+	 * the contents of a region of a particular SpiNNaker core.
+	 *
+	 * @param core
+	 *            The core that has the memory region.
+	 * @param region
+	 *            The region ID.
+	 * @param contents
+	 *            The contents to store.
+	 * @throws StorageException
+	 *             If anything goes wrong.
+	 */
+	default void appendRegionContents(HasCoreLocation core, int region,
+			ByteBuffer contents) throws StorageException {
+		byte[] ary = new byte[contents.remaining()];
+		contents.slice().get(ary);
+		appendRegionContents(core, region, ary);
+	}
 
 	/**
 	 * Retrieves some bytes from the database. The bytes represent the contents

--- a/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
+++ b/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -28,6 +29,10 @@ class TestSQLiteStorage {
 		db.delete();
 	}
 
+	private static ByteBuffer bytes(String str) {
+		return ByteBuffer.wrap(str.getBytes(UTF_8));
+	}
+
 	@Test
 	void testBasicOps() throws StorageException {
 		ConnectionProvider engine = new DatabaseEngine(db);
@@ -36,8 +41,8 @@ class TestSQLiteStorage {
 
 		assertEquals(Collections.emptyList(), storage.getCoresWithStorage());
 
-		storage.storeRegionContents(core, 0, "abc".getBytes(UTF_8));
-		storage.appendRegionContents(core, 0, "def".getBytes(UTF_8));
+		storage.storeRegionContents(core, 0, bytes("abc"));
+		storage.appendRegionContents(core, 0, bytes("def"));
 
 		assertArrayEquals("abcdef".getBytes(UTF_8),
 				storage.getRegionContents(core, 0));
@@ -56,14 +61,14 @@ class TestSQLiteStorage {
 		HasCoreLocation core = new CoreLocation(0, 0, 0);
 
 		// store overwrites
-		storage.storeRegionContents(core, 0, "abc".getBytes(UTF_8));
-		storage.storeRegionContents(core, 0, "def".getBytes(UTF_8));
+		storage.storeRegionContents(core, 0, bytes("abc"));
+		storage.storeRegionContents(core, 0, bytes("def"));
 		assertEquals("def",
 				new String(storage.getRegionContents(core, 0), UTF_8));
 
 		// append creates
-		storage.appendRegionContents(core, 1, "abc".getBytes(UTF_8));
-		storage.appendRegionContents(core, 1, "def".getBytes(UTF_8));
+		storage.appendRegionContents(core, 1, bytes("abc"));
+		storage.appendRegionContents(core, 1, bytes("def"));
 		assertEquals("abcdef",
 				new String(storage.getRegionContents(core, 1), UTF_8));
 	}


### PR DESCRIPTION
It's much more convenient to do it this way when pulling the data from memory, as that delivers byte buffers out. The old API is also supported, as that is more efficient when you already have the data in a raw array of bytes (since JDBC doesn't know anything about `ByteArray`s).