### PR TITLE
Ignore startAddress when reading specs from DB

### DIFF
--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
@@ -125,8 +125,8 @@ abstract class SQL {
 	@ResultColumns({"core_id", "x", "y", "processor", "app_id"})
 	static final String LIST_CORES_TO_LOAD =
 			"SELECT core_id, x, y, processor, app_id FROM core_view "
-					+ "WHERE ethernet_id = ? AND start_address IS NULL AND "
-					+ "app_id IS NOT NULL AND content IS NOT NULL";
+					+ "WHERE ethernet_id = ? AND app_id IS NOT NULL "
+					+ "AND content IS NOT NULL";
 
 	/** Get the data specification to run for a particular core. */
 	@Parameters("core_id")


### PR DESCRIPTION
Remove support for restarting the evaluation and uploading of data specs; we never used it, and it just caused confusion in the Python side of things.

fixes #217 
