### PR TITLE
Get rid of the max core ID constructor parameter

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -241,11 +241,6 @@ public class Transceiver extends UDPTransceiver
 			new DefaultMap<>(new HashSet<>());
 
 	/**
-	 * The maximum core ID in any discovered machine. Requests for a "machine"
-	 * will only have core IDs up to and including this value.
-	 */
-	private final Integer maxCoreID;
-	/**
 	 * The max size each chip can say it has for SDRAM. (This is mainly used for
 	 * debugging purposes.)
 	 */
@@ -349,9 +344,6 @@ public class Transceiver extends UDPTransceiver
 	 *            An optional set of links to ignore in the machine. Requests
 	 *            for a "machine" will have these links excluded, as if they
 	 *            never existed.
-	 * @param maxCoreID
-	 *            The maximum core ID in any discovered machine. Requests for a
-	 *            "machine" will only have core IDs up to this value.
 	 * @param bmpConnectionData
 	 *            the details of the BMP connections used to boot multi-board
 	 *            systems
@@ -377,7 +369,7 @@ public class Transceiver extends UDPTransceiver
 			Integer numberOfBoards, List<ChipLocation> ignoredChips,
 			Map<ChipLocation, Collection<Integer>> ignoredCores,
 			Map<ChipLocation, Collection<Direction>> ignoredLinks,
-			Integer maxCoreID, boolean autodetectBMP,
+			boolean autodetectBMP,
 			List<ConnectionDescriptor> scampConnections, Integer bootPortNumber,
 			Integer maxSDRAMSize)
 			throws IOException, SpinnmanException, ProcessException {
@@ -428,7 +420,6 @@ public class Transceiver extends UDPTransceiver
 		if (ignoredLinks != null) {
 			ignoreLinks.putAll(ignoredLinks);
 		}
-		this.maxCoreID = maxCoreID;
 		this.maxSDRAMSize = maxSDRAMSize;
 
 		originalConnections.addAll(connections);
@@ -465,7 +456,7 @@ public class Transceiver extends UDPTransceiver
 	public Transceiver(InetAddress hostname, MachineVersion version)
 			throws IOException, SpinnmanException, ProcessException {
 		this(hostname, version, null, 0, emptyList(), emptyMap(), emptyMap(),
-				null, false, null, null, null);
+				false, null, null, null);
 	}
 
 	/**
@@ -482,7 +473,7 @@ public class Transceiver extends UDPTransceiver
 	 */
 	public Transceiver(MachineVersion version)
 			throws IOException, SpinnmanException, ProcessException {
-		this(version, null, null, null, null, null, null, null);
+		this(version, null, null, null, null, null, null);
 	}
 
 	/**
@@ -505,7 +496,7 @@ public class Transceiver extends UDPTransceiver
 	public Transceiver(MachineVersion version,
 			Collection<Connection> connections)
 			throws IOException, SpinnmanException, ProcessException {
-		this(version, connections, null, null, null, null, null, null);
+		this(version, connections, null, null, null, null, null);
 	}
 
 	/**
@@ -524,8 +515,6 @@ public class Transceiver extends UDPTransceiver
 	 *            Blacklisted cores.
 	 * @param ignoredLinks
 	 *            Blacklisted links.
-	 * @param maxCoreID
-	 *            If not {@code null}, the maximum core ID to allow.
 	 * @param scampConnections
 	 *            Descriptions of SCP connections to create.
 	 * @param maxSDRAMSize
@@ -542,7 +531,6 @@ public class Transceiver extends UDPTransceiver
 			Collection<ChipLocation> ignoredChips,
 			Map<ChipLocation, Collection<Integer>> ignoredCores,
 			Map<ChipLocation, Collection<Direction>> ignoredLinks,
-			Integer maxCoreID,
 			Collection<ConnectionDescriptor> scampConnections,
 			Integer maxSDRAMSize)
 			throws IOException, SpinnmanException, ProcessException {
@@ -556,7 +544,6 @@ public class Transceiver extends UDPTransceiver
 		if (ignoredLinks != null) {
 			ignoreLinks.putAll(ignoredLinks);
 		}
-		this.maxCoreID = maxCoreID;
 		this.maxSDRAMSize = maxSDRAMSize;
 
 		if (connections == null) {
@@ -842,7 +829,7 @@ public class Transceiver extends UDPTransceiver
 
 		// Get the details of all the chips
 		machine = new GetMachineProcess(scpSelector, ignoreChips, ignoreCores,
-				ignoreLinks, maxCoreID, maxSDRAMSize, this)
+				ignoreLinks, maxSDRAMSize, this)
 						.getMachineDetails(versionInfo.core, dimensions);
 
 		/*

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -68,7 +68,7 @@ class TestTransceiver {
 		boardConfig.setUpRemoteBoard();
 		connections.add(new SCPConnection(boardConfig.remotehost));
 
-		try (Transceiver txrx = new Transceiver(FIVE, connections, null, null,
+		try (Transceiver txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
 			assertEquals(1, txrx.getConnections().size());
 		}
@@ -81,7 +81,7 @@ class TestTransceiver {
 		boardConfig.setUpRemoteBoard();
 		connections.add(new SCPConnection(boardConfig.remotehost));
 
-		try (Transceiver txrx = new Transceiver(FIVE, connections, null, null,
+		try (Transceiver txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
 			assertEquals(new HashSet<>(connections), txrx.getConnections());
 		}
@@ -97,7 +97,7 @@ class TestTransceiver {
 		boardConfig.setUpLocalVirtualBoard();
 		connections.add(new SCPConnection(boardConfig.remotehost));
 
-		try (Transceiver txrx = new Transceiver(FIVE, connections, null, null,
+		try (Transceiver txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
 			for (Connection c : txrx.getConnections()) {
 				assertTrue(connections.contains(c));
@@ -117,7 +117,7 @@ class TestTransceiver {
 		connections.add(
 				new BootConnection(null, null, boardConfig.remotehost, null));
 
-		try (Transceiver txrx = new Transceiver(FIVE, connections, null, null,
+		try (Transceiver txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
 			if (boardConfig.boardVersion.isFourChip) {
 				assertEquals(2, txrx.getMachineDimensions().width);
@@ -158,7 +158,7 @@ class TestTransceiver {
 		connections.add(orig);
 
 		// Create transceiver
-		try (Transceiver txrx = new Transceiver(FIVE, connections, null, null,
+		try (Transceiver txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
 			int port = orig.getLocalPort();
 			EIEIOConnectionFactory cf = new EIEIOConnectionFactory();
@@ -263,7 +263,7 @@ class MockWriteTransceiver extends Transceiver {
 			Collection<Connection> connections)
 			throws IOException, SpinnmanException,
 			uk.ac.manchester.spinnaker.transceiver.processes.ProcessException {
-		super(version, connections, null, null, null, null, null, null);
+		super(version, connections, null, null, null, null, null);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -370,7 +370,7 @@ public class TransceiverITCase {
 		try (Transceiver txrx =
 				new Transceiver(boardConfig.remotehost, boardConfig.boardVersion,
 						boardConfig.bmpNames, null, downChips, downCores, null,
-						null, boardConfig.autoDetectBMP, null, null, null)) {
+						boardConfig.autoDetectBMP, null, null, null)) {
 
 			section("Version Information", () -> boardReady(txrx));
 


### PR DESCRIPTION
We don't really need to pass around the maximum core ID; it's a fundamental property of the class of chips being used, not a feature that is particularly user-selectable.

This was something that (I think) @alan-stokes suggested.