### PR TITLE
Allow memory reads to funnel straight to the database

### DIFF
--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -20,6 +20,10 @@
 			<artifactId>SpiNNaker-machine</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>uk.ac.manchester.spinnaker</groupId>
+			<artifactId>SpiNNaker-storage</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -127,6 +127,8 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SendSignal;
 import uk.ac.manchester.spinnaker.messages.scp.SetLED;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
+import uk.ac.manchester.spinnaker.storage.Storage;
+import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.transceiver.processes.ApplicationRunProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.DeallocSDRAMProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess;
@@ -1509,6 +1511,14 @@ public class Transceiver extends UDPTransceiver
 			int length) throws IOException, Exception {
 		return new ReadMemoryProcess(scpSelector, this).readMemory(core,
 				baseAddress, length);
+	}
+
+	@Override
+	public void readMemory(HasCoreLocation core, int region, int baseAddress,
+			int length, Storage storage)
+			throws IOException, Exception, StorageException {
+		new ReadMemoryProcess(scpSelector, this).readMemory(core, region,
+				baseAddress, length, storage);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -68,6 +68,8 @@ import uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition;
 import uk.ac.manchester.spinnaker.messages.model.VersionInfo;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
+import uk.ac.manchester.spinnaker.storage.Storage;
+import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess.DataType;
 import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 
@@ -2212,6 +2214,32 @@ public interface TransceiverInterface {
 	 */
 	ByteBuffer readMemory(HasCoreLocation core, int baseAddress, int length)
 			throws IOException, Exception;
+
+	/**
+	 * Read some areas of SDRAM from a core of a chip on the board.
+	 *
+	 * @param core
+	 *            The coordinates of the core where the memory is to be read
+	 *            from
+	 * @param region
+	 *            The region of the core that is being read. Used to organise
+	 *            the data in the database.
+	 * @param baseAddress
+	 *            The address in SDRAM where the region of memory to be read
+	 *            starts
+	 * @param storage
+	 *            The database to write to
+	 * @param length
+	 *            The length of the data to be read in bytes
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws Exception
+	 *             If SpiNNaker rejects a message.
+	 * @throws StorageException
+	 *             If anything goes wrong with access to the database.
+	 */
+	void readMemory(HasCoreLocation core, int region, int baseAddress, int length,
+			Storage storage) throws IOException, Exception, StorageException;
 
 	/**
 	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -2238,8 +2238,9 @@ public interface TransceiverInterface {
 	 * @throws StorageException
 	 *             If anything goes wrong with access to the database.
 	 */
-	void readMemory(HasCoreLocation core, int region, int baseAddress, int length,
-			Storage storage) throws IOException, Exception, StorageException;
+	void readMemory(HasCoreLocation core, int region, int baseAddress,
+			int length, Storage storage)
+			throws IOException, Exception, StorageException;
 
 	/**
 	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
@@ -10,12 +10,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.selectors.ConnectionSelector;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.scp.ReadLink;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
+import uk.ac.manchester.spinnaker.storage.Storage;
+import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.transceiver.RetryTracker;
 
 /** A process for reading memory on a SpiNNaker chip. */
@@ -33,6 +39,14 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 			RetryTracker retryTracker) {
 		super(connectionSelector, retryTracker);
 	}
+
+	/**
+	 * How much data do we want to hit the database with in one go? This is
+	 * applied only for database writes because the database is more efficiently
+	 * written that way; when going to a memory buffer or random access file,
+	 * there's not really any point.
+	 */
+	private static final int DATABASE_WAIT_CHUNK = 1 << 17;
 
 	private static class Accumulator {
 		private final ByteBuffer buffer;
@@ -107,6 +121,64 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 				throw exception;
 			}
 			file.seek(initOffset);
+		}
+	}
+
+	private static class DBAccumulator {
+		private final Storage storage;
+		private final HasChipLocation chip;
+		private final int region;
+		private final Map<Integer, ByteBuffer> writes;
+		private boolean done = false;
+		private StorageException exception;
+
+		DBAccumulator(Storage storage, HasChipLocation chip, int region) {
+			this.storage = storage;
+			this.chip = chip;
+			this.region = region;
+			this.writes = new LinkedHashMap<>();
+		}
+
+		synchronized int bookSlot(int offset) {
+			if (done) {
+				throw new IllegalStateException(
+						"writing to fully written buffer");
+			}
+			writes.put(offset, null);
+			return offset;
+		}
+
+		synchronized void add(int offset, ByteBuffer data) {
+			if (done) {
+				throw new IllegalStateException(
+						"writing to fully written buffer");
+			}
+			writes.put(offset, data);
+			Iterator<Entry<Integer, ByteBuffer>> entries =
+					writes.entrySet().iterator();
+			while (entries.hasNext()) {
+				Entry<Integer, ByteBuffer> ent = entries.next();
+				if (ent.getValue() == null) {
+					break;
+				}
+				try {
+					storage.appendRegionContents(chip.getScampCore(), region,
+							ent.getValue());
+				} catch (StorageException e) {
+					if (exception == null) {
+						exception = e;
+					}
+				}
+				entries.remove();
+			}
+			return;
+		}
+
+		synchronized void finish() throws StorageException {
+			done = true;
+			if (exception != null) {
+				throw exception;
+			}
 		}
 	}
 
@@ -352,5 +424,48 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			readMemory(chip, baseAddress, size, s);
 		}
+	}
+
+	/**
+	 * Read memory into a database.
+	 *
+	 * @param chip
+	 *            What chip has the memory to read from.
+	 * @param region
+	 *            What region of the chip is being read. This is used to
+	 *            organise the data within the database.
+	 * @param baseAddress
+	 *            where to read from.
+	 * @param size
+	 *            The number of bytes to read.
+	 * @param storage
+	 *            where to write the bytes
+	 * @throws IOException
+	 *             If anything goes wrong with networking or with access to the
+	 *             file.
+	 * @throws Exception
+	 *             If SpiNNaker rejects a message.
+	 * @throws StorageException
+	 *             If anything goes wrong with access to the database.
+	 */
+	public void readMemory(HasChipLocation chip, int region, int baseAddress,
+			int size, Storage storage)
+			throws IOException, Exception, StorageException {
+		DBAccumulator a = new DBAccumulator(storage, chip, region);
+		int chunk;
+		for (int offset = 0, finishPoint = 0; offset < size; offset += chunk) {
+			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
+			int thisOffset = a.bookSlot(offset);
+			sendRequest(new ReadMemory(chip, baseAddress + offset, chunk),
+					response -> a.add(thisOffset, response.data));
+			// Apply wait chunking
+			if (thisOffset > finishPoint + DATABASE_WAIT_CHUNK) {
+				finish();
+				finishPoint = thisOffset;
+			}
+		}
+		finish();
+		checkForError();
+		a.finish();
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
@@ -46,7 +46,7 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * written that way; when going to a memory buffer or random access file,
 	 * there's not really any point.
 	 */
-	private static final int DATABASE_WAIT_CHUNK = 1 << 17;
+	private static final int DATABASE_WAIT_CHUNK = 0x20000;
 
 	private static class Accumulator {
 		private final ByteBuffer buffer;


### PR DESCRIPTION
This is about allowing reads from memory to be funneled more efficiently into the database.

It's tricky because we can't (easily) write to the middle of a BLOB with the DB API we have, so we instead need to stream things in when we can. And take care with out of order messages.