### PR TITLE
Improve consistency of request pipelines

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequestHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequestHeader.java
@@ -3,6 +3,7 @@ package uk.ac.manchester.spinnaker.messages.scp;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.getNextSequenceNumber;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 
 import uk.ac.manchester.spinnaker.messages.SerializableMessage;
 
@@ -36,14 +37,19 @@ public class SCPRequestHeader implements SerializableMessage {
 	 * Set the sequence number of this request to the next available number.
 	 * This can only ever be called once per request.
 	 *
+	 * @param inFlight
+	 *            What sequence numbers are current in use and shouldn't be
+	 *            used.
 	 * @return The number that was issued.
 	 */
-	public short issueSequenceNumber() {
+	public short issueSequenceNumber(Collection<Integer> inFlight) {
 		if (sequenceSet) {
 			throw new IllegalStateException(
 					"a message can only have its sequence number set once");
 		}
-		sequence = getNextSequenceNumber();
+		do {
+			sequence = getNextSequenceNumber();
+		} while (inFlight.contains((int) sequence));
 		sequenceSet = true;
 		return sequence;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
@@ -228,7 +228,8 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 			// Send the request, keeping track of how many are sent
 			Request req = new Request(request, callback);
 			if (requests.put(sequence, req) != null) {
-				throw new RuntimeException("duplicate sequence number catastrophe");
+				throw new RuntimeException(
+						"duplicate sequence number catastrophe");
 			}
 			req.send();
 		}

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -1,5 +1,6 @@
 package uk.ac.manchester.spinnaker.connections;
 
+import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
@@ -33,7 +34,7 @@ public class TestUDPConnection {
 	public void testSCPVersionWithBoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
 		GetVersion scpReq = new GetVersion(ZERO_CORE);
-		scpReq.scpRequestHeader.issueSequenceNumber();
+		scpReq.scpRequestHeader.issueSequenceNumber(emptySet());
 		SCPResultMessage result;
 		try (SCPConnection connection =
 				new SCPConnection(boardConfig.remotehost)) {
@@ -49,7 +50,7 @@ public class TestUDPConnection {
 	public void testSCPReadLinkWoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
 		ReadLink scpReq = new ReadLink(ZERO_CHIP, 0, 0x70000000, 250);
-		scpReq.scpRequestHeader.issueSequenceNumber();
+		scpReq.scpRequestHeader.issueSequenceNumber(emptySet());
 		SCPResultMessage result;
 		try (SCPConnection connection =
 				new SCPConnection(boardConfig.remotehost)) {
@@ -63,7 +64,7 @@ public class TestUDPConnection {
 	public void testSCPReadMemoryWithBoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
 		ReadMemory scpReq = new ReadMemory(ZERO_CHIP, 0x70000000, 256);
-		scpReq.scpRequestHeader.issueSequenceNumber();
+		scpReq.scpRequestHeader.issueSequenceNumber(emptySet());
 		SCPResultMessage result;
 		try (SCPConnection connection =
 				new SCPConnection(boardConfig.remotehost)) {
@@ -81,7 +82,7 @@ public class TestUDPConnection {
 			try (SCPConnection connection =
 					new SCPConnection(boardConfig.remotehost)) {
 				ReadMemory scp = new ReadMemory(ZERO_CHIP, 0, 256);
-				scp.scpRequestHeader.issueSequenceNumber();
+				scp.scpRequestHeader.issueSequenceNumber(emptySet());
 				connection.sendSCPRequest(scp);
 				connection.receiveSCPResponse(2);
 			}


### PR DESCRIPTION
Sequence numbers can wrap. That causes trouble when packet sending is fast enough. Fixing that also lets us reduce the number of internal state variables, which is itself a *GREAT* thing.