### PR TITLE
Rat

### DIFF
--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.lang.Thread.sleep;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOMessageFactory.readCommandMessage;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_BOOT_CONNECTION_DEFAULT_PORT;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/LocateConnectedMachineIPAddress.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/LocateConnectedMachineIPAddress.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.lang.Runtime.getRuntime;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPErrorHandler.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPErrorHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.net.InetAddress.getByAddress;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import uk.ac.manchester.spinnaker.messages.boot.BootMessage;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/BootSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Connection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Connection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import uk.ac.manchester.spinnaker.messages.eieio.EIEIOHeader;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/EIEIOSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/InvalidPacketException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/InvalidPacketException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.MS_PER_S;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageHandler.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSenderReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPSenderReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 /** Combo-interface. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SDPReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SDPReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SDPSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SDPSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SocketHolder.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SocketHolder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.net.InetAddress;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * @author Donal Fellows
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Classes used to model types of connections that talk to SpiNNaker.
  *

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/ConnectionSelector.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/ConnectionSelector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.selectors;
 
 import uk.ac.manchester.spinnaker.connections.model.Connection;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/MachineAware.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/MachineAware.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.selectors;
 
 import uk.ac.manchester.spinnaker.machine.Machine;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/MostDirectConnectionSelector.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/MostDirectConnectionSelector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.selectors;
 
 import java.util.Collection;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/RoundRobinConnectionSelector.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/RoundRobinConnectionSelector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections.selectors;
 
 import static java.util.Collections.unmodifiableList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/selectors/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Selectors for connections.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.io;
 
 import static java.lang.Math.max;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.io;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/Constants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.io;
 
 /** Misc constants. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/FileIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/FileIO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.io;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.io;
 
 import java.io.EOFException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Pretending that a SpiNNaker machine is simple I/O.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages;
 
 import uk.ac.manchester.spinnaker.utils.UnitConstants;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/SerializableMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/SerializableMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 /** The SCP BMP Information Types. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static java.util.Collections.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPSetLED.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPSetLED.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LED;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetBMPVersion.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetBMPVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_VER;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadADC.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadADC.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static uk.ac.manchester.spinnaker.messages.bmp.BMPInfo.ADC;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/SetPower.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/SetPower.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.MS_PER_S;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Messages that talk to the BMP.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootDataBlock.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootDataBlock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static uk.ac.manchester.spinnaker.messages.boot.BootMessages.BOOT_MESSAGE_DATA_WORDS;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootMessages.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static java.lang.Integer.reverseBytes;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootOpCode.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/BootOpCode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import java.util.HashMap;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/EndOfBootMessages.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/EndOfBootMessages.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static uk.ac.manchester.spinnaker.messages.boot.BootOpCode.FLOOD_FILL_CONTROL;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/StartOfBootMessages.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/StartOfBootMessages.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static uk.ac.manchester.spinnaker.messages.boot.BootOpCode.FLOOD_FILL_START;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/SystemVariableBootValues.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/SystemVariableBootValues.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.hardware_version;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Messages used to boot a SpiNNaker board.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/AbstractDataElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/AbstractDataElement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/CustomEIEIOCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/CustomEIEIOCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/DatabaseConfirmation.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/DatabaseConfirmation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static java.nio.charset.Charset.defaultCharset;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import java.util.HashMap;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIODataMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIODataMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static java.lang.Integer.toUnsignedLong;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOHeader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import uk.ac.manchester.spinnaker.messages.SerializableMessage;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import uk.ac.manchester.spinnaker.messages.SerializableMessage;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessageFactory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessageFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOPrefix.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOPrefix.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 /** Possible prefixing of keys in EIEIO packets. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOType.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EventStopRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EventStopRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.EVENT_STOP;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostDataRead.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostDataRead.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.HOST_DATA_READ;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostDataReadAck.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostDataReadAck.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.HOST_DATA_READ_ACK;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostSendSequencedData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostSendSequencedData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.HOST_SEND_SEQUENCED_DATA;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/KeyDataElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/KeyDataElement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/KeyPayloadDataElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/KeyPayloadDataElement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/NotificationProtocolPauseStop.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/NotificationProtocolPauseStop.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.STOP_PAUSE_NOTIFICATION;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/NotificationProtocolStartResume.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/NotificationProtocolStartResume.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.START_RESUME_NOTIFICATION;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/PaddingRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/PaddingRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.EVENT_PADDING;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/SpinnakerRequestBuffers.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/SpinnakerRequestBuffers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.SPINNAKER_REQUEST_BUFFERS;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/SpinnakerRequestReadData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/SpinnakerRequestReadData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.SPINNAKER_REQUEST_READ_DATA;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/StartRequests.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/StartRequests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.START_SENDING_REQUESTS;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/StopRequests.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/StopRequests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.eieio;
 
 import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.STOP_SENDING_REQUESTS;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * The messages of the EIEIO protocol.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ADCInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ADCInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.BMP_MISSING_FAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ARMRegisters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ARMRegisters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/AllocFree.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/AllocFree.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /** The SCP Allocation and Free codes. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/BMPConnectionData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/BMPConnectionData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import java.net.InetAddress;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/CPUInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/CPUInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/CPUState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/CPUState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipSummaryInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipSummaryInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.net.InetAddress.getByAddress;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Arrays.asList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ExecutableTargets.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ExecutableTargets.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /** An element of one of the heaps on SpiNNaker. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IOBuffer.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IOBuffer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.nio.ByteBuffer.wrap;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /** SCP IP tag Commands. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagTimeOutWaitTime.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagTimeOutWaitTime.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import java.util.HashMap;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/LEDAction.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/LEDAction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /** The SCP LED actions. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/MailboxCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/MailboxCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/MemoryAllocationFailedException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/MemoryAllocationFailedException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/P2PTable.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/P2PTable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/P2PTableRoute.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/P2PTableRoute.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/PowerCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/PowerCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 /** The BMP Power Commands. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/RouterDiagnostics.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/RouterDiagnostics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.System.arraycopy;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/RunTimeError.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/RunTimeError.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SARKField.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SARKField.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SARKStruct.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SARKStruct.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Signal.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Signal.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/UnexpectedResponseCodeException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/UnexpectedResponseCodeException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Version.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Version.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.Integer.compare;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/VersionInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Model support classes for the communication messages.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Generic support classes for messages. Also things that don't fit anywhere
  * else.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationRun.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationRun.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.machine.MachineDefaults.MAX_NUM_CORES;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationStop.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationStop.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.Signal.STOP;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/Bits.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/Bits.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 /** Standard bit shifts. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CheckOKResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CheckOKResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.Signal.Type.POINT_TO_POINT;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FILL;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillEnd.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillEnd.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_INFO;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetVersion.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_VER;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.CLR;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagFieldDefinitions.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagFieldDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 /** Constants for working with tags. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.GET;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.util.stream.IntStream.range;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequestHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPRequestHeader.java
@@ -1,3 +1,20 @@
+/*
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.getNextSequenceNumber;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResult.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import java.util.HashMap;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPResultMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPSDPHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPSDPHeader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.AllocFree.FREE_SDRAM_BY_APP_ID;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SendSignal.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SendSignal.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SequenceNumberSource.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SequenceNumberSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 /** Where to get sequence numbers from. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetLED.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetLED.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LED;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LINK_WRITE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_WRITE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * The messages of SpiNNaker Control Protocol (SCP).
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPHeader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.sdp;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.sdp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPPort.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SDPPort.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.sdp;
 
 /** SDP port handling output buffering data streaming. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/SpinnakerRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.sdp;
 
 import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_EXPECTED;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/sdp/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Messages sent and received by SDP (the SpiNNaker Datagram Protocol).
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Configuration.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Configuration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static java.util.Arrays.asList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/JobConstants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/JobConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/PropertyBasedDeserialiser.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/PropertyBasedDeserialiser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 /*

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocClient.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static java.lang.Thread.currentThread;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static java.lang.Math.max;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/Utils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static java.lang.Math.max;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/JobDestroyedException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/JobDestroyedException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.exceptions;
 
 /** Thrown when the job was destroyed while waiting for it to become ready. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocProtocolException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocProtocolException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.exceptions;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocProtocolTimeoutException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocProtocolTimeoutException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.exceptions;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocServerException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocServerException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.exceptions;
 
 import uk.ac.manchester.spinnaker.spalloc.messages.ExceptionResponse;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocStateChangeTimeoutException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/SpallocStateChangeTimeoutException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.exceptions;
 
 /** Thrown when a state change takes too long to occur. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/exceptions/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Exceptions of the spalloc client.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardCoordinates.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardCoordinates.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardLink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardPhysicalCoordinates.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/BoardPhysicalCoordinates.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Command.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Command.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import java.util.ArrayList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Connection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Connection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/CreateJobCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/CreateJobCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import java.util.List;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/DestroyJobCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/DestroyJobCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ExceptionResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ExceptionResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetBoardAtPositionCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetBoardAtPositionCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetBoardPositionCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetBoardPositionCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetJobMachineInfoCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetJobMachineInfoCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetJobStateCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/GetJobStateCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobDescription.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static java.util.Collections.unmodifiableList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobKeepAliveCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobKeepAliveCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobMachineInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobMachineInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import java.util.Collections;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobsChangedNotification.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobsChangedNotification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static java.util.Arrays.asList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ListJobsCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ListJobsCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ListMachinesCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ListMachinesCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Machine.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Machine.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import java.util.Collections;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/MachinesChangedNotification.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/MachinesChangedNotification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static java.util.Collections.emptyList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NoNotifyJobCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NoNotifyJobCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NoNotifyMachineCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NoNotifyMachineCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Notification.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Notification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NotifyJobCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NotifyJobCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NotifyMachineCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/NotifyMachineCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/PowerOffJobBoardsCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/PowerOffJobBoardsCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/PowerOnJobBoardsCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/PowerOnJobBoardsCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Response.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/Response.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ReturnResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/ReturnResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.annotation.JsonSetter;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/State.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/State.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.NUMBER;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/VersionCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/VersionCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIs.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIs.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import java.util.Objects;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsJobChipCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsJobChipCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineBoardLogicalCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineBoardLogicalCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineBoardPhysicalCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineBoardPhysicalCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineChipCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIsMachineChipCommand.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Commands to send to Spalloc, and responses received from Spalloc.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * SpiNNaker machine allocation client.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/AppIdTracker.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/AppIdTracker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.util.stream.Collectors.toSet;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RetryTracker.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RetryTracker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/SpinnmanException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/SpinnmanException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.Thread.sleep;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * How to actually talk to a SpiNNaker machine.
  */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/DeallocSDRAMProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/DeallocSDRAMProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/FillProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetCPUInfoProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetCPUInfoProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.util.Collections.unmodifiableList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetHeapProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetHeapProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.util.Collections.unmodifiableList;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMulticastRoutesProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMulticastRoutesProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Byte.toUnsignedInt;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetTagsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetTagsProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.util.stream.IntStream.range;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetVersionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetVersionProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadFixedRouteEntryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadFixedRouteEntryProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadMulticastRoutesProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/LoadMulticastRoutesProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MallocSDRAMProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MallocSDRAMProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/Process.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/Process.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ProcessException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ProcessException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadFixedRouteEntryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadFixedRouteEntryProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadIOBufProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadIOBufProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadMemoryProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Math.max;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadRouterDiagnosticsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ReadRouterDiagnosticsProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SingleConnectionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SingleConnectionProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryFloodProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryFloodProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Math.ceil;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * How to arrange messages to and from a SpiNNaker machine to do higher-level
  * operations.

--- a/SpiNNaker-comms/src/main/resources/spalloc.ini
+++ b/SpiNNaker-comms/src/main/resources/spalloc.ini
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 [spalloc]
 port=22244
 owner=DEFAULT-FIXME

--- a/SpiNNaker-comms/src/support/checkstyle/suppressions.xml
+++ b/SpiNNaker-comms/src/support/checkstyle/suppressions.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<!-- suppress files="[\/]TransceiverInterface.java" checks="FileLength" /-->

--- a/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
+++ b/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package testconfig;
 
 import static java.util.Arrays.asList;

--- a/SpiNNaker-comms/src/test/java/testconfig/Utils.java
+++ b/SpiNNaker-comms/src/test/java/testconfig/Utils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package testconfig;
 
 import java.util.Collection;

--- a/SpiNNaker-comms/src/test/java/testconfig/package-info.java
+++ b/SpiNNaker-comms/src/test/java/testconfig/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Testing configuration.
  */

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestBootConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestBootConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.util.Collections.emptySet;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/boot/TestMessage.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/boot/TestMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.boot;
 
 import static java.util.Arrays.asList;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestChipInfo.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestChipInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestCpuInfo.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestCpuInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestIOBufModel.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestIOBufModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestIptag.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestIptag.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * @author micro
  */
 public class TestVersion {
-       
+
     @Test
     public void testThreeUnquoted () {
         Version version = new Version("1.2.3");

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestVersionInfo.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/model/TestVersionInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestCountState.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestCountState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestSCPMessageAssembly.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestSCPMessageAssembly.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.String.join;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/sdp/TestEnums.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/sdp/TestEnums.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.messages.sdp;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockServer.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockServer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import java.io.BufferedReader;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestJob.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestJob.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import static java.lang.Thread.sleep;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc;
 
 import java.io.IOException;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestBoardCoordinates.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestBoardCoordinates.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +27,7 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocClient;
  * @author Christian
  */
 public class TestBoardCoordinates {
-    
+
     @Test
     void testFromJson() throws IOException {
         String json = "[2, 4, 6]";
@@ -20,11 +36,11 @@ public class TestBoardCoordinates {
         assertEquals(2, fromJson.getX());
         assertEquals(4, fromJson.getY());
         assertEquals(6, fromJson.getZ());
-        
+
         BoardCoordinates direct = new BoardCoordinates(2, 4, 6);
         assertEquals(direct, fromJson);
         assertEquals(direct.hashCode(), fromJson.hashCode());
         assertEquals(direct.toString(), fromJson.toString());
     }
-    
+
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestBoardPhysicalCoordinates.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestBoardPhysicalCoordinates.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +27,7 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocClient;
  * @author Christian
  */
 public class TestBoardPhysicalCoordinates {
-    
+
     @Test
     void testFromJson() throws IOException {
         String json = "[2, 4, 6]";
@@ -20,11 +36,11 @@ public class TestBoardPhysicalCoordinates {
         assertEquals(2, fromJson.getCabinet());
         assertEquals(4, fromJson.getFrame());
         assertEquals(6, fromJson.getBoard());
-        
+
         BoardPhysicalCoordinates direct = new BoardPhysicalCoordinates(2, 4, 6);
         assertEquals(direct, fromJson);
         assertEquals(direct.hashCode(), fromJson.hashCode());
         assertEquals(direct.toString(), fromJson.toString());
     }
-    
+
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestJobDescription.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestJobDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static org.hamcrest.MatcherAssert.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestJobMachineInfo.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestJobMachineInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,7 +29,7 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocClient;
  * @author Christian
  */
 public class TestJobMachineInfo {
-    
+
     @Test
     void testFromJson() throws IOException {
         String json =  "{\"connections\":[[[0,0],\"10.2.225.177\"],"
@@ -31,7 +47,7 @@ public class TestJobMachineInfo {
         assertEquals(24, fromJson.getHeight());
         assertEquals("Spin24b-001", fromJson.getMachineName());
     }
-    
+
     @Test
     void testNullJson() throws IOException {
         String json = "{\"connections\":null,"

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestMachine.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestMachine.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static org.hamcrest.MatcherAssert.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestState.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestWhereIs.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/messages/TestWhereIs.java
@@ -1,7 +1,19 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.spalloc.messages;
 
@@ -18,14 +30,14 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocClient;
  * @author micro
  */
 public class TestWhereIs {
-    
+
     void testFromJson() throws IOException {
         ChipLocation jobChip = new ChipLocation(1, 2);
         ChipLocation chip = new ChipLocation(3, 4);
         ChipLocation boardChip = new ChipLocation(8, 9);
         BoardCoordinates logical = new BoardCoordinates(5, 6, 7);
         BoardPhysicalCoordinates physical = new BoardPhysicalCoordinates(10, 11, 12);
-        
+
         String json = "{\"job_chip\":[1,2],\"job_id\":666,\"chip\":[3,4],\"logical\":[5,6,7],\"machine\":\"Spin24b-001\",\"board_chip\":[8,9],\"physical\":[10,11,12]}";
         ObjectMapper mapper = SpallocClient.createMapper();
         WhereIs fromJson = mapper.readValue(json, WhereIs.class);
@@ -36,20 +48,20 @@ public class TestWhereIs {
         assertEquals("Spin24b-001", fromJson.getMachine());
         assertEquals(boardChip, fromJson.getBoardChip());
         assertEquals(boardChip, fromJson.getPhysical());
-        
+
         WhereIs direct = new WhereIs(jobChip, 666, chip, logical, "Spin24b-001", boardChip, physical);
         assertEquals(direct, fromJson);
         //assertEquals(direct.hashCode(), fromJson.hashCode());
         assertEquals(direct.toString(), fromJson.toString());
     }
-    
+
     @Test
     void testBug() throws IOException {
         ChipLocation chip = new ChipLocation(8, 4);
         ChipLocation boardChip = new ChipLocation(0, 0);
         BoardCoordinates logical = new BoardCoordinates(0, 0, 1);
         BoardPhysicalCoordinates physical = new BoardPhysicalCoordinates(0, 0, 8);
-        
+
         String json = "{\"job_chip\":null,\"job_id\":null,\"chip\":[8,4],\"logical\":[0,0,1],\"machine\":\"Spin24b-001\",\"board_chip\":[0,0],\"physical\":[0,0,8]}";
         ObjectMapper mapper = SpallocClient.createMapper();
         WhereIs fromJson = mapper.readValue(json, WhereIs.class);
@@ -60,16 +72,16 @@ public class TestWhereIs {
         assertEquals("Spin24b-001", fromJson.getMachine());
         assertEquals(boardChip, fromJson.getBoardChip());
         assertEquals(physical, fromJson.getPhysical());
-        
+
         WhereIs direct = new WhereIs(null, 0, chip, logical, "Spin24b-001", boardChip, physical);
         assertEquals(direct, fromJson);
         //assertEquals(direct.hashCode(), fromJson.hashCode());
         assertEquals(direct.toString(), fromJson.toString());
     }
-    
+
     @Test
     void testNulls() throws IOException {
-        
+
         String json = "{\"job_chip\":null,\"job_id\":null,\"chip\":null,\"logical\":null,\"machine\":null,\"board_chip\":null,\"physical\":null}";
         ObjectMapper mapper = SpallocClient.createMapper();
         WhereIs fromJson = mapper.readValue(json, WhereIs.class);
@@ -80,7 +92,7 @@ public class TestWhereIs {
         assertNull(fromJson.getMachine());
         assertNull(fromJson.getBoardChip());
         assertNull(fromJson.getPhysical());
-        
+
         WhereIs direct = new WhereIs(null, 0, null, null, null, null, null);
         assertEquals(direct, fromJson);
         //assertEquals(direct.hashCode(), fromJson.hashCode());

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +49,7 @@ class ReliabilityITCase {
         jsonMachine = new Machine(fromJson);
 	}
 
-	private static final int REPETITIONS = 50;
+	private static final int REPETITIONS = 8;
 
 	@Test
 	void testReliableMachine() throws Exception {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/SpallocMachineTest.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/SpallocMachineTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.String.format;

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.Math.random;

--- a/SpiNNaker-comms/src/test/resources/log4j.properties
+++ b/SpiNNaker-comms/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 log4j.logger.org.apache.commons.beanutils=ERROR

--- a/SpiNNaker-comms/src/test/resources/spalloc-test.ini
+++ b/SpiNNaker-comms/src/test/resources/spalloc-test.ini
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 [spalloc]
 port=22244
 owner=dummy

--- a/SpiNNaker-comms/src/test/resources/testconfig/test.cfg
+++ b/SpiNNaker-comms/src/test/resources/testconfig/test.cfg
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 [Machine]
 # Machine behind spalloc that turns of board
 #machineName = spinn-2.cs.man.ac.uk

--- a/SpiNNaker-data-specification/pom.xml
+++ b/SpiNNaker-data-specification/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Callable.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Callable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import uk.ac.manchester.spinnaker.data_spec.exceptions.DataSpecificationException;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Commands.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Commands.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import java.util.HashMap;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Constants.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Constants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 /**

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.nio.ByteBuffer.wrap;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/FunctionAPI.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/FunctionAPI.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static uk.ac.manchester.spinnaker.data_spec.Commands.BREAK;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.lang.String.format;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/HostExecuteDataSpecification.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/HostExecuteDataSpecification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.lang.Math.max;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.lang.System.arraycopy;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Operation.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Operation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/OperationMapper.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/OperationMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.lang.String.format;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/DataSpecificationException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/DataSpecificationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 /**

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/ExecuteBreakInstruction.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/ExecuteBreakInstruction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 /**

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/NoMoreException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/NoMoreException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 /**

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/NoRegionSelectedException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/NoRegionSelectedException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 import uk.ac.manchester.spinnaker.data_spec.Commands;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionInUseException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionInUseException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 /**

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionNotAllocatedException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionNotAllocatedException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 import uk.ac.manchester.spinnaker.data_spec.Commands;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionUnfilledException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/RegionUnfilledException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 import uk.ac.manchester.spinnaker.data_spec.Commands;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/UnimplementedDSECommandException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/UnimplementedDSECommandException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 import static java.lang.String.format;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/UnknownTypeLengthException.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/UnknownTypeLengthException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec.exceptions;
 
 import uk.ac.manchester.spinnaker.data_spec.Commands;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/package-info.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/exceptions/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Exceptions for the Data Specification Executor.
  *

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/package-info.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Data specification generator and executor.
  * The main class here is {@link Executor}.

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/Generator.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/Generator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static java.io.File.createTempFile;

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegion.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestOperationMapper.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestOperationMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.data_spec;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-data-specification/src/test/resources/log4j.properties
+++ b/SpiNNaker-data-specification/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/Constants.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/Constants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataOut.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataOut.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/HostDataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/HostDataReceiver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.lang.Math.ceil;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/MissingSequenceNumbersMessage.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/MissingSequenceNumbersMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.lang.Math.min;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/ProtocolID.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/ProtocolID.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 /** The various IDs of messages used in the fast download protocol. */

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/ProtocolMessage.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/ProtocolMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static uk.ac.manchester.spinnaker.messages.sdp.SDPHeader.Flag.REPLY_NOT_EXPECTED;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/StartSendingMessage.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/StartSendingMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.nio.ByteBuffer.allocate;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/package-info.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Code for downloading data very quickly from SpiNNaker.
  *

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/DataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/DataReceiver.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/DataReceiverRunner.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/DataReceiverRunner.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/Placement.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/Placement.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/Vertex.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/Vertex.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/package-info.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * The buffer manager and support classes.
  */

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/BufferedReceivingData.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/BufferedReceivingData.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management.storage_objects;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/BufferingOperation.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/BufferingOperation.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management.storage_objects;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/ChannelBufferState.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/ChannelBufferState.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management.storage_objects;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/package-info.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/storage_objects/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * The buffer manager's storage_objects.
  */

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/package-info.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * The front-end interface to the Java implementation of the SpiNNaker host
  * libraries.

--- a/SpiNNaker-front-end/src/main/resources-filtered/command-line.properties
+++ b/SpiNNaker-front-end/src/main/resources-filtered/command-line.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 mainClass: ${mainClass}
 jar: ${exeJar}
 version: ${project.version}

--- a/SpiNNaker-front-end/src/main/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/main/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=WARN, stderr
 

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.front_end;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/TestPlacements.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/interfaces/buffer_management/TestPlacements.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.front_end.interfaces.buffer_management;
 

--- a/SpiNNaker-front-end/src/test/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 

--- a/SpiNNaker-machine/pom.xml
+++ b/SpiNNaker-machine/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Chip.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Chip.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/ChipInformation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/ChipInformation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 import java.util.BitSet;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/ChipLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/ChipLocation.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreLocation.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreSubsets.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreSubsets.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 
@@ -15,7 +28,7 @@ import java.util.TreeMap;
 import uk.ac.manchester.spinnaker.utils.DoubleMapIterator;
 
 /**
- * Represents a set of of CoreLocations organized by Chip.
+ * Represents a set of of {@link CoreLocation}s organized by Chip.
  * <p>
  * @see <a
  * href="https://github.com/SpiNNakerManchester/SpiNNMachine/blob/master/spinn_machine/core_subsets.py">

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreSubsetsFailedChipsTuple.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/CoreSubsetsFailedChipsTuple.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Direction.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Direction.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/HasChipLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/HasChipLocation.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/HasCoreLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/HasCoreLocation.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Link.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Link.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineDefaults.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineDefaults.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineDimensions.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineDimensions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 /** Represents the size of a machine in chips. */

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineVersion.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineVersion.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MulticastRoutingEntry.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MulticastRoutingEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 /** A multicast packet routing table entry. */

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/NeighbourIterator.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/NeighbourIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Processor.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Processor.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RegionLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RegionLocation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 /**

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Router.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Router.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RoutingEntry.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/RoutingEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 import java.util.ArrayList;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/SpiNNakerTriadGeometry.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/SpiNNakerTriadGeometry.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/VirtualMachine.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/VirtualMachine.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipBean.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipBean.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.bean;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipDetails.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipDetails.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.bean;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipResources.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/ChipResources.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.bean;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/MachineBean.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/MachineBean.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.bean;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/MapperFactory.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/MapperFactory.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.bean;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/package-info.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/bean/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /** Beans to describes a SpiNNaker machine. */
 package uk.ac.manchester.spinnaker.machine.bean;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/AbstractDataLink.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/AbstractDataLink.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FPGALinkData.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FPGALinkData.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FpgaEnum.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FpgaEnum.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FpgaId.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/FpgaId.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/InetIdTuple.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/InetIdTuple.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/SpinnakerLinkData.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/SpinnakerLinkData.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/package-info.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/datalinks/package-info.java
@@ -1,2 +1,18 @@
-/** Describes a Datalinks. */
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/** Describes a datalink. */
 package uk.ac.manchester.spinnaker.machine.datalinks;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/package-info.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /** Describes a SpiNNaker machine. */
 package uk.ac.manchester.spinnaker.machine;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/Reports.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/Reports.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.reports;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/package-info.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/reports/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * User-facing reports about the allocated machine.
  *

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.tags;
 
 import static java.lang.Integer.rotateLeft;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/ReverseIPTag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/ReverseIPTag.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.tags;
 
 import static java.lang.Integer.rotateLeft;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/Tag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/Tag.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.tags;
 
 import java.net.InetAddress;

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/TrafficIdentifer.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/TrafficIdentifer.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.tags;
 

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/package-info.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /** Describes IPtags and reverse IPtags. */
 package uk.ac.manchester.spinnaker.machine.tags;

--- a/SpiNNaker-machine/src/main/javadoc/overview.html
+++ b/SpiNNaker-machine/src/main/javadoc/overview.html
@@ -1,4 +1,20 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <HTML>
     <HEAD>
     <TITLE>SpiNNaker Machine Description</TITLE>

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestChip.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestChip.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestChipLocation.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestChipLocation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 import java.util.HashMap;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreLocation.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreLocation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 import java.util.HashMap;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreSubsets.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreSubsets.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreSubsetsFailedChipTuple.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestCoreSubsetsFailedChipTuple.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestDirection.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestDirection.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestLink.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestLink.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachine.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachine.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineDefaults.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineDefaults.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineDimensions.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineDimensions.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineVersion.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMachineVersion.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMultiCastRoutingEntry.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestMultiCastRoutingEntry.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestProcessor.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestProcessor.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRegionLocation.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRegionLocation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine;
 
 import java.util.HashMap;
@@ -28,7 +44,7 @@ public class TestRegionLocation {
         assertEquals(r1.toString(), r2.toString());
         assertEquals(r1.hashCode(), r2.hashCode());
     }
-    
+
     private void greater(RegionLocation big, RegionLocation small) {
         assertThat(big, greaterThan(small));
         assertThat(small, lessThan(big));
@@ -36,7 +52,7 @@ public class TestRegionLocation {
         assertNotEquals(big.hashCode(), small.hashCode());
         assertNotEquals(big.toString(), small.toString());
     }
-            
+
     @Test
     public void testCompare() {
         CoreLocation core001 = new CoreLocation(0, 0, 1);

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRouter.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRouter.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRoutingEntry.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestRoutingEntry.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestSpiNNakerTriadGeometry.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestSpiNNakerTriadGeometry.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestVirtualMachine.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/TestVirtualMachine.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipDetails.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipDetails.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.bean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipLocationBean.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipLocationBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.bean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipbean.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestChipbean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.bean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestMachineBean.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/bean/TestMachineBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.machine.bean;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestAbstractDataLink.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestAbstractDataLink.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestFpgaLinkData.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestFpgaLinkData.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestFpgaLinkId.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestFpgaLinkId.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestInetIdTuple.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestInetIdTuple.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestSpinnakerLinkData.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/datalinks/TestSpinnakerLinkData.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.datalinks;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/tags/TestIPTag.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/tags/TestIPTag.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.tags;
 

--- a/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/tags/TestReverseIPTag.java
+++ b/SpiNNaker-machine/src/test/java/uk/ac/manchester/spinnaker/machine/tags/TestReverseIPTag.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.machine.tags;
 

--- a/SpiNNaker-machine/src/test/resources/log4j.properties
+++ b/SpiNNaker-machine/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 

--- a/SpiNNaker-pacman/pom.xml
+++ b/SpiNNaker-pacman/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/SpiNNaker-pacman/src/main/java/uk/ac/manchester/spinnaker/pacman/RemoveMe.java
+++ b/SpiNNaker-pacman/src/main/java/uk/ac/manchester/spinnaker/pacman/RemoveMe.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.pacman;
 
 /**

--- a/SpiNNaker-pacman/src/main/java/uk/ac/manchester/spinnaker/pacman/package-info.java
+++ b/SpiNNaker-pacman/src/main/java/uk/ac/manchester/spinnaker/pacman/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Implementation of the Partitioning and Configuration Manager (PACMAN).
  */

--- a/SpiNNaker-pacman/src/test/resources/log4j.properties
+++ b/SpiNNaker-pacman/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 

--- a/SpiNNaker-storage/pom.xml
+++ b/SpiNNaker-storage/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/ConnectionProvider.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/ConnectionProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 import java.sql.Connection;

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/DatabaseEngine.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/DatabaseEngine.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/SQLiteStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/SQLiteStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 import static java.sql.Statement.RETURN_GENERATED_KEYS;

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/Storage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/Storage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/StorageException.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/StorageException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 /**

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/package-info.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * Storage management.
  */

--- a/SpiNNaker-storage/src/main/resources/db.sql
+++ b/SpiNNaker-storage/src/main/resources/db.sql
@@ -1,3 +1,18 @@
+-- Copyright (c) 2018 The University of Manchester
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 -- A table mapping unique names to blobs of data. It's trivial!
 CREATE TABLE IF NOT EXISTS storage(
 	storage_id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
+++ b/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.storage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/SpiNNaker-storage/src/test/resources/log4j.properties
+++ b/SpiNNaker-storage/src/test/resources/log4j.properties
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Root logger option
 log4j.rootLogger=INFO, stderr
 log4j.logger.org.apache.commons.beanutils=ERROR

--- a/SpiNNaker-utils/pom.xml
+++ b/SpiNNaker-utils/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Counter.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Counter.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DefaultMap.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DefaultMap.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import static java.util.Objects.requireNonNull;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DoubleMapIterable.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DoubleMapIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DoubleMapIterator.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/DoubleMapIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/InetFactory.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/InetFactory.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/OneShotEvent.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/OneShotEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import java.util.concurrent.locks.Condition;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Ping.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Ping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import java.io.IOException;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/RawConfigParser.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/RawConfigParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import static java.lang.String.format;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ReaderLineIterable.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ReaderLineIterable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import java.io.BufferedReader;

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Slice.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Slice.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 /**

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/TripleMapIterable.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/TripleMapIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/TripleMapIterator.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/TripleMapIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/UnitConstants.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/UnitConstants.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ValueHolder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 /**

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/package-info.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * General utilities for the SpiNNaker runtime.
  */

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressBar.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressBar.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils.progress;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterable.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils.progress;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterator.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/ProgressIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils.progress;
 

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/package-info.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/progress/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /**
  * ProegressBar (and Timer) utilities.
  */

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestCounter.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestCounter.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDefaultMap.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDefaultMap.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterable.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterator.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDoubleMapIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestInetFactory.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestInetFactory.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestOneShotEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.spinnaker.utils;
 
 import org.junit.jupiter.api.Test;

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestPing.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestPing.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestRawConfigParser.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestRawConfigParser.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestReaderLineIterable.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestReaderLineIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestTripleMapIterable.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestTripleMapIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestTripleMapIterator.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestTripleMapIterator.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestUnits.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestUnits.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestBar.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestBar.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils.progress;
 

--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestIterable.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/progress/TestIterable.java
@@ -1,5 +1,18 @@
 /*
  * Copyright (c) 2018 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package uk.ac.manchester.spinnaker.utils.progress;
 

--- a/SpiNNaker-utils/src/test/resources/testconfig/test.cfg
+++ b/SpiNNaker-utils/src/test/resources/testconfig/test.cfg
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 [Machine]
 machineName = spinn-2.cs.man.ac.uk
 bmp_names = spinn-2c.cs.man.ac.uk

--- a/pom.xml
+++ b/pom.xml
@@ -213,23 +213,56 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+					<groupId>org.eluder.coveralls</groupId>
+					<artifactId>coveralls-maven-plugin</artifactId>
+					<version>4.3.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.rat</groupId>
+					<artifactId>apache-rat-plugin</artifactId>
+					<version>0.13</version>
+					<configuration>
+						<excludes>
+							<exclude>.github/*</exclude>
+							<exclude>.travis/*</exclude>
+							<exclude>.travis.yml</exclude>
+							<exclude>README.md</exclude>
+						</excludes>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.3.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
 						<goals>
 							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.rat</groupId>
+				<artifactId>apache-rat-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -246,9 +246,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 					<version>0.13</version>
 					<configuration>
 						<excludes>
+							<!-- Files without comment formats should be excluded -->
 							<exclude>.github/*</exclude>
 							<exclude>.travis/*</exclude>
 							<exclude>.travis.yml</exclude>
+							<exclude>**/*.json</exclude>
 							<exclude>README.md</exclude>
 						</excludes>
 					</configuration>

--- a/src/support/checkstyle/style.xml
+++ b/src/support/checkstyle/style.xml
@@ -2,6 +2,22 @@
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
           "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <module name="Checker">
 	<property name="fileExtensions" value="java, properties, xml" />
 	<module name="JavadocPackage" />


### PR DESCRIPTION
Adds auditing of copyright notices in the file. This is a huge change, of which almost all is just adding missing copyright notices (in the correct, recommended form for GPL3 software). This will probably irritate me more than anyone else, as I'm _terrible_ for failing to add this sort of thing! But it's still good to include the audit as part of our CI build.