### PR TITLE
fixes #222

### DIFF
--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/boot/TestMessage.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/boot/TestMessage.java
@@ -70,10 +70,9 @@ class TestMessage {
 		assertArrayEquals(expected, got);
 	}
 
-	private static final List<Integer> EXPECTED_SIZES = asList(18, 1042, 566);
+	private static final List<Integer> EXPECTED_SIZES = asList(18, 1042, 690);
 
-	// @Test
-    // https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues/222
+	@Test
 	void testBootMessagesSerialize() {
 		BootMessages bm = new BootMessages(FIVE);
 		for (BootMessage b : bm.getMessages().collect(Collectors.toList())) {


### PR DESCRIPTION
The SCAMP image has been updated (growing slightly), so the test that it serialized correctly also needed to be updated. Oops.