### PR TITLE
Rename Process.Exception to ProcessException

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
@@ -9,8 +9,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 import uk.ac.manchester.spinnaker.utils.Slice;
 
 /**
@@ -30,12 +30,12 @@ public interface AbstractIO extends AutoCloseable {
 	 * @param slice
 	 *            A single index for a single byte of memory.
 	 * @return The slice view of the byte.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	AbstractIO get(int slice) throws IOException, Exception;
+	AbstractIO get(int slice) throws IOException, ProcessException;
 
 	/**
 	 * Get a sub-region of this memory object. The slice must be in range of the
@@ -44,12 +44,12 @@ public interface AbstractIO extends AutoCloseable {
 	 * @param slice
 	 *            A description of a contiguous slice of memory.
 	 * @return The slice view of the chunk.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	AbstractIO get(Slice slice) throws IOException, Exception;
+	AbstractIO get(Slice slice) throws IOException, ProcessException;
 
 	/** @return whether the object has been closed. */
 	boolean isClosed();
@@ -57,12 +57,12 @@ public interface AbstractIO extends AutoCloseable {
 	/**
 	 * Flush any outstanding written data.
 	 *
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	void flush() throws IOException, Exception;
+	void flush() throws IOException, ProcessException;
 
 	/**
 	 * Seek to a position within the region.
@@ -73,12 +73,13 @@ public interface AbstractIO extends AutoCloseable {
 	 *            the file region to be restricted by slice.)
 	 * @param whence
 	 *            Where the numBytes should be measured relative to.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	default void seek(int numBytes, Seek whence) throws IOException, Exception {
+	default void seek(int numBytes, Seek whence)
+			throws IOException, ProcessException {
 		switch (whence) {
 		case SET:
 			seek(numBytes);
@@ -101,23 +102,23 @@ public interface AbstractIO extends AutoCloseable {
 	 *            The absolute location within the region. (Note that this isn't
 	 *            the same concept as the address property; this still allows
 	 *            for the file region to be restricted by slice.)
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	void seek(int numBytes) throws IOException, Exception;
+	void seek(int numBytes) throws IOException, ProcessException;
 
 	/**
 	 * Return the current position within the region relative to the start.
 	 *
 	 * @return the current offset
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If something goes wrong
 	 */
-	int tell() throws IOException, Exception;
+	int tell() throws IOException, ProcessException;
 
 	/** @return the current absolute address within the region. */
 	int getAddress();
@@ -126,12 +127,12 @@ public interface AbstractIO extends AutoCloseable {
 	 * Read the rest of the data.
 	 *
 	 * @return The bytes that have been read.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the read will be beyond the end of the region
 	 */
-	default byte[] read() throws IOException, Exception {
+	default byte[] read() throws IOException, ProcessException {
 		return read(null);
 	}
 
@@ -142,12 +143,12 @@ public interface AbstractIO extends AutoCloseable {
 	 * @param numBytes
 	 *            The number of bytes to read
 	 * @return The bytes that have been read.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the read will be beyond the end of the region
 	 */
-	byte[] read(Integer numBytes) throws IOException, Exception;
+	byte[] read(Integer numBytes) throws IOException, ProcessException;
 
 	/**
 	 * Write some data to the region.
@@ -155,24 +156,24 @@ public interface AbstractIO extends AutoCloseable {
 	 * @param data
 	 *            The data to write
 	 * @return The number of bytes written
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the write will go over the end of the region
 	 */
-	int write(byte[] data) throws IOException, Exception;
+	int write(byte[] data) throws IOException, ProcessException;
 
 	/**
 	 * Fill the rest of the region with repeated data words.
 	 *
 	 * @param value
 	 *            The value to repeat
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the amount of data to fill is more than the region
 	 */
-	default void fill(int value) throws IOException, Exception {
+	default void fill(int value) throws IOException, ProcessException {
 		fill(value, null, FillProcess.DataType.WORD);
 	}
 
@@ -183,12 +184,13 @@ public interface AbstractIO extends AutoCloseable {
 	 *            The value to repeat
 	 * @param size
 	 *            Number of bytes to fill from current position
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the amount of data to fill is more than the region
 	 */
-	default void fill(int value, int size) throws IOException, Exception {
+	default void fill(int value, int size)
+			throws IOException, ProcessException {
 		fill(value, size, FillProcess.DataType.WORD);
 	}
 
@@ -199,13 +201,13 @@ public interface AbstractIO extends AutoCloseable {
 	 *            The value to repeat
 	 * @param type
 	 *            The type of the repeat value
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the amount of data to fill is more than the region
 	 */
 	default void fill(int value, FillProcess.DataType type)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		fill(value, null, type);
 	}
 
@@ -215,17 +217,17 @@ public interface AbstractIO extends AutoCloseable {
 	 * @param value
 	 *            The value to repeat
 	 * @param size
-	 *            Number of bytes to fill from current position, or
-	 *            {@code null} to fill to the end
+	 *            Number of bytes to fill from current position, or {@code null}
+	 *            to fill to the end
 	 * @param type
 	 *            The type of the repeat value
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the communications with SpiNNaker fails
 	 * @throws IOException
 	 *             If the amount of data to fill is more than the region
 	 */
 	void fill(int value, Integer size, FillProcess.DataType type)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * The various positions that a {@link #seek(int,Seek)} may be relative to.
@@ -253,7 +255,7 @@ public interface AbstractIO extends AutoCloseable {
 					return b[0];
 				} catch (EOFException e) {
 					return -1;
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -266,7 +268,7 @@ public interface AbstractIO extends AutoCloseable {
 					return b.length;
 				} catch (EOFException e) {
 					return -1;
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -280,7 +282,7 @@ public interface AbstractIO extends AutoCloseable {
 					return b.length;
 				} catch (EOFException e) {
 					return -1;
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -292,7 +294,7 @@ public interface AbstractIO extends AutoCloseable {
 					seek(max((int) n, 0), Seek.CUR);
 					int after = tell();
 					return after - before;
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -312,7 +314,7 @@ public interface AbstractIO extends AutoCloseable {
 				buffer[0] = (byte) (b & BYTE_MASK);
 				try {
 					AbstractIO.this.write(buffer);
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -321,7 +323,7 @@ public interface AbstractIO extends AutoCloseable {
 			public void write(byte[] bytes) throws IOException {
 				try {
 					AbstractIO.this.write(bytes);
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -333,7 +335,7 @@ public interface AbstractIO extends AutoCloseable {
 				arraycopy(bytes, offset, buffer, 0, length);
 				try {
 					AbstractIO.this.write(buffer);
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}
@@ -342,7 +344,7 @@ public interface AbstractIO extends AutoCloseable {
 			public void flush() throws IOException {
 				try {
 					AbstractIO.this.flush();
-				} catch (Exception e) {
+				} catch (ProcessException e) {
 					throw new IOException(e);
 				}
 			}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
@@ -17,8 +17,8 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 
 /** A file-like object for the memory of a chip. */
 final class ChipMemoryIO {
@@ -103,7 +103,7 @@ final class ChipMemoryIO {
 	}
 
 	/** Force the writing of the current write buffer. */
-	void flushWriteBuffer() throws IOException, Exception {
+	void flushWriteBuffer() throws IOException, ProcessException {
 		if (writeBuffer.position() > 0) {
 			Transceiver t = hold;
 			if (t == null) {
@@ -124,7 +124,7 @@ final class ChipMemoryIO {
 	 * @param address
 	 *            The address to set.
 	 */
-	void setCurrentAddress(int address) throws IOException, Exception {
+	void setCurrentAddress(int address) throws IOException, ProcessException {
 		flushWriteBuffer();
 		currentAddress = address;
 		writeAddress = address;
@@ -137,7 +137,7 @@ final class ChipMemoryIO {
 	 * @param numBytes
 	 *            The number of bytes to read
 	 */
-	byte[] read(int numBytes) throws IOException, Exception {
+	byte[] read(int numBytes) throws IOException, ProcessException {
 		if (numBytes == 0) {
 			return new byte[0];
 		}
@@ -160,7 +160,7 @@ final class ChipMemoryIO {
 	 * @param data
 	 *            The data to write
 	 */
-	void write(byte[] data) throws IOException, Exception {
+	void write(byte[] data) throws IOException, ProcessException {
 		int numBytes = data.length;
 
 		Transceiver t = txrx();
@@ -197,7 +197,7 @@ final class ChipMemoryIO {
 	 *            The type of the repeat value
 	 */
 	void fill(int value, int size, FillProcess.DataType type)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		Transceiver t = txrx();
 		flushWriteBuffer();
 		t.fillMemory(core, currentAddress, value, size, type);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess.DataType;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 import uk.ac.manchester.spinnaker.utils.Slice;
 
 /** A file-like object for reading and writing memory. */
@@ -51,7 +51,7 @@ public class MemoryIO implements AbstractIO {
 	}
 
 	@Override
-	public void close() throws Exception, IOException {
+	public void close() throws ProcessException, IOException {
 		synchronized (io) {
 			io.flushWriteBuffer();
 		}
@@ -107,7 +107,7 @@ public class MemoryIO implements AbstractIO {
 	}
 
 	@Override
-	public void flush() throws IOException, Exception {
+	public void flush() throws IOException, ProcessException {
 		synchronized (io) {
 			io.flushWriteBuffer();
 		}
@@ -135,7 +135,7 @@ public class MemoryIO implements AbstractIO {
 	}
 
 	@Override
-	public byte[] read(Integer numBytes) throws IOException, Exception {
+	public byte[] read(Integer numBytes) throws IOException, ProcessException {
 		int size = (numBytes != null && numBytes >= 0) ? numBytes
 				: (endAddress - currentAddress);
 		if (currentAddress + size > endAddress) {
@@ -151,7 +151,7 @@ public class MemoryIO implements AbstractIO {
 	}
 
 	@Override
-	public int write(byte[] data) throws IOException, Exception {
+	public int write(byte[] data) throws IOException, ProcessException {
 		int size = data.length;
 		if (currentAddress + size > endAddress) {
 			throw new EOFException();
@@ -166,7 +166,7 @@ public class MemoryIO implements AbstractIO {
 
 	@Override
 	public void fill(int value, Integer size, DataType type)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		int len = (size == null) ? endAddress - currentAddress : size;
 		if (currentAddress + len > endAddress) {
 			throw new EOFException();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1528,7 +1528,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void readMemory(HasCoreLocation core, int region, int baseAddress,
 			int length, Storage storage)
-			throws IOException, Exception, StorageException {
+			throws IOException, ProcessException, StorageException {
 		new ReadMemoryProcess(scpSelector, this).readMemory(core, region,
 				baseAddress, length, storage);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -129,6 +129,7 @@ import uk.ac.manchester.spinnaker.messages.scp.SetLED;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 import uk.ac.manchester.spinnaker.transceiver.processes.ApplicationRunProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.DeallocSDRAMProcess;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess.DataType;
 import uk.ac.manchester.spinnaker.transceiver.processes.GetCPUInfoProcess;
@@ -140,7 +141,6 @@ import uk.ac.manchester.spinnaker.transceiver.processes.GetVersionProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.LoadFixedRouteEntryProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.LoadMulticastRoutesProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.MallocSDRAMProcess;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 import uk.ac.manchester.spinnaker.transceiver.processes.ReadFixedRouteEntryProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.ReadIOBufProcess;
 import uk.ac.manchester.spinnaker.transceiver.processes.ReadMemoryProcess;
@@ -321,7 +321,7 @@ public class Transceiver extends UDPTransceiver
 	 *            in debugging purposes)
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable.
@@ -334,7 +334,7 @@ public class Transceiver extends UDPTransceiver
 			Integer maxCoreID, boolean autodetectBMP,
 			List<ConnectionDescriptor> scampConnections, Integer bootPortNumber,
 			Integer maxSDRAMSize)
-			throws IOException, SpinnmanException, Exception {
+			throws IOException, SpinnmanException, ProcessException {
 		if (host != null) {
 			log.info("Creating transceiver for {}", host);
 		}
@@ -412,13 +412,13 @@ public class Transceiver extends UDPTransceiver
 	 *            spinn-3 would equal 3 and so on.
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable.
 	 */
 	public Transceiver(InetAddress hostname, int version)
-			throws IOException, SpinnmanException, Exception {
+			throws IOException, SpinnmanException, ProcessException {
 		this(hostname, version, null, 0, emptyList(), emptyMap(), emptyMap(),
 				null, false, null, null, null);
 	}
@@ -430,13 +430,13 @@ public class Transceiver extends UDPTransceiver
 	 *            The SpiNNaker board version number.
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable.
 	 */
 	public Transceiver(int version)
-			throws IOException, SpinnmanException, Exception {
+			throws IOException, SpinnmanException, ProcessException {
 		this(version, null, null, null, null, null, null, null);
 	}
 
@@ -462,7 +462,7 @@ public class Transceiver extends UDPTransceiver
 	 *            If not {@code null}, the maximum SDRAM size to allow.
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable.
@@ -474,7 +474,7 @@ public class Transceiver extends UDPTransceiver
 			Integer maxCoreID,
 			Collection<ConnectionDescriptor> scampConnections,
 			Integer maxSDRAMSize)
-			throws IOException, SpinnmanException, Exception {
+			throws IOException, SpinnmanException, ProcessException {
 		this.version = version;
 		if (ignoreChips != null) {
 			this.ignoreChips.addAll(ignoreChips);
@@ -586,7 +586,7 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	private Object getSystemVariable(HasChipLocation chip,
-			SystemVariableDefinition dataItem) throws IOException, Exception {
+			SystemVariableDefinition dataItem) throws IOException, ProcessException {
 		ByteBuffer buffer =
 				readMemory(chip, SYSTEM_VARIABLE_BASE_ADDRESS + dataItem.offset,
 						dataItem.type.value);
@@ -690,7 +690,7 @@ public class Transceiver extends UDPTransceiver
 
 	/** Check that the BMP connections are actually connected to valid BMPs. */
 	private void checkBMPConnections()
-			throws IOException, SpinnmanException, Exception {
+			throws IOException, SpinnmanException, ProcessException {
 		/*
 		 * Check that the UDP BMP conn is actually connected to a BMP via the
 		 * SVER command
@@ -723,7 +723,7 @@ public class Transceiver extends UDPTransceiver
 						format("BMP connection to %s is not responding",
 								conn.getRemoteIPAddress()),
 						e);
-			} catch (Exception e) {
+			} catch (ProcessException e) {
 				log.error("Failed to speak to BMP at {}",
 						conn.getRemoteIPAddress(), e);
 				throw e;
@@ -762,7 +762,7 @@ public class Transceiver extends UDPTransceiver
 				}
 				sleep(CONNECTION_CHECK_DELAY);
 			} catch (InterruptedException | SocketTimeoutException
-					| Exception e) {
+					| ProcessException e) {
 				// do nothing
 			} catch (IOException e) {
 				break;
@@ -792,7 +792,7 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	/** Get the current machine status and store it. */
-	void updateMachine() throws IOException, Exception {
+	void updateMachine() throws IOException, ProcessException {
 		// Get the width and height of the machine
 		getMachineDimensions();
 
@@ -845,11 +845,11 @@ public class Transceiver extends UDPTransceiver
 	 *         initially given connections in the constructor
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public List<SCPConnection> discoverScampConnections()
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		/*
 		 * Currently, this only finds other UDP connections given a connection
 		 * that supports SCP - this is done via the machine
@@ -933,7 +933,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public MachineDimensions getMachineDimensions()
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		if (dimensions == null) {
 			ByteBuffer data = readMemory(DEFAULT_DESTINATION,
 					SYSTEM_VARIABLE_BASE_ADDRESS + y_size.offset, 2);
@@ -945,7 +945,7 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	@Override
-	public Machine getMachineDetails() throws IOException, Exception {
+	public Machine getMachineDetails() throws IOException, ProcessException {
 		if (machine == null) {
 			updateMachine();
 		}
@@ -956,10 +956,10 @@ public class Transceiver extends UDPTransceiver
 	 * @return the application ID tracker for this transceiver.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	public AppIdTracker getAppIdTracker() throws IOException, Exception {
+	public AppIdTracker getAppIdTracker() throws IOException, ProcessException {
 		if (appIDTracker == null) {
 			updateMachine();
 		}
@@ -985,7 +985,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public VersionInfo getScampVersion(HasChipLocation chip,
 			ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		if (connectionSelector == null) {
 			connectionSelector = scpSelector;
 		}
@@ -1054,7 +1054,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public VersionInfo ensureBoardIsReady(int numRetries,
 			Map<SystemVariableDefinition, Object> extraBootValues)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// try to get a SCAMP version once
 		log.info("Working out if machine is booted");
 		VersionInfo versionInfo;
@@ -1117,12 +1117,12 @@ public class Transceiver extends UDPTransceiver
 	 * @return version info for SCAMP on the booted system
 	 * @throws IOException
 	 *             if networking fails
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	private VersionInfo findScampAndBoot(int numAttempts,
 			Map<SystemVariableDefinition, Object> extraBootValues)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		VersionInfo versionInfo = null;
 		int triesLeft = numAttempts;
 		while (versionInfo == null && triesLeft > 0) {
@@ -1133,7 +1133,7 @@ public class Transceiver extends UDPTransceiver
 					versionInfo = null;
 					sleep(CONNECTION_CHECK_DELAY);
 				}
-			} catch (Exception e) {
+			} catch (ProcessException e) {
 				if (e.getCause() instanceof SocketTimeoutException) {
 					log.info("Attempting to boot machine");
 					bootBoard(extraBootValues);
@@ -1172,7 +1172,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@SuppressWarnings("deprecation")
 	public Iterable<CPUInfo> getCPUInformation(CoreSubsets coreSubsets)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		// Get all the cores if the subsets are not given
 		if (coreSubsets == null) {
 			if (machine == null) {
@@ -1192,7 +1192,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public Iterable<IOBuffer> getIobuf(CoreSubsets coreSubsets)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		// making the assumption that all chips have the same iobuf size.
 		if (iobufSize == null) {
 			iobufSize = (Integer) getSystemVariable(new ChipLocation(0, 0),
@@ -1206,7 +1206,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void setWatchDogTimeoutOnChip(HasChipLocation chip, int watchdog)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		// build data holder
 		ByteBuffer data = ByteBuffer.allocate(1);
 		data.put((byte) watchdog).flip();
@@ -1219,7 +1219,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void enableWatchDogTimerOnChip(HasChipLocation chip,
-			boolean watchdog) throws IOException, Exception {
+			boolean watchdog) throws IOException, ProcessException {
 		// build data holder
 		ByteBuffer data = ByteBuffer.allocate(1);
 		data.put((byte) (watchdog
@@ -1234,14 +1234,14 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public int getCoreStateCount(int appID, CPUState state)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return simpleProcess().execute(new CountState(appID, state)).count;
 	}
 
 	@Override
 	public void execute(HasChipLocation chip, Collection<Integer> processors,
 			InputStream executable, int numBytes, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against updates
 		try (ExecuteLock lock = new ExecuteLock(chip)) {
 			// Write the executable
@@ -1256,7 +1256,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public final void execute(HasChipLocation chip,
 			Collection<Integer> processors, File executable, int appID,
-			boolean wait) throws IOException, Exception, InterruptedException {
+			boolean wait) throws IOException, ProcessException, InterruptedException {
 		// Lock against updates
 		try (ExecuteLock lock = new ExecuteLock(chip)) {
 			// Write the executable
@@ -1271,7 +1271,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void execute(HasChipLocation chip, Collection<Integer> processors,
 			ByteBuffer executable, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against updates
 		try (ExecuteLock lock = new ExecuteLock(chip)) {
 			// Write the executable
@@ -1286,7 +1286,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void executeFlood(CoreSubsets coreSubsets, InputStream executable,
 			int numBytes, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against other executables
 		synchronized (chipExecuteLockCondition) {
 			while (numChipExecuteLocks > 0) {
@@ -1305,7 +1305,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void executeFlood(CoreSubsets coreSubsets, File executable,
 			int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against other executables
 		synchronized (chipExecuteLockCondition) {
 			while (numChipExecuteLocks > 0) {
@@ -1324,7 +1324,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void executeFlood(CoreSubsets coreSubsets, ByteBuffer executable,
 			int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against other executables
 		synchronized (chipExecuteLockCondition) {
 			while (numChipExecuteLocks > 0) {
@@ -1342,7 +1342,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void powerOnMachine()
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		if (bmpConnections.isEmpty()) {
 			log.warn("No BMP connections, so can't power on");
 		}
@@ -1354,7 +1354,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void powerOffMachine()
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		if (bmpConnections.isEmpty()) {
 			log.warn("No BMP connections, so can't power off");
 		}
@@ -1365,13 +1365,13 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	private <T extends BMPRequest.BMPResponse> T bmpCall(int cabinet, int frame,
-			BMPRequest<T> request) throws IOException, Exception {
+			BMPRequest<T> request) throws IOException, ProcessException {
 		return new SendSingleBMPCommandProcess<T>(bmpConnection(cabinet, frame),
 				this).execute(request);
 	}
 
 	private <T extends BMPRequest.BMPResponse> T bmpCall(int cabinet, int frame,
-			int timeout, BMPRequest<T> request) throws IOException, Exception {
+			int timeout, BMPRequest<T> request) throws IOException, ProcessException {
 		return new SendSingleBMPCommandProcess<T>(bmpConnection(cabinet, frame),
 				timeout, this).execute(request);
 	}
@@ -1379,7 +1379,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void power(PowerCommand powerCommand, Collection<Integer> boards,
 			int cabinet, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		int timeout = (int) (MS_PER_S
 				* (powerCommand == POWER_ON ? BMP_POWER_ON_TIMEOUT
 						: BMP_TIMEOUT));
@@ -1396,54 +1396,54 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void setLED(Collection<Integer> leds, LEDAction action,
 			Collection<Integer> board, int cabinet, int frame)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		bmpCall(cabinet, frame, new BMPSetLED(leds, action, board));
 	}
 
 	@Override
 	public int readFPGARegister(int fpgaNumber, int register, int cabinet,
-			int frame, int board) throws IOException, Exception {
+			int frame, int board) throws IOException, ProcessException {
 		return bmpCall(cabinet, frame,
 				new ReadFPGARegister(fpgaNumber, register, board)).fpgaRegister;
 	}
 
 	@Override
 	public void writeFPGARegister(int fpgaNumber, int register, int value,
-			int cabinet, int frame, int board) throws IOException, Exception {
+			int cabinet, int frame, int board) throws IOException, ProcessException {
 		bmpCall(cabinet, frame,
 				new WriteFPGARegister(fpgaNumber, register, value, board));
 	}
 
 	@Override
 	public ADCInfo readADCData(int board, int cabinet, int frame)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return bmpCall(cabinet, frame, new ReadADC(board)).adcInfo;
 	}
 
 	@Override
 	public VersionInfo readBMPVersion(int board, int cabinet, int frame)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return bmpCall(cabinet, frame, new GetBMPVersion(board)).versionInfo;
 	}
 
 	@Override
 	public void writeMemory(HasCoreLocation core, int baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeMemory(core, baseAddress,
 				dataStream, numBytes);
 	}
 
 	@Override
 	public void writeMemory(HasCoreLocation core, int baseAddress,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeMemory(core, baseAddress,
 				dataFile);
 	}
 
 	@Override
 	public void writeMemory(HasCoreLocation core, int baseAddress,
-			ByteBuffer data) throws IOException, Exception {
+			ByteBuffer data) throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeMemory(core, baseAddress,
 				data);
 	}
@@ -1451,28 +1451,28 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeNeighbourMemory(HasCoreLocation core, int link,
 			int baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeLink(core, link,
 				baseAddress, dataStream, numBytes);
 	}
 
 	@Override
 	public void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, File dataFile) throws IOException, Exception {
+			int baseAddress, File dataFile) throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeLink(core, link,
 				baseAddress, dataFile);
 	}
 
 	@Override
 	public void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, ByteBuffer data) throws IOException, Exception {
+			int baseAddress, ByteBuffer data) throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeLink(core, link,
 				baseAddress, data);
 	}
 
 	@Override
 	public void writeMemoryFlood(int baseAddress, InputStream dataStream,
-			int numBytes) throws IOException, Exception {
+			int numBytes) throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
@@ -1485,7 +1485,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void writeMemoryFlood(int baseAddress, File dataFile)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
@@ -1498,7 +1498,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void writeMemoryFlood(int baseAddress, ByteBuffer data)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
@@ -1510,20 +1510,20 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public ByteBuffer readMemory(HasCoreLocation core, int baseAddress,
-			int length) throws IOException, Exception {
+			int length) throws IOException, ProcessException {
 		return new ReadMemoryProcess(scpSelector, this).readMemory(core,
 				baseAddress, length);
 	}
 
 	@Override
 	public ByteBuffer readNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, int length) throws IOException, Exception {
+			int baseAddress, int length) throws IOException, ProcessException {
 		return new ReadMemoryProcess(scpSelector, this).readLink(core, link,
 				baseAddress, length);
 	}
 
 	@Override
-	public void stopApplication(int appID) throws IOException, Exception {
+	public void stopApplication(int appID) throws IOException, ProcessException {
 		if (machineOff) {
 			log.warn("You are calling a app stop on a turned off machine. "
 					+ "Please fix and try again");
@@ -1536,7 +1536,7 @@ public class Transceiver extends UDPTransceiver
 	public void waitForCoresToBeInState(CoreSubsets allCoreSubsets, int appID,
 			Set<CPUState> cpuStates, Integer timeout, int timeBetweenPolls,
 			Set<CPUState> errorStates, int countBetweenFullChecks)
-			throws IOException, Exception, InterruptedException,
+			throws IOException, ProcessException, InterruptedException,
 			SpinnmanException {
 		// check that the right number of processors are in the states
 		int processorsReady = 0;
@@ -1600,13 +1600,13 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void sendSignal(int appID, Signal signal)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		simpleProcess().execute(new SendSignal(appID, signal));
 	}
 
 	@Override
 	public void setLEDs(HasCoreLocation core, Map<Integer, LEDAction> ledStates)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		simpleProcess().execute(new SetLED(core, ledStates));
 	}
 
@@ -1616,7 +1616,7 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	@Override
-	public void setIPTag(IPTag tag) throws IOException, Exception {
+	public void setIPTag(IPTag tag) throws IOException, ProcessException {
 		// Check that the tag has a port assigned
 		if (tag.getPort() == null) {
 			throw new IllegalArgumentException(
@@ -1650,7 +1650,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void setReverseIPTag(ReverseIPTag tag)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		if (requireNonNull(tag).getPort() == SCP_SCAMP_PORT
 				|| tag.getPort() == UDP_BOOT_CONNECTION_DEFAULT_PORT) {
 			throw new IllegalArgumentException(format(
@@ -1679,7 +1679,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void clearIPTag(int tag, SCPConnection connection,
-			InetAddress boardAddress) throws IOException, Exception {
+			InetAddress boardAddress) throws IOException, ProcessException {
 		for (SCPConnection conn : getConnectionList(connection, boardAddress)) {
 			simpleProcess().execute(new IPTagClear(conn.getChip(), tag));
 		}
@@ -1687,7 +1687,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public List<Tag> getTags(SCPConnection connection)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		List<Tag> allTags = new ArrayList<>();
 		for (SCPConnection conn : getConnectionList(connection, null)) {
 			allTags.addAll(new GetTagsProcess(scpSelector, this).getTags(conn));
@@ -1697,21 +1697,21 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public int mallocSDRAM(HasChipLocation chip, int size, int appID, int tag)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return new MallocSDRAMProcess(scpSelector, this).mallocSDRAM(chip, size,
 				appID, tag);
 	}
 
 	@Override
 	public void freeSDRAM(HasChipLocation chip, int baseAddress, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		new DeallocSDRAMProcess(scpSelector, this).deallocSDRAM(chip, appID,
 				baseAddress);
 	}
 
 	@Override
 	public int freeSDRAMByAppID(HasChipLocation chip, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return new DeallocSDRAMProcess(scpSelector, this).deallocSDRAM(chip,
 				appID);
 	}
@@ -1719,28 +1719,28 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void loadMulticastRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		new LoadMulticastRoutesProcess(scpSelector, this).loadRoutes(chip,
 				routes, appID);
 	}
 
 	@Override
 	public void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute,
-			int appID) throws IOException, Exception {
+			int appID) throws IOException, ProcessException {
 		new LoadFixedRouteEntryProcess(scpSelector, this).loadFixedRoute(chip,
 				fixedRoute, appID);
 	}
 
 	@Override
 	public RoutingEntry readFixedRoute(HasChipLocation chip, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return new ReadFixedRouteEntryProcess(scpSelector, this)
 				.readFixedRoute(chip, appID);
 	}
 
 	@Override
 	public List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip,
-			Integer appID) throws IOException, Exception {
+			Integer appID) throws IOException, ProcessException {
 		int address = (int) getSystemVariable(chip, router_table_copy_address);
 		return new GetMulticastRoutesProcess(scpSelector, this).getRoutes(chip,
 				address, appID);
@@ -1748,20 +1748,20 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void clearMulticastRoutes(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		simpleProcess().execute(new RouterClear(chip));
 	}
 
 	@Override
 	public RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return new ReadRouterDiagnosticsProcess(scpSelector, this)
 				.getRouterDiagnostics(chip);
 	}
 
 	@Override
 	public void setRouterDiagnosticFilter(HasChipLocation chip, int position,
-			DiagnosticFilter diagnosticFilter) throws IOException, Exception {
+			DiagnosticFilter diagnosticFilter) throws IOException, ProcessException {
 		if (position < 0 || position > NO_ROUTER_DIAGNOSTIC_FILTERS) {
 			throw new IllegalArgumentException(
 					"router filter positions must be beween 0 and "
@@ -1785,7 +1785,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public DiagnosticFilter getRouterDiagnosticFilter(HasChipLocation chip,
-			int position) throws IOException, Exception {
+			int position) throws IOException, ProcessException {
 		if (position < 0 || position > NO_ROUTER_DIAGNOSTIC_FILTERS) {
 			throw new IllegalArgumentException(
 					"router filter positions must be beween 0 and "
@@ -1805,7 +1805,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void clearRouterDiagnosticCounters(HasChipLocation chip,
 			boolean enable, Iterable<Integer> counterIDs)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		int clearData = 0;
 		for (int counterID : requireNonNull(counterIDs)) {
 			if (counterID < 0 || counterID >= NUM_ROUTER_DIAGNOSTIC_COUNTERS) {
@@ -1824,14 +1824,14 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public List<HeapElement> getHeap(HasChipLocation chip,
-			SystemVariableDefinition heap) throws IOException, Exception {
+			SystemVariableDefinition heap) throws IOException, ProcessException {
 		return new GetHeapProcess(scpSelector, this).getBlocks(chip, heap);
 	}
 
 	@Override
 	public void fillMemory(HasChipLocation chip, int baseAddress,
 			int repeatValue, int size, DataType dataType)
-			throws Exception, IOException {
+			throws ProcessException, IOException {
 		new FillProcess(scpSelector, this).fillMemory(chip, baseAddress,
 				repeatValue, size, dataType);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -586,7 +586,8 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	private Object getSystemVariable(HasChipLocation chip,
-			SystemVariableDefinition dataItem) throws IOException, ProcessException {
+			SystemVariableDefinition dataItem)
+			throws IOException, ProcessException {
 		ByteBuffer buffer =
 				readMemory(chip, SYSTEM_VARIABLE_BASE_ADDRESS + dataItem.offset,
 						dataItem.type.value);
@@ -804,9 +805,11 @@ public class Transceiver extends UDPTransceiver
 				ignoreLinks, maxCoreID, maxSDRAMSize, this)
 						.getMachineDetails(versionInfo.core, dimensions);
 
-        // Ask the machine to check itself
-        //and if required to rebuild itself with out invalid links or chips ect.
-        machine = machine.rebuild();
+		/*
+		 * Ask the machine to check itself and if required to rebuild itself
+		 * with out invalid links or chips etc.
+		 */
+		machine = machine.rebuild();
 
 		// update the SCAMP selector with the machine
 		if (scpSelector instanceof MachineAware) {
@@ -1256,7 +1259,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public final void execute(HasChipLocation chip,
 			Collection<Integer> processors, File executable, int appID,
-			boolean wait) throws IOException, ProcessException, InterruptedException {
+			boolean wait)
+			throws IOException, ProcessException, InterruptedException {
 		// Lock against updates
 		try (ExecuteLock lock = new ExecuteLock(chip)) {
 			// Write the executable
@@ -1371,7 +1375,8 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	private <T extends BMPRequest.BMPResponse> T bmpCall(int cabinet, int frame,
-			int timeout, BMPRequest<T> request) throws IOException, ProcessException {
+			int timeout, BMPRequest<T> request)
+			throws IOException, ProcessException {
 		return new SendSingleBMPCommandProcess<T>(bmpConnection(cabinet, frame),
 				timeout, this).execute(request);
 	}
@@ -1409,7 +1414,8 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void writeFPGARegister(int fpgaNumber, int register, int value,
-			int cabinet, int frame, int board) throws IOException, ProcessException {
+			int cabinet, int frame, int board)
+			throws IOException, ProcessException {
 		bmpCall(cabinet, frame,
 				new WriteFPGARegister(fpgaNumber, register, value, board));
 	}
@@ -1458,14 +1464,16 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, File dataFile) throws IOException, ProcessException {
+			int baseAddress, File dataFile)
+			throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeLink(core, link,
 				baseAddress, dataFile);
 	}
 
 	@Override
 	public void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, ByteBuffer data) throws IOException, ProcessException {
+			int baseAddress, ByteBuffer data)
+			throws IOException, ProcessException {
 		new WriteMemoryProcess(scpSelector, this).writeLink(core, link,
 				baseAddress, data);
 	}
@@ -1523,7 +1531,8 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	@Override
-	public void stopApplication(int appID) throws IOException, ProcessException {
+	public void stopApplication(int appID)
+			throws IOException, ProcessException {
 		if (machineOff) {
 			log.warn("You are calling a app stop on a turned off machine. "
 					+ "Please fix and try again");
@@ -1761,7 +1770,8 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void setRouterDiagnosticFilter(HasChipLocation chip, int position,
-			DiagnosticFilter diagnosticFilter) throws IOException, ProcessException {
+			DiagnosticFilter diagnosticFilter)
+			throws IOException, ProcessException {
 		if (position < 0 || position > NO_ROUTER_DIAGNOSTIC_FILTERS) {
 			throw new IllegalArgumentException(
 					"router filter positions must be beween 0 and "
@@ -1824,7 +1834,8 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public List<HeapElement> getHeap(HasChipLocation chip,
-			SystemVariableDefinition heap) throws IOException, ProcessException {
+			SystemVariableDefinition heap)
+			throws IOException, ProcessException {
 		return new GetHeapProcess(scpSelector, this).getBlocks(chip, heap);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -2248,14 +2248,14 @@ public interface TransceiverInterface {
 	 *            The length of the data to be read in bytes
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If anything goes wrong with access to the database.
 	 */
 	void readMemory(HasCoreLocation core, int region, int baseAddress,
 			int length, Storage storage)
-			throws IOException, Exception, StorageException;
+			throws IOException, ProcessException, StorageException;
 
 	/**
 	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -68,8 +68,8 @@ import uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition;
 import uk.ac.manchester.spinnaker.messages.model.VersionInfo;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.processes.FillProcess.DataType;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 
 /**
  * The interface supported by the {@link Transceiver}. Emulates a lot of default
@@ -162,10 +162,11 @@ public interface TransceiverInterface {
 	 * @return The dimensions of the machine
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	MachineDimensions getMachineDimensions() throws IOException, Exception;
+	MachineDimensions getMachineDimensions()
+			throws IOException, ProcessException;
 
 	/**
 	 * Get the details of the machine made up of chips on a board and how they
@@ -174,10 +175,10 @@ public interface TransceiverInterface {
 	 * @return A machine description
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	Machine getMachineDetails() throws IOException, Exception;
+	Machine getMachineDetails() throws IOException, ProcessException;
 
 	/**
 	 * Determines if the board can be contacted.
@@ -205,10 +206,10 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default VersionInfo getScampVersion() throws IOException, Exception {
+	default VersionInfo getScampVersion() throws IOException, ProcessException {
 		return getScampVersion(DEFAULT_DESTINATION,
 				getScampConnectionSelector());
 	}
@@ -222,12 +223,12 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default VersionInfo getScampVersion(
 			ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getScampVersion(DEFAULT_DESTINATION, connectionSelector);
 	}
 
@@ -239,11 +240,11 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default VersionInfo getScampVersion(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getScampVersion(chip, getScampConnectionSelector());
 	}
 
@@ -258,12 +259,12 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	VersionInfo getScampVersion(HasChipLocation chip,
 			ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Attempt to boot the board. No check is performed to see if the board is
@@ -300,13 +301,13 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default VersionInfo ensureBoardIsReady()
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		return ensureBoardIsReady(BOARD_BOOT_RETRIES, null);
 	}
 
@@ -320,14 +321,14 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default VersionInfo ensureBoardIsReady(
 			Map<SystemVariableDefinition, Object> extraBootValues)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		return ensureBoardIsReady(BOARD_BOOT_RETRIES, extraBootValues);
 	}
 
@@ -341,13 +342,13 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default VersionInfo ensureBoardIsReady(int numRetries)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		return ensureBoardIsReady(numRetries, null);
 	}
 
@@ -363,14 +364,14 @@ public interface TransceiverInterface {
 	 * @return The version identifier
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	VersionInfo ensureBoardIsReady(int numRetries,
 			Map<SystemVariableDefinition, Object> extraBootValues)
-			throws IOException, Exception, InterruptedException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get information about the processors on the board.
@@ -378,11 +379,11 @@ public interface TransceiverInterface {
 	 * @return An iterable of the CPU information for all cores.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default Iterable<CPUInfo> getCPUInformation()
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getCPUInformation((CoreSubsets) null);
 	}
 
@@ -394,11 +395,11 @@ public interface TransceiverInterface {
 	 * @return The CPU information for the selected core
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default CPUInfo getCPUInformation(HasCoreLocation core)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		CoreSubsets coreSubsets = new CoreSubsets();
 		coreSubsets.addCore(core.asCoreLocation());
 		return getCPUInformation(coreSubsets).iterator().next();
@@ -415,11 +416,11 @@ public interface TransceiverInterface {
 	 *         cores if {@code coreSubsets} is {@code null}.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	Iterable<CPUInfo> getCPUInformation(CoreSubsets coreSubsets)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Get the address of user<sub>0</sub> for a given processor on the board.
@@ -502,10 +503,10 @@ public interface TransceiverInterface {
 	 * @return An iterable of the buffers, order undetermined.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default Iterable<IOBuffer> getIobuf() throws IOException, Exception {
+	default Iterable<IOBuffer> getIobuf() throws IOException, ProcessException {
 		return getIobuf((CoreSubsets) null);
 	}
 
@@ -517,11 +518,11 @@ public interface TransceiverInterface {
 	 * @return An IOBUF buffer
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default IOBuffer getIobuf(HasCoreLocation core)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		CoreSubsets coreSubsets = new CoreSubsets();
 		coreSubsets.addCore(core.asCoreLocation());
 		return getIobuf(coreSubsets).iterator().next();
@@ -536,11 +537,11 @@ public interface TransceiverInterface {
 	 *         {@code coreSubsets}
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	Iterable<IOBuffer> getIobuf(CoreSubsets coreSubsets)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Set the value of the watch dog timer on a specific chip.
@@ -551,11 +552,11 @@ public interface TransceiverInterface {
 	 *            value to set the timer count to
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void setWatchDogTimeoutOnChip(HasChipLocation chip, int watchdog)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Enable or disable the watch dog timer on a specific chip.
@@ -566,11 +567,11 @@ public interface TransceiverInterface {
 	 *            whether to enable (True) or disable (False) the watchdog timer
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void enableWatchDogTimerOnChip(HasChipLocation chip, boolean watchdog)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Set the value of the watch dog timer.
@@ -579,11 +580,11 @@ public interface TransceiverInterface {
 	 *            value to set the timer count to.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void setWatchDogTimeout(int watchdog)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		for (ChipLocation chip : getMachineDetails().chipCoordinates()) {
 			setWatchDogTimeoutOnChip(chip, watchdog);
 		}
@@ -597,11 +598,11 @@ public interface TransceiverInterface {
 	 *            timer
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void enableWatchDogTimer(boolean watchdog)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		for (ChipLocation chip : getMachineDetails().chipCoordinates()) {
 			enableWatchDogTimerOnChip(chip, watchdog);
 		}
@@ -617,11 +618,11 @@ public interface TransceiverInterface {
 	 * @return A count of the cores with the given status
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	int getCoreStateCount(int appID, CPUState state)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Start an executable running on a single core.
@@ -638,14 +639,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, InputStream executable,
 			int numBytes, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, numBytes, appID);
 	}
 
@@ -666,14 +667,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasChipLocation chip, Collection<Integer> processors,
 			InputStream executable, int numBytes, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(chip, processors, executable, numBytes, appID, false);
 	}
 
@@ -694,14 +695,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, InputStream executable,
 			int numBytes, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, numBytes, appID,
 				wait);
 	}
@@ -725,14 +726,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void execute(HasChipLocation chip, Collection<Integer> processors,
 			InputStream executable, int numBytes, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on a single core.
@@ -747,13 +748,13 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, File executable, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, appID, false);
 	}
 
@@ -772,14 +773,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasChipLocation chip, Collection<Integer> processors,
 			File executable, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(chip, processors, executable, appID, false);
 	}
 
@@ -798,13 +799,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, File executable, int appID,
-			boolean wait) throws IOException, Exception, InterruptedException {
+			boolean wait)
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, appID, wait);
 	}
 
@@ -825,14 +827,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void execute(HasChipLocation chip, Collection<Integer> processors,
 			File executable, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on a single core.
@@ -846,13 +848,13 @@ public interface TransceiverInterface {
 	 *            executable
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, ByteBuffer executable, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, appID, false);
 	}
 
@@ -870,14 +872,14 @@ public interface TransceiverInterface {
 	 *            executable
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasChipLocation chip, Collection<Integer> processors,
 			ByteBuffer executable, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(chip, processors, executable, appID, false);
 	}
 
@@ -895,13 +897,14 @@ public interface TransceiverInterface {
 	 *            True if the binary should enter a "wait" state on loading
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void execute(HasCoreLocation core, ByteBuffer executable, int appID,
-			boolean wait) throws IOException, Exception, InterruptedException {
+			boolean wait)
+			throws IOException, ProcessException, InterruptedException {
 		execute(core, singleton(core.getP()), executable, appID, wait);
 	}
 
@@ -921,14 +924,14 @@ public interface TransceiverInterface {
 	 *            True if the binary should enter a "wait" state on loading
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void execute(HasChipLocation chip, Collection<Integer> processors,
 			ByteBuffer executable, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on multiple places on the board. This will be
@@ -947,14 +950,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void executeFlood(CoreSubsets coreSubsets, InputStream executable,
 			int numBytes, int appID)
-			throws IOException, Exception, InterruptedException {
+			throws IOException, ProcessException, InterruptedException {
 		executeFlood(coreSubsets, executable, numBytes, appID, false);
 	}
 
@@ -977,14 +980,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void executeFlood(CoreSubsets coreSubsets, InputStream executable,
 			int numBytes, int appID, boolean wait)
-			throws IOException, Exception, InterruptedException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on multiple places on the board. This will be
@@ -1001,13 +1004,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void executeFlood(CoreSubsets coreSubsets, File executable,
-			int appID) throws IOException, Exception, InterruptedException {
+			int appID)
+			throws IOException, ProcessException, InterruptedException {
 		executeFlood(coreSubsets, executable, appID, false);
 	}
 
@@ -1028,13 +1032,14 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void executeFlood(CoreSubsets coreSubsets, File executable, int appID,
-			boolean wait) throws IOException, Exception, InterruptedException;
+			boolean wait)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on multiple places on the board. This will be
@@ -1050,13 +1055,14 @@ public interface TransceiverInterface {
 	 *            executable
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void executeFlood(CoreSubsets coreSubsets, ByteBuffer executable,
-			int appID) throws IOException, Exception, InterruptedException {
+			int appID)
+			throws IOException, ProcessException, InterruptedException {
 		executeFlood(coreSubsets, executable, appID, false);
 	}
 
@@ -1076,13 +1082,14 @@ public interface TransceiverInterface {
 	 *            True if the processors should enter a "wait" state on loading
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void executeFlood(CoreSubsets coreSubsets, ByteBuffer executable, int appID,
-			boolean wait) throws IOException, Exception, InterruptedException;
+			boolean wait)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Execute a set of binaries that make up a complete application on
@@ -1096,7 +1103,7 @@ public interface TransceiverInterface {
 	 *            The application ID to give this application
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
@@ -1104,8 +1111,8 @@ public interface TransceiverInterface {
 	 *             If some cores enter an unexpected state.
 	 */
 	default void executeApplication(ExecutableTargets executableTargets,
-			int appID) throws IOException, Exception, InterruptedException,
-			SpinnmanException {
+			int appID) throws IOException, ProcessException,
+			InterruptedException, SpinnmanException {
 		// Execute each of the binaries and get them in to a "wait" state
 		for (String binary : executableTargets.getBinaries()) {
 			executeFlood(executableTargets.getCoresForBinary(binary),
@@ -1140,12 +1147,13 @@ public interface TransceiverInterface {
 	 *
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
-	void powerOnMachine() throws InterruptedException, IOException, Exception;
+	void powerOnMachine()
+			throws InterruptedException, IOException, ProcessException;
 
 	/**
 	 * Power on a set of boards in the machine.
@@ -1157,13 +1165,13 @@ public interface TransceiverInterface {
 	 *            if the boards are not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOn(Collection<Integer> boards, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_ON, boards, 0, frame);
 	}
 
@@ -1180,13 +1188,13 @@ public interface TransceiverInterface {
 	 *            if the boards are not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOn(Collection<Integer> boards, int cabinet, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_ON, boards, cabinet, frame);
 	}
 
@@ -1197,13 +1205,13 @@ public interface TransceiverInterface {
 	 *            The board to power off (in cabinet 0, frame 0)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOn(int board)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_ON, singleton(board), 0, 0);
 	}
 
@@ -1217,13 +1225,13 @@ public interface TransceiverInterface {
 	 *            if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOn(int board, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_ON, singleton(board), 0, frame);
 	}
 
@@ -1240,13 +1248,13 @@ public interface TransceiverInterface {
 	 *            if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOn(int board, int cabinet, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_ON, singleton(board), cabinet, frame);
 	}
 
@@ -1255,12 +1263,13 @@ public interface TransceiverInterface {
 	 *
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
-	void powerOffMachine() throws InterruptedException, IOException, Exception;
+	void powerOffMachine()
+			throws InterruptedException, IOException, ProcessException;
 
 	/**
 	 * Power off a set of boards in the machine.
@@ -1272,13 +1281,13 @@ public interface TransceiverInterface {
 	 *            0 if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOff(Collection<Integer> boards, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_OFF, boards, 0, frame);
 	}
 
@@ -1295,13 +1304,13 @@ public interface TransceiverInterface {
 	 *            0 if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOff(Collection<Integer> boards, int cabinet, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_OFF, boards, cabinet, frame);
 	}
 
@@ -1312,13 +1321,13 @@ public interface TransceiverInterface {
 	 *            The board to power off (in cabinet 0, frame 0)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOff(int board)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_OFF, singleton(board), 0, 0);
 	}
 
@@ -1332,13 +1341,13 @@ public interface TransceiverInterface {
 	 *            if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOff(int board, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_OFF, singleton(board), 0, frame);
 	}
 
@@ -1355,13 +1364,13 @@ public interface TransceiverInterface {
 	 *            if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	default void powerOff(int board, int cabinet, int frame)
-			throws InterruptedException, IOException, Exception {
+			throws InterruptedException, IOException, ProcessException {
 		power(POWER_OFF, singleton(board), cabinet, frame);
 	}
 
@@ -1380,14 +1389,14 @@ public interface TransceiverInterface {
 	 *            0 if the board is not in a frame
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
 	 */
 	void power(PowerCommand powerCommand, Collection<Integer> boards,
 			int cabinet, int frame)
-			throws InterruptedException, IOException, Exception;
+			throws InterruptedException, IOException, ProcessException;
 
 	/**
 	 * Set the LED state of a board in the machine.
@@ -1405,12 +1414,12 @@ public interface TransceiverInterface {
 	 *            the frame this is targeting
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void setLED(Collection<Integer> leds, LEDAction action,
 			Collection<Integer> board, int cabinet, int frame)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Set the LED state of a board in the machine.
@@ -1427,11 +1436,11 @@ public interface TransceiverInterface {
 	 *            the frame this is targeting
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void setLED(Collection<Integer> leds, LEDAction action, int board,
-			int cabinet, int frame) throws IOException, Exception {
+			int cabinet, int frame) throws IOException, ProcessException {
 		setLED(leds, action, singleton(board), cabinet, frame);
 	}
 
@@ -1451,11 +1460,11 @@ public interface TransceiverInterface {
 	 *            the frame this is targeting
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void setLED(int led, LEDAction action, Collection<Integer> board,
-			int cabinet, int frame) throws IOException, Exception {
+			int cabinet, int frame) throws IOException, ProcessException {
 		setLED(singleton(led), action, board, cabinet, frame);
 	}
 
@@ -1474,11 +1483,11 @@ public interface TransceiverInterface {
 	 *            the frame this is targeting
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void setLED(int led, LEDAction action, int board, int cabinet,
-			int frame) throws IOException, Exception {
+			int frame) throws IOException, ProcessException {
 		setLED(singleton(led), action, singleton(board), cabinet, frame);
 	}
 
@@ -1500,11 +1509,11 @@ public interface TransceiverInterface {
 	 * @return the register data
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	int readFPGARegister(int fpgaNumber, int register, int cabinet, int frame,
-			int board) throws IOException, Exception;
+			int board) throws IOException, ProcessException;
 
 	/**
 	 * Write a register on a FPGA of a board. The meaning of setting the
@@ -1525,11 +1534,11 @@ public interface TransceiverInterface {
 	 *            which board to write the FPGA register to
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeFPGARegister(int fpgaNumber, int register, int value, int cabinet,
-			int frame, int board) throws IOException, Exception;
+			int frame, int board) throws IOException, ProcessException;
 
 	/**
 	 * Read the ADC data.
@@ -1543,11 +1552,11 @@ public interface TransceiverInterface {
 	 * @return the FPGA's ADC data object
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	ADCInfo readADCData(int board, int cabinet, int frame)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Read the BMP version.
@@ -1562,11 +1571,11 @@ public interface TransceiverInterface {
 	 * @return the SVER from the BMP
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default VersionInfo readBMPVersion(Iterable<Integer> boards, int cabinet,
-			int frame) throws IOException, Exception {
+			int frame) throws IOException, ProcessException {
 		return readBMPVersion(boards.iterator().next(), cabinet, frame);
 	}
 
@@ -1582,11 +1591,11 @@ public interface TransceiverInterface {
 	 * @return the SVER from the BMP
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	VersionInfo readBMPVersion(int board, int cabinet, int frame)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1604,12 +1613,12 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or reading from the
 	 *             input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasChipLocation chip, int baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataStream, numBytes);
 	}
 
@@ -1629,11 +1638,12 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or reading from the
 	 *             input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemory(HasCoreLocation core, int baseAddress,
-			InputStream dataStream, int numBytes) throws IOException, Exception;
+			InputStream dataStream, int numBytes)
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1649,11 +1659,11 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or reading from the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasChipLocation chip, int baseAddress,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataFile);
 	}
 
@@ -1671,11 +1681,11 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or reading from the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemory(HasCoreLocation core, int baseAddress, File dataFile)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1690,11 +1700,11 @@ public interface TransceiverInterface {
 	 *            The word that is to be written (as 4 bytes).
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasChipLocation chip, int baseAddress,
-			int dataWord) throws IOException, Exception {
+			int dataWord) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataWord);
 	}
 
@@ -1711,11 +1721,11 @@ public interface TransceiverInterface {
 	 *            The word that is to be written (as 4 bytes).
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasCoreLocation core, int baseAddress,
-			int dataWord) throws IOException, Exception {
+			int dataWord) throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeMemory(core, baseAddress, b);
@@ -1734,11 +1744,11 @@ public interface TransceiverInterface {
 	 *            The data that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasChipLocation chip, int baseAddress, byte[] data)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, wrap(data));
 	}
 
@@ -1755,11 +1765,11 @@ public interface TransceiverInterface {
 	 *            The data that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasCoreLocation core, int baseAddress, byte[] data)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		writeMemory(core, baseAddress, wrap(data));
 	}
 
@@ -1777,11 +1787,11 @@ public interface TransceiverInterface {
 	 *            <i>position</i> to the <i>limit</i>.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemory(HasChipLocation chip, int baseAddress,
-			ByteBuffer data) throws IOException, Exception {
+			ByteBuffer data) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, data);
 	}
 
@@ -1799,11 +1809,11 @@ public interface TransceiverInterface {
 	 *            <i>position</i> to the <i>limit</i>.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemory(HasCoreLocation core, int baseAddress, ByteBuffer data)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_READ SCP command.
@@ -1826,12 +1836,12 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasChipLocation chip, int link,
 			int baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataStream,
 				numBytes);
 	}
@@ -1858,11 +1868,12 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeNeighbourMemory(HasCoreLocation core, int link, int baseAddress,
-			InputStream dataStream, int numBytes) throws IOException, Exception;
+			InputStream dataStream, int numBytes)
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_READ SCP command.
@@ -1883,11 +1894,12 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasChipLocation chip, int link,
-			int baseAddress, File dataFile) throws IOException, Exception {
+			int baseAddress, File dataFile)
+			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataFile);
 	}
 
@@ -1911,11 +1923,11 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeNeighbourMemory(HasCoreLocation core, int link, int baseAddress,
-			File dataFile) throws IOException, Exception;
+			File dataFile) throws IOException, ProcessException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_READ SCP command.
@@ -1935,11 +1947,12 @@ public interface TransceiverInterface {
 	 *            The word that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasChipLocation chip, int link,
-			int baseAddress, int dataWord) throws IOException, Exception {
+			int baseAddress, int dataWord)
+			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataWord);
 	}
 
@@ -1962,11 +1975,12 @@ public interface TransceiverInterface {
 	 *            The word that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, int dataWord) throws IOException, Exception {
+			int baseAddress, int dataWord)
+			throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeNeighbourMemory(core, link, baseAddress, b);
@@ -1990,11 +2004,11 @@ public interface TransceiverInterface {
 	 *            The data that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasChipLocation chip, int link,
-			int baseAddress, byte[] data) throws IOException, Exception {
+			int baseAddress, byte[] data) throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
 
@@ -2017,11 +2031,11 @@ public interface TransceiverInterface {
 	 *            The data that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, byte[] data) throws IOException, Exception {
+			int baseAddress, byte[] data) throws IOException, ProcessException {
 		writeNeighbourMemory(core, link, baseAddress, wrap(data));
 	}
 
@@ -2044,11 +2058,12 @@ public interface TransceiverInterface {
 	 *            <i>position</i> to the <i>limit</i>.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeNeighbourMemory(HasChipLocation chip, int link,
-			int baseAddress, ByteBuffer data) throws IOException, Exception {
+			int baseAddress, ByteBuffer data)
+			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
 
@@ -2072,11 +2087,11 @@ public interface TransceiverInterface {
 	 *            <i>position</i> to the <i>limit</i>.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeNeighbourMemory(HasCoreLocation core, int link, int baseAddress,
-			ByteBuffer data) throws IOException, Exception;
+			ByteBuffer data) throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2091,11 +2106,11 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemoryFlood(int baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2108,11 +2123,11 @@ public interface TransceiverInterface {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with reading from
 	 *             the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemoryFlood(int baseAddress, File dataFile)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2124,11 +2139,11 @@ public interface TransceiverInterface {
 	 *            The word that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemoryFlood(int baseAddress, int dataWord)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeMemoryFlood(baseAddress, b);
@@ -2144,11 +2159,11 @@ public interface TransceiverInterface {
 	 *            The data that is to be written.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void writeMemoryFlood(int baseAddress, byte[] data)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		writeMemoryFlood(baseAddress, wrap(data));
 	}
 
@@ -2163,11 +2178,11 @@ public interface TransceiverInterface {
 	 *            <i>position</i> to the <i>limit</i>.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeMemoryFlood(int baseAddress, ByteBuffer data)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Read some areas of SDRAM from the board.
@@ -2184,11 +2199,11 @@ public interface TransceiverInterface {
 	 *         the data
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default ByteBuffer readMemory(HasChipLocation chip, int baseAddress,
-			int length) throws IOException, Exception {
+			int length) throws IOException, ProcessException {
 		return readMemory(chip.getScampCore(), baseAddress, length);
 	}
 
@@ -2207,11 +2222,11 @@ public interface TransceiverInterface {
 	 *         the data
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	ByteBuffer readMemory(HasCoreLocation core, int baseAddress, int length)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP
@@ -2230,11 +2245,11 @@ public interface TransceiverInterface {
 	 *         the start of the data
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default ByteBuffer readNeighbourMemory(HasChipLocation chip, int link,
-			int baseAddress, int length) throws IOException, Exception {
+			int baseAddress, int length) throws IOException, ProcessException {
 		return readNeighbourMemory(chip.getScampCore(), link, baseAddress,
 				length);
 	}
@@ -2260,11 +2275,11 @@ public interface TransceiverInterface {
 	 *         the start of the data
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	ByteBuffer readNeighbourMemory(HasCoreLocation core, int link,
-			int baseAddress, int length) throws IOException, Exception;
+			int baseAddress, int length) throws IOException, ProcessException;
 
 	/**
 	 * Sends a stop request for an application ID.
@@ -2273,10 +2288,10 @@ public interface TransceiverInterface {
 	 *            The ID of the application to send to
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void stopApplication(int appID) throws IOException, Exception;
+	void stopApplication(int appID) throws IOException, ProcessException;
 
 	/**
 	 * Waits for the specified cores running the given application to be in some
@@ -2291,7 +2306,7 @@ public interface TransceiverInterface {
 	 *            is when each application is in one of these states
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
@@ -2299,7 +2314,7 @@ public interface TransceiverInterface {
 	 *             If some cores enter an error state.
 	 */
 	default void waitForCoresToBeInState(CoreSubsets allCoreSubsets, int appID,
-			Set<CPUState> cpuStates) throws IOException, Exception,
+			Set<CPUState> cpuStates) throws IOException, ProcessException,
 			InterruptedException, SpinnmanException {
 		waitForCoresToBeInState(allCoreSubsets, appID, cpuStates,
 				TIMEOUT_DISABLED, DEFAULT_POLL_INTERVAL, DEFAULT_ERROR_STATES,
@@ -2331,7 +2346,7 @@ public interface TransceiverInterface {
 	 *            using the full CPU state check
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
@@ -2341,7 +2356,7 @@ public interface TransceiverInterface {
 	void waitForCoresToBeInState(CoreSubsets allCoreSubsets, int appID,
 			Set<CPUState> cpuStates, Integer timeout, int timeBetweenPolls,
 			Set<CPUState> errorStates, int countsBetweenFullCheck)
-			throws IOException, Exception, InterruptedException,
+			throws IOException, ProcessException, InterruptedException,
 			SpinnmanException;
 
 	/**
@@ -2354,11 +2369,11 @@ public interface TransceiverInterface {
 	 * @return Core subsets object containing cores in the given state
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default CoreSubsets getCoresInState(CoreSubsets allCoreSubsets,
-			CPUState state) throws IOException, Exception {
+			CPUState state) throws IOException, ProcessException {
 		return getCoresInState(allCoreSubsets, singleton(state));
 	}
 
@@ -2372,11 +2387,11 @@ public interface TransceiverInterface {
 	 * @return Core subsets object containing cores in the given states
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default CoreSubsets getCoresInState(CoreSubsets allCoreSubsets,
-			Set<CPUState> states) throws IOException, Exception {
+			Set<CPUState> states) throws IOException, ProcessException {
 		Iterable<CPUInfo> coreInfos = getCPUInformation(allCoreSubsets);
 		CoreSubsets coresInState = new CoreSubsets();
 		for (CPUInfo coreInfo : coreInfos) {
@@ -2397,12 +2412,12 @@ public interface TransceiverInterface {
 	 * @return Core subsets object containing cores not in the given state
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default Map<CoreLocation, CPUInfo> getCoresNotInState(
 			CoreSubsets allCoreSubsets, CPUState state)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getCoresNotInState(allCoreSubsets, singleton(state));
 	}
 
@@ -2416,12 +2431,12 @@ public interface TransceiverInterface {
 	 * @return Core subsets object containing cores not in the given states
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default Map<CoreLocation, CPUInfo> getCoresNotInState(
 			CoreSubsets allCoreSubsets, Set<CPUState> states)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		Iterable<CPUInfo> coreInfos = getCPUInformation(allCoreSubsets);
 		Map<CoreLocation, CPUInfo> coresNotInState = new TreeMap<>();
 		for (CPUInfo coreInfo : coreInfos) {
@@ -2441,10 +2456,11 @@ public interface TransceiverInterface {
 	 *            The signal to send
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void sendSignal(int appID, Signal signal) throws IOException, Exception;
+	void sendSignal(int appID, Signal signal)
+			throws IOException, ProcessException;
 
 	/**
 	 * Set LED states.
@@ -2456,11 +2472,12 @@ public interface TransceiverInterface {
 	 *            inverted.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void setLEDs(HasChipLocation chip,
-			Map<Integer, LEDAction> ledStates) throws IOException, Exception {
+			Map<Integer, LEDAction> ledStates)
+			throws IOException, ProcessException {
 		setLEDs(chip.getScampCore(), ledStates);
 	}
 
@@ -2474,19 +2491,19 @@ public interface TransceiverInterface {
 	 *            inverted.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void setLEDs(HasCoreLocation core, Map<Integer, LEDAction> ledStates)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Find a connection that matches the given board IP address.
 	 *
 	 * @param boardAddress
 	 *            The IP address of the Ethernet connection on the board
-	 * @return A connection for the given IP address, or {@code null} if no
-	 *         such connection exists
+	 * @return A connection for the given IP address, or {@code null} if no such
+	 *         connection exists
 	 */
 	SCPConnection locateSpinnakerConnection(InetAddress boardAddress);
 
@@ -2494,15 +2511,14 @@ public interface TransceiverInterface {
 	 * Set up an IP tag.
 	 *
 	 * @param tag
-	 *            The tag to set up; note its board address can be
-	 *            {@code null}, in which case, the tag will be assigned to all
-	 *            boards
+	 *            The tag to set up; note its board address can be {@code null},
+	 *            in which case, the tag will be assigned to all boards
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void setIPTag(IPTag tag) throws IOException, Exception;
+	void setIPTag(IPTag tag) throws IOException, ProcessException;
 
 	/**
 	 * Set up a reverse IP tag.
@@ -2513,10 +2529,10 @@ public interface TransceiverInterface {
 	 *            boards
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void setReverseIPTag(ReverseIPTag tag) throws IOException, Exception;
+	void setReverseIPTag(ReverseIPTag tag) throws IOException, ProcessException;
 
 	/**
 	 * Clear the setting of an IP tag.
@@ -2525,10 +2541,10 @@ public interface TransceiverInterface {
 	 *            The tag
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void clearIPTag(Tag tag) throws IOException, Exception {
+	default void clearIPTag(Tag tag) throws IOException, ProcessException {
 		clearIPTag(tag.getTag(), null, tag.getBoardAddress());
 	}
 
@@ -2539,10 +2555,10 @@ public interface TransceiverInterface {
 	 *            The tag ID
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void clearIPTag(int tag) throws IOException, Exception {
+	default void clearIPTag(int tag) throws IOException, ProcessException {
 		clearIPTag(tag, null, null);
 	}
 
@@ -2557,11 +2573,11 @@ public interface TransceiverInterface {
 	 *            tag
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearIPTag(int tag, SCPConnection connection)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		clearIPTag(tag, requireNonNull(connection), null);
 	}
 
@@ -2576,11 +2592,11 @@ public interface TransceiverInterface {
 	 *            tag
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearIPTag(Tag tag, SCPConnection connection)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		clearIPTag(tag.getTag(), requireNonNull(connection),
 				tag.getBoardAddress());
 	}
@@ -2594,11 +2610,11 @@ public interface TransceiverInterface {
 	 *            Board address where the tag should be cleared.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearIPTag(int tag, InetAddress boardAddress)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		clearIPTag(tag, null, requireNonNull(boardAddress));
 	}
 
@@ -2617,11 +2633,11 @@ public interface TransceiverInterface {
 	 *            clear the tag
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void clearIPTag(int tag, SCPConnection connection, InetAddress boardAddress)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Get the current set of tags that have been set on the board using all
@@ -2630,10 +2646,10 @@ public interface TransceiverInterface {
 	 * @return An iterable of tags
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default List<Tag> getTags() throws IOException, Exception {
+	default List<Tag> getTags() throws IOException, ProcessException {
 		return getTags(null);
 	}
 
@@ -2645,10 +2661,11 @@ public interface TransceiverInterface {
 	 * @return An iterable of tags
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	List<Tag> getTags(SCPConnection connection) throws IOException, Exception;
+	List<Tag> getTags(SCPConnection connection)
+			throws IOException, ProcessException;
 
 	/**
 	 * Allocates a chunk of SDRAM on a chip on the machine.
@@ -2660,11 +2677,11 @@ public interface TransceiverInterface {
 	 * @return the base address of the allocated memory
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default int mallocSDRAM(HasChipLocation chip, int size)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return mallocSDRAM(chip, size, 0, 0);
 	}
 
@@ -2680,11 +2697,11 @@ public interface TransceiverInterface {
 	 * @return the base address of the allocated memory
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default int mallocSDRAM(HasChipLocation chip, int size, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return mallocSDRAM(chip, size, appID, 0);
 	}
 
@@ -2704,11 +2721,11 @@ public interface TransceiverInterface {
 	 * @return the base address of the allocated memory
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	int mallocSDRAM(HasChipLocation chip, int size, int appID, int tag)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Free allocated SDRAM.
@@ -2721,11 +2738,11 @@ public interface TransceiverInterface {
 	 *            The app ID of the allocated memory
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void freeSDRAM(HasChipLocation chip, int baseAddress, int appID)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Free all SDRAM allocated to a given application ID.
@@ -2737,11 +2754,11 @@ public interface TransceiverInterface {
 	 * @return The number of blocks freed
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	int freeSDRAMByAppID(HasChipLocation chip, int appID)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Load a set of multicast routes on to a chip associated with the default
@@ -2753,12 +2770,12 @@ public interface TransceiverInterface {
 	 *            An iterable of multicast routes to load
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void loadMulticastRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		loadMulticastRoutes(chip, routes, 0);
 	}
 
@@ -2773,12 +2790,12 @@ public interface TransceiverInterface {
 	 *            The ID of the application with which to associate the routes.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void loadMulticastRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes, int appID)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Loads a fixed route routing table entry onto a chip's router.
@@ -2789,11 +2806,11 @@ public interface TransceiverInterface {
 	 *            the route for the fixed route entry on this chip
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		loadFixedRoute(chip, fixedRoute, 0);
 	}
 
@@ -2808,11 +2825,11 @@ public interface TransceiverInterface {
 	 *            The ID of the application with which to associate the route.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute,
-			int appID) throws IOException, Exception;
+			int appID) throws IOException, ProcessException;
 
 	/**
 	 * Reads a fixed route routing table entry from a chip's router.
@@ -2822,11 +2839,11 @@ public interface TransceiverInterface {
 	 * @return the route as a fixed route entry
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default RoutingEntry readFixedRoute(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return readFixedRoute(chip, 0);
 	}
 
@@ -2840,11 +2857,11 @@ public interface TransceiverInterface {
 	 * @return the route as a fixed route entry
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	RoutingEntry readFixedRoute(HasChipLocation chip, int appID)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Get the current multicast routes set up on a chip.
@@ -2854,11 +2871,11 @@ public interface TransceiverInterface {
 	 * @return An iterable of multicast routes
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getMulticastRoutes(chip, null);
 	}
 
@@ -2872,11 +2889,11 @@ public interface TransceiverInterface {
 	 * @return An iterable of multicast routes
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip,
-			int appID) throws IOException, Exception {
+			int appID) throws IOException, ProcessException {
 		return getMulticastRoutes(chip, appID);
 	}
 
@@ -2890,11 +2907,11 @@ public interface TransceiverInterface {
 	 * @return An iterable of multicast routes
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip,
-			Integer appID) throws IOException, Exception;
+			Integer appID) throws IOException, ProcessException;
 
 	/**
 	 * Remove all the multicast routes on a chip.
@@ -2903,11 +2920,11 @@ public interface TransceiverInterface {
 	 *            The coordinates of the chip on which to clear the routes
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void clearMulticastRoutes(HasChipLocation chip)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Get router diagnostic information from a chip.
@@ -2917,11 +2934,11 @@ public interface TransceiverInterface {
 	 * @return The router diagnostic information
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
-			throws IOException, Exception;
+			throws IOException, ProcessException;
 
 	/**
 	 * Sets a router diagnostic filter in a router.
@@ -2937,11 +2954,12 @@ public interface TransceiverInterface {
 	 *            the diagnostic filter being set in the position.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void setRouterDiagnosticFilter(HasChipLocation chip, int position,
-			DiagnosticFilter diagnosticFilter) throws IOException, Exception;
+			DiagnosticFilter diagnosticFilter)
+			throws IOException, ProcessException;
 
 	/**
 	 * Gets a router diagnostic filter from a router.
@@ -2955,11 +2973,11 @@ public interface TransceiverInterface {
 	 * @return The diagnostic filter read
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	DiagnosticFilter getRouterDiagnosticFilter(HasChipLocation chip,
-			int position) throws IOException, Exception;
+			int position) throws IOException, ProcessException;
 
 	/**
 	 * Clear router diagnostic information on a chip. Resets and enables all
@@ -2969,11 +2987,11 @@ public interface TransceiverInterface {
 	 *            The coordinates of the chip
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearRouterDiagnosticCounters(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		clearRouterDiagnosticCounters(chip, false,
 				range(0, NO_ROUTER_DIAGNOSTIC_FILTERS).boxed()
 						.collect(toList()));
@@ -2989,11 +3007,11 @@ public interface TransceiverInterface {
 	 *            True (default) if the counters should be enabled
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearRouterDiagnosticCounters(HasChipLocation chip,
-			boolean enable) throws IOException, Exception {
+			boolean enable) throws IOException, ProcessException {
 		clearRouterDiagnosticCounters(chip, enable,
 				range(0, NO_ROUTER_DIAGNOSTIC_FILTERS).boxed()
 						.collect(toList()));
@@ -3010,11 +3028,11 @@ public interface TransceiverInterface {
 	 *            between 0 and 15
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void clearRouterDiagnosticCounters(HasChipLocation chip,
-			Iterable<Integer> counterIDs) throws IOException, Exception {
+			Iterable<Integer> counterIDs) throws IOException, ProcessException {
 		clearRouterDiagnosticCounters(chip, false, counterIDs);
 	}
 
@@ -3030,11 +3048,11 @@ public interface TransceiverInterface {
 	 *            each must be between 0 and 15
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void clearRouterDiagnosticCounters(HasChipLocation chip, boolean enable,
-			Iterable<Integer> counterIDs) throws IOException, Exception;
+			Iterable<Integer> counterIDs) throws IOException, ProcessException;
 
 	/**
 	 * Get the contents of the SDRAM heap on a given chip.
@@ -3044,11 +3062,11 @@ public interface TransceiverInterface {
 	 * @return the list of chunks in the heap
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default List<HeapElement> getHeap(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return getHeap(chip, sdram_heap_address);
 	}
 
@@ -3062,11 +3080,11 @@ public interface TransceiverInterface {
 	 * @return the list of chunks in the heap
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	List<HeapElement> getHeap(HasChipLocation chip,
-			SystemVariableDefinition heap) throws IOException, Exception;
+			SystemVariableDefinition heap) throws IOException, ProcessException;
 
 	/**
 	 * Fill some memory with repeated data.
@@ -3083,11 +3101,11 @@ public interface TransceiverInterface {
 	 *            be divisible by 4
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	default void fillMemory(HasChipLocation chip, int baseAddress,
-			int repeatValue, int size) throws Exception, IOException {
+			int repeatValue, int size) throws ProcessException, IOException {
 		fillMemory(chip, baseAddress, repeatValue, size, WORD);
 	}
 
@@ -3108,9 +3126,9 @@ public interface TransceiverInterface {
 	 *            The type of data to fill.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	void fillMemory(HasChipLocation chip, int baseAddress, int repeatValue,
-			int size, DataType dataType) throws Exception, IOException;
+			int size, DataType dataType) throws ProcessException, IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
@@ -68,11 +68,11 @@ public class ApplicationRunProcess
 	 *            before returning.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void run(int appID, CoreSubsets coreSubsets, boolean wait)
-			throws Exception, IOException {
+			throws ProcessException, IOException {
 		for (ChipLocation chip : coreSubsets.getChips()) {
 			sendRequest(new ApplicationRun(appID, chip,
 					coreSubsets.pByChip(chip), wait));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/DeallocSDRAMProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/DeallocSDRAMProcess.java
@@ -34,11 +34,11 @@ public class DeallocSDRAMProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return the number of blocks freed
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public int deallocSDRAM(HasChipLocation chip, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(new SDRAMDeAlloc(chip, appID)).numFreedBlocks;
 	}
 
@@ -54,11 +54,11 @@ public class DeallocSDRAMProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            deallocated
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public void deallocSDRAM(HasChipLocation chip, int appID, int baseAddress)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		synchronousCall(new SDRAMDeAlloc(chip, appID, baseAddress));
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/FillProcess.java
@@ -79,11 +79,11 @@ public class FillProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            The type of data to fill with.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void fillMemory(HasChipLocation chip, int baseAddress, int data,
-			int size, DataType dataType) throws Exception, IOException {
+			int size, DataType dataType) throws ProcessException, IOException {
 		// Don't do anything if there is nothing to do!
 		if (size == 0) {
 			return;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetCPUInfoProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetCPUInfoProcess.java
@@ -43,11 +43,11 @@ public class GetCPUInfoProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return The CPU information, in undetermined order.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public Collection<CPUInfo> getCPUInfo(CoreSubsets coreSubsets)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		List<CPUInfo> cpuInfo = new ArrayList<>();
 		for (CoreLocation core : coreSubsets) {
 			sendRequest(

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetHeapProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetHeapProcess.java
@@ -46,11 +46,12 @@ public class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return A list of block descriptors, in block chain order.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public List<HeapElement> getBlocks(HasChipLocation chip,
-			SystemVariableDefinition heap) throws IOException, Exception {
+			SystemVariableDefinition heap)
+			throws IOException, ProcessException {
 		int heapBase = readFromAddress(chip,
 				SYSTEM_VARIABLE_BASE_ADDRESS + heap.offset, heap.type.value)
 						.get();
@@ -76,7 +77,7 @@ public class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 	}
 
 	private IntBuffer readFromAddress(HasChipLocation chip, int address,
-			int size) throws IOException, Exception {
+			int size) throws IOException, ProcessException {
 		return synchronousCall(new ReadMemory(chip, address, size)).data
 				.asIntBuffer();
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
@@ -115,11 +115,11 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return The machine description.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public Machine getMachineDetails(HasChipLocation bootChip,
-			MachineDimensions size) throws IOException, Exception {
+			MachineDimensions size) throws IOException, ProcessException {
 		// Get the P2P table; 8 entries are packed into each 32-bit word
 		List<ByteBuffer> p2pColumnData = new ArrayList<>();
 		for (int column = 0; column < size.width; column++) {
@@ -129,8 +129,8 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 									+ getColumnOffset(column),
 							getNumColumnBytes(size.height)),
 					response -> p2pColumnData.add(response.data));
-            // TODO work out why mutiple calls is a problem
-    		finish();
+			// TODO work out why mutiple calls is a problem
+			finish();
 		}
 		checkForError();
 		P2PTable p2pTable = new P2PTable(size, p2pColumnData);
@@ -143,7 +143,7 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 		finish();
 		try {
 			checkForError();
-		} catch (Exception ignored) {
+		} catch (ProcessException ignored) {
 			/*
 			 * Ignore errors so far, as any error here just means that a chip is
 			 * down that wasn't marked as down

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMulticastRoutesProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMulticastRoutesProcess.java
@@ -58,11 +58,12 @@ public class GetMulticastRoutesProcess
 	 * @return The list of routes.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public List<MulticastRoutingEntry> getRoutes(HasChipLocation chip,
-			int baseAddress, Integer appID) throws IOException, Exception {
+			int baseAddress, Integer appID)
+			throws IOException, ProcessException {
 		Map<Integer, MulticastRoutingEntry> routes = new TreeMap<>();
 		for (int i = 0; i < NUM_READS; i++) {
 			int offset = i * ENTRIES_PER_READ;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetTagsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetTagsProcess.java
@@ -43,11 +43,11 @@ public class GetTagsProcess extends MultiConnectionProcess<SCPConnection> {
 	 *         absent.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public List<Tag> getTags(SCPConnection connection)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		Response tagInfo =
 				synchronousCall(new IPTagGetInfo(connection.getChip()));
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetVersionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetVersionProcess.java
@@ -34,11 +34,11 @@ public class GetVersionProcess extends SingleConnectionProcess<SCPConnection> {
 	 * @return The version description.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public VersionInfo getVersion(HasCoreLocation core)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(new GetVersion(core)).versionInfo;
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadFixedRouteEntryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadFixedRouteEntryProcess.java
@@ -36,11 +36,11 @@ public class LoadFixedRouteEntryProcess
 	 *            the fixed route entry
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		loadFixedRoute(chip, fixedRoute, 0);
 	}
 
@@ -55,11 +55,11 @@ public class LoadFixedRouteEntryProcess
 	 *            The ID of the application with which to associate the routes.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute,
-			int appID) throws IOException, Exception {
+			int appID) throws IOException, ProcessException {
 		int entry = fixedRoute.encode();
 		synchronousCall(new FixedRouteInitialise(chip, entry, appID));
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadMulticastRoutesProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadMulticastRoutesProcess.java
@@ -66,12 +66,12 @@ public class LoadMulticastRoutesProcess
 	 *            The application ID associated with the routes.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void loadRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		/*
 		 * Create the routing data. 16 bytes per entry plus one for the end
 		 * entry

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MallocSDRAMProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MallocSDRAMProcess.java
@@ -36,11 +36,11 @@ public class MallocSDRAMProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return Where the start of the allocated memory is.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public int mallocSDRAM(HasChipLocation chip, int size, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(new SDRAMAlloc(chip, appID, size)).baseAddress;
 	}
 
@@ -60,11 +60,11 @@ public class MallocSDRAMProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return Where the start of the allocated memory is.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public int mallocSDRAM(HasChipLocation chip, int size, int appID, int tag)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(
 				new SDRAMAlloc(chip, appID, size, tag)).baseAddress;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ProcessException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ProcessException.java
@@ -1,0 +1,28 @@
+package uk.ac.manchester.spinnaker.transceiver.processes;
+
+import static java.lang.String.format;
+
+import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+
+/**
+ * Encapsulates exceptions from processes which communicate with some core/chip.
+ */
+public class ProcessException extends Exception {
+	private static final long serialVersionUID = 7759365416594564702L;
+	private static final String S = "     "; // five spaces
+
+	/**
+	 * Create an exception.
+	 *
+	 * @param core
+	 *            What core were we talking to.
+	 * @param cause
+	 *            What exception caused problems.
+	 */
+	public ProcessException(HasCoreLocation core, Throwable cause) {
+		super(format("\n" + S + "Received exception class: %s\n" + S
+				+ "With message: %s\n" + S + "When sending to %d:%d:%d\n",
+				cause.getClass().getName(), cause.getMessage(), core.getX(),
+				core.getY(), core.getP()), cause);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadFixedRouteEntryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadFixedRouteEntryProcess.java
@@ -34,11 +34,11 @@ public class ReadFixedRouteEntryProcess
 	 * @return The route.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public RoutingEntry readFixedRoute(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return readFixedRoute(chip, 0);
 	}
 
@@ -52,11 +52,11 @@ public class ReadFixedRouteEntryProcess
 	 * @return The route.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
 	 */
 	public RoutingEntry readFixedRoute(HasChipLocation chip, int appID)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(new FixedRouteRead(chip, appID)).getRoute();
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadIOBufProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadIOBufProcess.java
@@ -67,11 +67,11 @@ public class ReadIOBufProcess extends MultiConnectionProcess<SCPConnection> {
 	 *         whatever order they are produced in.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public Iterable<IOBuffer> readIOBuf(int size, CoreSubsets cores)
-			throws Exception, IOException {
+			throws ProcessException, IOException {
 		// Get the IOBuf address for each core
 		for (CoreLocation core : cores) {
 			sendRequest(new ReadMemory(core.getScampCore(),

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
@@ -444,14 +444,14 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with access to the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If anything goes wrong with access to the database.
 	 */
 	public void readMemory(HasChipLocation chip, int region, int baseAddress,
 			int size, Storage storage)
-			throws IOException, Exception, StorageException {
+			throws IOException, ProcessException, StorageException {
 		DBAccumulator a = new DBAccumulator(storage, chip, region);
 		int chunk;
 		for (int offset = 0, finishPoint = 0; offset < size; offset += chunk) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
@@ -124,11 +124,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            determines how much memory to read.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readLink(HasChipLocation chip, int linkID, int baseAddress,
-			ByteBuffer receivingBuffer) throws IOException, Exception {
+			ByteBuffer receivingBuffer) throws IOException, ProcessException {
 		int size = receivingBuffer.remaining();
 		Accumulator a = new Accumulator(receivingBuffer);
 		int chunk;
@@ -155,11 +155,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            determines how much memory to read.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readMemory(HasChipLocation chip, int baseAddress,
-			ByteBuffer receivingBuffer) throws IOException, Exception {
+			ByteBuffer receivingBuffer) throws IOException, ProcessException {
 		int size = receivingBuffer.remaining();
 		Accumulator a = new Accumulator(receivingBuffer);
 		int chunk;
@@ -188,11 +188,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return the filled buffer
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public ByteBuffer readLink(HasChipLocation chip, int linkID,
-			int baseAddress, int size) throws IOException, Exception {
+			int baseAddress, int size) throws IOException, ProcessException {
 		Accumulator a = new Accumulator(size);
 		int chunk;
 		for (int offset = 0; offset < size; offset += chunk) {
@@ -218,11 +218,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @return the filled buffer
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public ByteBuffer readMemory(HasChipLocation chip, int baseAddress,
-			int size) throws IOException, Exception {
+			int size) throws IOException, ProcessException {
 		Accumulator a = new Accumulator(size);
 		int chunk;
 		for (int offset = 0; offset < size; offset += chunk) {
@@ -253,11 +253,12 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with access to the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readLink(HasChipLocation chip, int linkID, int baseAddress,
-			int size, RandomAccessFile dataFile) throws IOException, Exception {
+			int size, RandomAccessFile dataFile)
+			throws IOException, ProcessException {
 		FileAccumulator a = new FileAccumulator(dataFile);
 		int chunk;
 		for (int offset = 0; offset < size; offset += chunk) {
@@ -286,11 +287,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with access to the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readMemory(HasChipLocation chip, int baseAddress, int size,
-			RandomAccessFile dataFile) throws IOException, Exception {
+			RandomAccessFile dataFile) throws IOException, ProcessException {
 		FileAccumulator a = new FileAccumulator(dataFile);
 		int chunk;
 		for (int offset = 0; offset < size; offset += chunk) {
@@ -320,11 +321,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with access to the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readLink(HasChipLocation chip, int linkID, int baseAddress,
-			int size, File dataFile) throws IOException, Exception {
+			int size, File dataFile) throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			readLink(chip, linkID, baseAddress, size, s);
 		}
@@ -344,11 +345,11 @@ public class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IOException
 	 *             If anything goes wrong with networking or with access to the
 	 *             file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void readMemory(HasChipLocation chip, int baseAddress, int size,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			readMemory(chip, baseAddress, size, s);
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadRouterDiagnosticsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadRouterDiagnosticsProcess.java
@@ -41,11 +41,11 @@ public class ReadRouterDiagnosticsProcess
 	 * @return The diagnostics from the chip's router.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		ValueHolder<Integer> cr = new ValueHolder<>();
 		ValueHolder<Integer> es = new ValueHolder<>();
 		int[] reg = new int[NUM_REGISTERS];

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
@@ -28,7 +28,6 @@ import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequestHeader;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 import uk.ac.manchester.spinnaker.transceiver.RetryTracker;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
 import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 /**
@@ -101,10 +100,11 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 	 * @return The successful response to the request
 	 * @throws IOException
 	 *             If the communications fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If the other side responds with a failure code
 	 */
-	public R execute(BMPRequest<R> request) throws IOException, Exception {
+	public R execute(BMPRequest<R> request)
+			throws IOException, ProcessException {
 		ValueHolder<R> holder = new ValueHolder<>();
 		/*
 		 * If no pipeline built yet, build one on the connection selected for
@@ -115,7 +115,7 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 		requestPipeline.sendRequest(request, holder::setValue);
 		requestPipeline.finish();
 		if (exception != null) {
-			throw new Exception(errorRequest.sdpHeader.getDestination(),
+			throw new ProcessException(errorRequest.sdpHeader.getDestination(),
 					exception);
 		}
 		return holder.getValue();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
@@ -60,11 +60,11 @@ public class SendSingleSCPCommandProcess
 	 * @return The response to the request
 	 * @throws IOException
 	 *             If communications fail.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SCAMP on SpiNNaker reports a failure.
 	 */
 	public <T extends SCPResponse> T execute(SCPRequest<T> request)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return synchronousCall(request);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryFloodProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryFloodProcess.java
@@ -77,11 +77,11 @@ public class WriteMemoryFloodProcess
 	 *            <i>limit</i> (exclusive)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(byte nearestNeighbourID, int baseAddress,
-			ByteBuffer data) throws IOException, Exception {
+			ByteBuffer data) throws IOException, ProcessException {
 		data = data.asReadOnlyBuffer();
 		int numBytes = data.remaining();
 		synchronousCall(
@@ -121,12 +121,12 @@ public class WriteMemoryFloodProcess
 	 *            problems.
 	 * @throws IOException
 	 *             If anything goes wrong with networking or the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(byte nearestNeighbourID, int baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		synchronousCall(
 				new FloodFillStart(nearestNeighbourID, numBlocks(numBytes)));
 
@@ -162,11 +162,11 @@ public class WriteMemoryFloodProcess
 	 *            The data in a file, which will be fully transferred.
 	 * @throws IOException
 	 *             If anything goes wrong with networking or access to the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(byte nearestNeighbourID, int baseAddress,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		try (InputStream s =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
 			writeMemory(nearestNeighbourID, baseAddress, s,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
@@ -98,11 +98,11 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            (exclusive).
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeLink(HasCoreLocation core, int link, int baseAddress,
-			ByteBuffer data) throws IOException, Exception {
+			ByteBuffer data) throws IOException, ProcessException {
 		writeMemory(baseAddress, data,
 				(addr, bytes) -> new WriteLink(core, link, addr, bytes));
 	}
@@ -123,11 +123,12 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            How many bytes should be copied from the stream?
 	 * @throws IOException
 	 *             If anything goes wrong with networking or the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeLink(HasCoreLocation core, int link, int baseAddress,
-			InputStream data, int bytesToWrite) throws IOException, Exception {
+			InputStream data, int bytesToWrite)
+			throws IOException, ProcessException {
 		writeMemory(baseAddress, data, bytesToWrite,
 				(addr, bytes) -> new WriteLink(core, link, addr, bytes));
 	}
@@ -147,11 +148,11 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            transferred.
 	 * @throws IOException
 	 *             If anything goes wrong with networking or access to the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeLink(HasCoreLocation core, int link, int baseAddress,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		try (InputStream data =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
 			writeMemory(baseAddress, data, (int) dataFile.length(),
@@ -173,11 +174,11 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            (exclusive).
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(HasCoreLocation core, int baseAddress,
-			ByteBuffer data) throws IOException, Exception {
+			ByteBuffer data) throws IOException, ProcessException {
 		writeMemory(baseAddress, data,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -196,11 +197,12 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            How many bytes should be copied from the stream?
 	 * @throws IOException
 	 *             If anything goes wrong with networking or the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(HasCoreLocation core, int baseAddress,
-			InputStream data, int bytesToWrite) throws IOException, Exception {
+			InputStream data, int bytesToWrite)
+			throws IOException, ProcessException {
 		writeMemory(baseAddress, data, bytesToWrite,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -218,11 +220,11 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            transferred.
 	 * @throws IOException
 	 *             If anything goes wrong with networking or access to the file.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	public void writeMemory(HasCoreLocation core, int baseAddress,
-			File dataFile) throws IOException, Exception {
+			File dataFile) throws IOException, ProcessException {
 		try (InputStream data =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
 			writeMemory(baseAddress, data, (int) dataFile.length(),
@@ -243,12 +245,12 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            The way to create messages to send to do the writing.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	protected <T extends SCPRequest<CheckOKResponse>> void writeMemory(
 			int baseAddress, ByteBuffer data, MessageProvider<T> msgProvider)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		int offset = data.position();
 		int bytesToWrite = data.remaining();
 		int writePosition = baseAddress;
@@ -281,12 +283,13 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *            The way to create messages to send to do the writing.
 	 * @throws IOException
 	 *             If anything goes wrong with networking or the input stream.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	protected <T extends SCPRequest<CheckOKResponse>> void writeMemory(
 			int baseAddress, InputStream data, int bytesToWrite,
-			MessageProvider<T> msgProvider) throws IOException, Exception {
+			MessageProvider<T> msgProvider)
+			throws IOException, ProcessException {
 		int writePosition = baseAddress;
 		ByteBuffer workingBuffer = allocate(UDP_MESSAGE_MAX_SIZE);
 		while (bytesToWrite > 0) {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.bean.MachineBean;
 import uk.ac.manchester.spinnaker.machine.bean.MapperFactory;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
@@ -46,7 +46,7 @@ class ReliabilityITCase {
         		txrx.getScampVersion();
 				Machine machine = txrx.getMachineDetails();
                 assertNull(jsonMachine.difference(machine));
-            } catch (Process.Exception e) {
+            } catch (ProcessException e) {
             	if (e.getCause() instanceof SocketTimeoutException) {
             		log.info("ignoring timeout from " + e.getCause());
             	} else {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -245,7 +245,7 @@ class MockWriteTransceiver extends Transceiver {
 
 	public MockWriteTransceiver(int version, Collection<Connection> connections)
 			throws IOException, SpinnmanException,
-			uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception {
+			uk.ac.manchester.spinnaker.transceiver.processes.ProcessException {
 		super(version, connections, null, null, null, null, null, null);
 	}
 

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/HostExecuteDataSpecification.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/HostExecuteDataSpecification.java
@@ -18,7 +18,7 @@ import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
-import uk.ac.manchester.spinnaker.transceiver.processes.Process.Exception;
+import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import uk.ac.manchester.spinnaker.utils.progress.ProgressIterable;
 
 /**
@@ -55,14 +55,14 @@ public class HostExecuteDataSpecification {
 	 *         happened.
 	 * @throws IOException
 	 *             if communication or disk IO fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             if SCAMP rejects a message
 	 * @throws DataSpecificationException
 	 *             if there's a bug in a data spec file
 	 */
 	public Map<CoreLocation, LocationInfo> load(Machine machine, int appID,
 			Map<CoreLocation, File> dsgTargets)
-			throws IOException, Exception, DataSpecificationException {
+			throws IOException, ProcessException, DataSpecificationException {
 		return load(machine, appID, dsgTargets, null);
 	}
 
@@ -83,7 +83,7 @@ public class HostExecuteDataSpecification {
 	 *         happened.
 	 * @throws IOException
 	 *             if communication or disk IO fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             if SCAMP rejects a message
 	 * @throws DataSpecificationException
 	 *             if there's a bug in a data spec file
@@ -91,7 +91,7 @@ public class HostExecuteDataSpecification {
 	public Map<CoreLocation, LocationInfo> load(Machine machine, int appID,
 			Map<CoreLocation, File> dsgTargets,
 			Map<CoreLocation, LocationInfo> info)
-			throws IOException, Exception, DataSpecificationException {
+			throws IOException, ProcessException, DataSpecificationException {
 		if (info == null) {
 			info = new HashMap<>();
 		}
@@ -116,14 +116,14 @@ public class HostExecuteDataSpecification {
 	 * @return Information about what was written.
 	 * @throws IOException
 	 *             if communication or disk IO fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             if SCAMP rejects a message
 	 * @throws DataSpecificationException
 	 *             if there's a bug in a data spec file
 	 */
 	public LocationInfo load(Machine machine, int appID, HasCoreLocation core,
 			File dataSpec)
-			throws IOException, Exception, DataSpecificationException {
+			throws IOException, ProcessException, DataSpecificationException {
 		try (Executor executor =
 				new Executor(dataSpec, machine.getChipAt(core).sdram)) {
 			executor.execute();
@@ -155,11 +155,11 @@ public class HostExecuteDataSpecification {
 	 * @return How many bytes were actually written.
 	 * @throws IOException
 	 *             If anything goes wrong with I/O.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SCAMP rejects the request.
 	 */
 	private int writeHeader(HasCoreLocation core, Executor executor,
-			int startAddress) throws IOException, Exception {
+			int startAddress) throws IOException, ProcessException {
 		ByteBuffer b = allocate(APP_PTR_TABLE_HEADER_SIZE + REGION_TABLE_SIZE)
 				.order(LITTLE_ENDIAN);
 
@@ -183,11 +183,11 @@ public class HostExecuteDataSpecification {
 	 * @return How many bytes were actually written.
 	 * @throws IOException
 	 *             If anything goes wrong with I/O.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SCAMP rejects the request.
 	 */
 	private int writeRegion(HasCoreLocation core, MemoryRegion region)
-			throws IOException, Exception {
+			throws IOException, ProcessException {
 		return writeRegion(core, region, region.getRegionBase());
 	}
 
@@ -204,11 +204,11 @@ public class HostExecuteDataSpecification {
 	 * @return How many bytes were actually written.
 	 * @throws IOException
 	 *             If anything goes wrong with I/O.
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             If SCAMP rejects the request.
 	 */
 	private int writeRegion(HasCoreLocation core, MemoryRegion region,
-			int baseAddress) throws IOException, Exception {
+			int baseAddress) throws IOException, ProcessException {
 		ByteBuffer data = region.getRegionData().duplicate();
 
 		data.flip();
@@ -228,13 +228,13 @@ public class HostExecuteDataSpecification {
 	 *            The file holding the data specification for the core.
 	 * @throws IOException
 	 *             if communication or disk IO fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             if SCAMP rejects a message
 	 * @throws DataSpecificationException
 	 *             if there's a bug in a data spec file
 	 */
 	public void reload(HasCoreLocation core, File dataSpec)
-			throws DataSpecificationException, IOException, Exception {
+			throws DataSpecificationException, IOException, ProcessException {
 		try (Executor executor = new Executor(dataSpec, DEFAULT_SDRAM_BYTES)) {
 			// execute the spec
 			executor.execute();
@@ -268,13 +268,13 @@ public class HostExecuteDataSpecification {
 	 *            The file holding the data specification for the core.
 	 * @throws IOException
 	 *             if communication or disk IO fail
-	 * @throws Exception
+	 * @throws ProcessException
 	 *             if SCAMP rejects a message
 	 * @throws DataSpecificationException
 	 *             if there's a bug in a data spec file
 	 */
 	public void reload(HasCoreLocation core, LocationInfo info, File dataSpec)
-			throws DataSpecificationException, IOException, Exception {
+			throws DataSpecificationException, IOException, ProcessException {
 		try (Executor executor = new Executor(dataSpec, info.memoryUsed)) {
 			// execute the spec
 			executor.execute();


### PR DESCRIPTION
This breaks code… for the better. It's simply clearer to make the exception be its own top-level class.