### PR TITLE
Control over the logging level

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
@@ -29,12 +29,19 @@ import org.apache.log4j.FileAppender;
  * @author Donal Fellows
  */
 public abstract class LogControl {
-	private LogControl() {
-		// TODO Auto-generated constructor stub
-	}
-
+	private static final String DEFAULT_LOGGING_LEVEL = "INFO";
 	private static final String LOG_FILE = "jspin.log";
 	private static final String LOGGER_NAME = "tofile";
+	private static final String LOGGING_LEVEL_NAME = "logging.level";
+
+	static {
+		if (System.getProperty(LOGGING_LEVEL_NAME) == null) {
+			System.setProperty(LOGGING_LEVEL_NAME, DEFAULT_LOGGING_LEVEL);
+		}
+	}
+
+	private LogControl() {
+	}
 
 	/**
 	 * Initialise the logging subsystem to log to the correct directory.

--- a/SpiNNaker-front-end/src/main/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/main/resources/log4j.properties
@@ -20,6 +20,6 @@ log4j.rootLogger=DEBUG, tofile
 log4j.appender.tofile=org.apache.log4j.FileAppender
 log4j.appender.tofile.append=true
 log4j.appender.tofile.file=initial.log
-log4j.appender.tofile.threshold=INFO
+log4j.appender.tofile.threshold=${logging.level}
 log4j.appender.tofile.layout=org.apache.log4j.PatternLayout
 log4j.appender.tofile.layout.ConversionPattern=%d{HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
To control the logging level, set the `logging.level` system property to something other than `INFO` (e.g., `WARN` or `DEBUG`) as part of the command line (using the standard Java syntax for doing so). It should default to `INFO`.

Fixes #213