### PR TITLE
Corrected computation of transfer units and transfer size clamp

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
@@ -5,7 +5,7 @@ import uk.ac.manchester.spinnaker.utils.UnitConstants;
 /** Miscellaneous SpiNNaker constants. */
 public abstract class Constants {
 	/** The max size a UDP packet can be. */
-	public static final int UDP_MESSAGE_MAX_SIZE = 255;
+	public static final int UDP_MESSAGE_MAX_SIZE = 256;
 	/** The default port of the connection. */
 	public static final int SCP_SCAMP_PORT = 17893;
 	/** The default port of the connection. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -11,7 +11,13 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 
 /** An SCP request to read a region of memory via a link on a chip. */
 public class ReadLink extends SCPRequest<ReadLink.Response> {
-	private static final int SIZE_MASK = 0xFF;
+	private static final int MAX_SIZE = 256;
+	private static int validate(int size) {
+		if (size < 1 || size > MAX_SIZE) {
+			throw new IllegalArgumentException("size must be in range 1 to 256");
+		}
+		return size;
+	}
 
 	/**
 	 * @param core
@@ -24,7 +30,7 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	 *            The number of bytes to read, between 1 and 256
 	 */
 	public ReadLink(HasCoreLocation core, int link, int baseAddress, int size) {
-		super(core, CMD_LINK_READ, baseAddress, size & SIZE_MASK, link);
+		super(core, CMD_LINK_READ, baseAddress, validate(size), link);
 	}
 
 	/**
@@ -38,7 +44,7 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	 *            The number of bytes to read, between 1 and 256
 	 */
 	public ReadLink(HasChipLocation chip, int link, int baseAddress, int size) {
-		super(chip.getScampCore(), CMD_LINK_READ, baseAddress, size & SIZE_MASK,
+		super(chip.getScampCore(), CMD_LINK_READ, baseAddress, validate(size),
 				link);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -1,6 +1,7 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LINK_READ;
 
 import java.nio.ByteBuffer;
@@ -11,9 +12,8 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 
 /** An SCP request to read a region of memory via a link on a chip. */
 public class ReadLink extends SCPRequest<ReadLink.Response> {
-	private static final int MAX_SIZE = 256;
 	private static int validate(int size) {
-		if (size < 1 || size > MAX_SIZE) {
+		if (size < 1 || size > UDP_MESSAGE_MAX_SIZE) {
 			throw new IllegalArgumentException("size must be in range 1 to 256");
 		}
 		return size;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -14,7 +14,8 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 public class ReadLink extends SCPRequest<ReadLink.Response> {
 	private static int validate(int size) {
 		if (size < 1 || size > UDP_MESSAGE_MAX_SIZE) {
-			throw new IllegalArgumentException("size must be in range 1 to 256");
+			throw new IllegalArgumentException(
+					"size must be in range 1 to 256");
 		}
 		return size;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -12,7 +12,13 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 
 /** An SCP request to read a region of memory. */
 public class ReadMemory extends SCPRequest<ReadMemory.Response> {
-	private static final int SIZE_MASK = 0xFF;
+	private static final int MAX_SIZE = 256;
+	private static int validate(int size) {
+		if (size < 1 || size > MAX_SIZE) {
+			throw new IllegalArgumentException("size must be in range 1 to 256");
+		}
+		return size;
+	}
 
 	/**
 	 * @param core
@@ -23,7 +29,7 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	 *            The number of bytes to read, between 1 and 256
 	 */
 	public ReadMemory(HasCoreLocation core, int address, int size) {
-		super(core, CMD_READ, address, size & SIZE_MASK,
+		super(core, CMD_READ, address, validate(size),
 				efficientTransferUnit(address, size).value);
 	}
 
@@ -36,7 +42,7 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	 *            The number of bytes to read, between 1 and 256
 	 */
 	public ReadMemory(HasChipLocation chip, int address, int size) {
-		super(chip.getScampCore(), CMD_READ, address, size & SIZE_MASK,
+		super(chip.getScampCore(), CMD_READ, address, validate(size),
 				efficientTransferUnit(address, size).value);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -15,7 +15,8 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	private static int validate(int size) {
 		if (size < 1 || size > UDP_MESSAGE_MAX_SIZE) {
-			throw new IllegalArgumentException("size must be in range 1 to 256");
+			throw new IllegalArgumentException(
+					"size must be in range 1 to 256");
 		}
 		return size;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -1,6 +1,7 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_READ;
 import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTransferUnit;
 
@@ -12,9 +13,8 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
 
 /** An SCP request to read a region of memory. */
 public class ReadMemory extends SCPRequest<ReadMemory.Response> {
-	private static final int MAX_SIZE = 256;
 	private static int validate(int size) {
-		if (size < 1 || size > MAX_SIZE) {
+		if (size < 1 || size > UDP_MESSAGE_MAX_SIZE) {
 			throw new IllegalArgumentException("size must be in range 1 to 256");
 		}
 		return size;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
@@ -1,6 +1,5 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.Constants.SHORT_SIZE;
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
 /** What to move data in units of. */
@@ -22,6 +21,17 @@ enum TransferUnit {
 	}
 
 	/**
+	 * Is a value an odd number
+	 *
+	 * @param value
+	 *            The value to test
+	 * @return True exactly when the value is odd.
+	 */
+	private static boolean odd(int value) {
+		return (value & 1) == 1;
+	}
+
+	/**
 	 * What is an efficient transfer unit to use, given a starting address and a
 	 * size of data to move.
 	 *
@@ -34,11 +44,10 @@ enum TransferUnit {
 	public static TransferUnit efficientTransferUnit(int address, int size) {
 		if (address % WORD_SIZE == 0 && size % WORD_SIZE == 0) {
 			return WORD;
-		} else if (address % WORD_SIZE == SHORT_SIZE
-				|| size % WORD_SIZE == SHORT_SIZE) {
-			return HALF_WORD;
-		} else {
+		} else if (odd(address) || odd(size)) {
 			return BYTE;
+		} else {
+			return HALF_WORD;
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
@@ -21,7 +21,7 @@ enum TransferUnit {
 	}
 
 	/**
-	 * Is a value an odd number
+	 * Is a value an odd number?
 	 *
 	 * @param value
 	 *            The value to test

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import testconfig.BoardTestConfiguration;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
+import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion.Response;
 import uk.ac.manchester.spinnaker.messages.scp.ReadLink;
@@ -62,7 +63,8 @@ public class TestUDPConnection {
 	@Test
 	public void testSCPReadMemoryWithBoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
-		ReadMemory scpReq = new ReadMemory(ZERO_CHIP, 0x70000000, 256);
+		ReadMemory scpReq = new ReadMemory(
+                ZERO_CHIP, 0x70000000, UDP_MESSAGE_MAX_SIZE);
 		scpReq.scpRequestHeader.issueSequenceNumber();
 		SCPResultMessage result;
 		try (SCPConnection connection =
@@ -80,7 +82,8 @@ public class TestUDPConnection {
 		assertThrows(SocketTimeoutException.class, () -> {
 			try (SCPConnection connection =
 					new SCPConnection(boardConfig.remotehost)) {
-				ReadMemory scp = new ReadMemory(ZERO_CHIP, 0, 256);
+				ReadMemory scp = new ReadMemory(
+                        ZERO_CHIP, 0, UDP_MESSAGE_MAX_SIZE);
 				scp.scpRequestHeader.issueSequenceNumber();
 				connection.sendSCPRequest(scp);
 				connection.receiveSCPResponse(2);


### PR DESCRIPTION
This should make transfers of odd sizes and of 256 bytes work.