### PR TITLE
Fixes fast data in

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
@@ -32,8 +32,8 @@ public interface SCPReceiver extends SocketHolder {
 	 * been received, or a timeout occurs.
 	 *
 	 * @param timeout
-	 *            The time in seconds to wait for the message to arrive; if not
-	 *            specified, will wait forever, or until the connection is
+	 *            The time in milliseconds to wait for the message to arrive; if
+	 *            {@code null}, will wait forever, or until the connection is
 	 *            closed.
 	 * @return The SCP result, the sequence number, and the data of the
 	 *         response. The buffer pointer will be positioned at the point

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -56,7 +56,7 @@ public class ThrottledConnection implements Closeable {
 	public static final int THROTTLE_NS = 35000;
 	/** The {@link #receive()} timeout, in milliseconds. */
 	private static final int TIMEOUT_MS = 1000;
-	private static final int IPTAG_REPROGRAM_TIMEOUT = 1;
+	private static final int IPTAG_REPROGRAM_TIMEOUT = 1000;
 	private static final int IPTAG_REPROGRAM_ATTEMPTS = 3;
 
 	private final ChipLocation location;


### PR DESCRIPTION
This stops the code that sets the tag for fast data in communications from hammering SCAMP (which was happening because I'd mis-documented the `SCPReceiver` implementation, which was a copy-and-paste-from-Python error). That hammering was pushing SCAMP into a strange state, and was triggering the later failures.

Also copy some more constant naming from Python and how to reset boards' timeout schemes.