### PR TITLE
Logging tweaking

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -586,7 +586,8 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 			ra = getRemoteAddress();
 		} catch (IOException ignore) {
 		}
-		return String.format("%s(%s <--> %s)",
-				getClass().getSimpleName().replaceAll("^.*\\.", ""), la, ra);
+		return String.format("%s(%s <-%s-> %s)",
+				getClass().getSimpleName().replaceAll("^.*\\.", ""), la,
+				isClosed() ? "|" : "", ra);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -18,6 +18,7 @@ package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;
 import static java.util.stream.IntStream.range;
+import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;
 import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.BYTE_SHIFT;
 import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
@@ -28,6 +29,9 @@ import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.USE_
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
@@ -39,6 +43,9 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * @see ReverseIPTagSet
  */
 public class IPTagSet extends SCPRequest<CheckOKResponse> {
+	private static final Logger log = getLogger(IPTagSet.class);
+	private static final byte[] INADDR_ANY = new byte[4];
+
 	/**
 	 * @param chip
 	 *            The chip to set the tag on.
@@ -57,6 +64,9 @@ public class IPTagSet extends SCPRequest<CheckOKResponse> {
 			boolean strip, boolean useSender) {
 		super(chip.getScampCore(), CMD_IPTAG, argument1(tag, strip, useSender),
 				argument2(port), argument3(host));
+		if (useSender && !Arrays.equals(host, INADDR_ANY)) {
+			log.warn("IPTag has real host address but useSender was true");
+		}
 	}
 
 	private static int argument1(int tag, boolean strip, boolean useSender) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -44,13 +44,15 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  */
 public class IPTagSet extends SCPRequest<CheckOKResponse> {
 	private static final Logger log = getLogger(IPTagSet.class);
-	private static final byte[] INADDR_ANY = new byte[4];
+	private static final int INADDRSZ = 4;;
+	private static final byte[] INADDR_ANY = new byte[INADDRSZ];
 
 	/**
 	 * @param chip
 	 *            The chip to set the tag on.
 	 * @param host
-	 *            The host address, as an array of 4 bytes.
+	 *            The host address, as an array of 4 bytes. May be {@code null}
+	 *            to use the ANY address.
 	 * @param port
 	 *            The port, between 0 and 65535
 	 * @param tag
@@ -64,7 +66,7 @@ public class IPTagSet extends SCPRequest<CheckOKResponse> {
 			boolean strip, boolean useSender) {
 		super(chip.getScampCore(), CMD_IPTAG, argument1(tag, strip, useSender),
 				argument2(port), argument3(host));
-		if (useSender && !Arrays.equals(host, INADDR_ANY)) {
+		if (useSender && host != null && !Arrays.equals(host, INADDR_ANY)) {
 			log.warn("IPTag has real host address but useSender was true");
 		}
 	}
@@ -80,6 +82,9 @@ public class IPTagSet extends SCPRequest<CheckOKResponse> {
 	}
 
 	private static int argument3(byte[] host) {
+		if (host == null) {
+			return 0;
+		}
 		return range(0, host.length)
 				.map(i -> toUnsignedInt(host[host.length - 1 - i]))
 				.reduce(0, (i, j) -> (i << BYTE_SHIFT) | j);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1894,16 +1894,22 @@ public class Transceiver extends UDPTransceiver
 		}
 
 		for (SCPConnection connection : connections) {
-			// Convert the host string
-			InetAddress host = tag.getIPAddress();
-			if (host == null || host.isAnyLocalAddress()
-					|| host.isLoopbackAddress()) {
-				host = connection.getLocalIPAddress();
-			}
+			IPTagSet tagSet;
 
-			simpleProcess().execute(new IPTagSet(connection.getChip(),
-					host.getAddress(), tag.getPort(), tag.getTag(),
-					tag.isStripSDP(), useSender));
+			if (useSender) {
+				tagSet = new IPTagSet(connection.getChip(), new byte[4], 0,
+						tag.getTag(), tag.isStripSDP(), true);
+			} else {
+				// Convert the host string
+				InetAddress host = tag.getIPAddress();
+				if (host == null || host.isAnyLocalAddress()
+						|| host.isLoopbackAddress()) {
+					host = connection.getLocalIPAddress();
+				}
+				tagSet = new IPTagSet(connection.getChip(), host.getAddress(),
+						tag.getPort(), tag.getTag(), tag.isStripSDP(), false);
+			}
+			simpleProcess().execute(tagSet);
 		}
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1897,7 +1897,7 @@ public class Transceiver extends UDPTransceiver
 			IPTagSet tagSet;
 
 			if (useSender) {
-				tagSet = new IPTagSet(connection.getChip(), new byte[4], 0,
+				tagSet = new IPTagSet(connection.getChip(), null, 0,
 						tag.getTag(), tag.isStripSDP(), true);
 			} else {
 				// Convert the host string

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
@@ -181,7 +181,7 @@ class Functions implements FunctionAPI {
                     + " but needs to be in 0 to " + (memorySpace - 1)
                     + " (inclusive)");
 		}
-		memRegions.set(region, new MemoryRegion(0, unfilled, size));
+		memRegions.set(new MemoryRegion(region, 0, unfilled, size));
 		spaceAllocated += size;
 	}
 

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
@@ -41,10 +41,14 @@ public class MemoryRegion {
 	private boolean unfilled;
 	/** The base address of the region. Set after the fact. */
 	private int regionBaseAddress;
+	/** The index of the memory region. */
+	private final int index;
 
 	/**
 	 * Create a memory region.
 	 *
+	 * @param index
+	 *            the index of the memory region
 	 * @param memoryPointer
 	 *            where the start of the block is
 	 * @param unfilled
@@ -52,7 +56,9 @@ public class MemoryRegion {
 	 * @param size
 	 *            the allocated size of the memory region
 	 */
-	public MemoryRegion(int memoryPointer, boolean unfilled, int size) {
+	public MemoryRegion(int index, int memoryPointer, boolean unfilled,
+			int size) {
+		this.index = index;
 		memPointer = memoryPointer;
 		maxWritePointer = 0;
 		regionBaseAddress = 0;
@@ -100,6 +106,10 @@ public class MemoryRegion {
 		return maxWritePointer;
 	}
 
+	/** @return the index of the memory region */
+	public int getIndex() {
+		return index;
+	}
 	/**
 	 * Set the write pointer. The write pointer is where the next block of data
 	 * to be written will actually be written.

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionCollection.java
@@ -33,7 +33,7 @@ import uk.ac.manchester.spinnaker.data_spec.exceptions.RegionInUseException;
 /**
  * A collection of memory regions. Note that the collection cannot be modified
  * by the standard collection API; those modification operations will fail. The
- * {@link #set(int,MemoryRegion) set(...)} operation works.
+ * {@link #set(MemoryRegion) set(...)} operation works.
  *
  * @author Donal Fellows
  */
@@ -75,19 +75,17 @@ public final class MemoryRegionCollection implements Collection<MemoryRegion> {
 	/**
 	 * Set the region with the given ID.
 	 *
-	 * @param regionID
-	 *            The region ID to set. Must not be {@code null}.
 	 * @param region
-	 *            The region to store.
+	 *            The region to store. Regions know their ID/index.
 	 * @throws RegionInUseException
 	 *             if the region has already been set to a non-empty region.
 	 */
-	public void set(int regionID, MemoryRegion region)
+	public void set(MemoryRegion region)
 			throws RegionInUseException {
-		if (!isEmpty(regionID)) {
-			throw new RegionInUseException(regionID);
+		if (!isEmpty(region.getIndex())) {
+			throw new RegionInUseException(region.getIndex());
 		}
-		regions[regionID] =
+		regions[region.getIndex()] =
             requireNonNull(region, "must not set an empty region");
 	}
 

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegion.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegion.java
@@ -24,18 +24,19 @@ class TestMemoryRegion {
 
 	@Test
 	void test() {
-		MemoryRegion r = new MemoryRegion(123, false, 5);
+		MemoryRegion r = new MemoryRegion(77, 123, false, 5);
+		assertEquals(77, r.getIndex());
 		assertEquals(123, r.getMemoryPointer());
 		assertEquals(5, r.getAllocatedSize());
 		assertFalse(r.isUnfilled());
 		assertEquals(5, r.getRemainingSpace());
 		assertEquals(0, r.getWritePointer());
 		r.writeIntoRegionData(new byte[] {1, 2, 3, 4});
+		assertEquals(77, r.getIndex());
 		assertEquals(123, r.getMemoryPointer());
 		assertEquals(5, r.getAllocatedSize());
 		assertFalse(r.isUnfilled());
 		assertEquals(1, r.getRemainingSpace());
 		assertEquals(4, r.getWritePointer());
 	}
-
 }

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
@@ -47,9 +47,9 @@ class TestMemoryRegionCollection {
 		assertEquals(1, c.size());
 		assertFalse(c.isEmpty());
 		assertTrue(new MemoryRegionCollection(0).isEmpty());
-		MemoryRegion mr = new MemoryRegion(123, false, 5);
-		c.set(0, mr);
-		assertThrows(RegionInUseException.class, () -> c.set(0, mr));
+		MemoryRegion mr = new MemoryRegion(0, 123, false, 5);
+		c.set(mr);
+		assertThrows(RegionInUseException.class, () -> c.set(mr));
 		assertFalse(c.isEmpty(0));
 		assertFalse(c.isUnfilled(0));
 		assertEquals(5, c.getSize(0));
@@ -58,32 +58,32 @@ class TestMemoryRegionCollection {
 		assertTrue(c.contains(mr));
 		assertTrue(c.containsAll(Collections.singleton(mr)));
 		assertArrayEquals(new MemoryRegion[] {
-				mr
+			mr
 		}, c.toArray(new MemoryRegion[0]));
 		assertArrayEquals(new MemoryRegion[] {
-				mr
+			mr
 		}, c.toArray(new MemoryRegion[1]));
 		assertArrayEquals(new Object[] {
-				mr
+			mr
 		}, c.toArray());
 	}
 
 	@Test
 	void testMultiRegions() throws RegionInUseException {
 		MemoryRegionCollection c = new MemoryRegionCollection(6);
-		MemoryRegion mr1 = new MemoryRegion(123, true, 5);
-		MemoryRegion mr2 = new MemoryRegion(123, false, 7);
-		c.set(2, mr1);
-		c.set(4, mr2);
+		MemoryRegion mr1 = new MemoryRegion(2, 123, true, 5);
+		MemoryRegion mr2 = new MemoryRegion(4, 123, false, 7);
+		c.set(mr1);
+		c.set(mr2);
 		assertTrue(c.needsToWriteRegion(1));
 		assertFalse(c.needsToWriteRegion(5));
 		assertEquals(6, c.size());
 		c.spliterator();
 		assertArrayEquals(new Object[] {
-				null, null, mr1, null, mr2, null, null
+			null, null, mr1, null, mr2, null, null
 		}, c.toArray(new Object[7]));
 		assertFalse(c.containsAll(
-				Arrays.asList(mr1, mr2, new MemoryRegion(123, true, 123))));
+				Arrays.asList(mr1, mr2, new MemoryRegion(5, 123, true, 123))));
 		assertThrows(IllegalArgumentException.class,
 				() -> c.needsToWriteRegion(6));
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.spinnaker.front_end;
 import static org.apache.log4j.Logger.getRootLogger;
 
 import java.io.File;
+import java.util.concurrent.Executor;
 
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
@@ -39,6 +40,7 @@ public abstract class LogControl {
 	private static final String PARALLEL_LOGGER_NAME = "parallog";
 	private static final String LOGGING_LEVEL_NAME = "logging.level";
 	private static final String UDP_LOGGING = "logging.udp";
+	private static final String EXECUTOR_LOGGING = "logging.executor";
 
 	private LogControl() {
 	}
@@ -70,6 +72,9 @@ public abstract class LogControl {
 
 		if (System.getProperty(UDP_LOGGING) != null) {
 			Logger.getLogger(UDPConnection.class).setLevel(Level.DEBUG);
+		}
+		if (System.getProperty(EXECUTOR_LOGGING) != null) {
+			Logger.getLogger(Executor.class).setLevel(Level.DEBUG);
 		}
 	}
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
@@ -82,9 +82,10 @@ public class NoDropPacketContext implements AutoCloseable {
 		CoreLocation firstCore = monitorCores.iterator().next();
 		firstChip = firstCore.asChipLocation();
 		lastStatus = txrx.getReinjectionStatus(firstCore);
-		log.info("switching board at {} to non-drop mode (saved status: {})",
-				firstChip, lastStatus);
-		log.info("will switch {} cores", monitorCores.size());
+		log.info(
+				"switching board at {} ({} monitor cores) to "
+						+ "non-drop mode (saved status: {})",
+				firstChip, monitorCores.size(), lastStatus);
 		try {
 			// Set to not inject dropped packets
 			txrx.setReinjection(monitorCores, false);
@@ -172,7 +173,7 @@ public class NoDropPacketContext implements AutoCloseable {
 			txrx.setReinjectionTimeout(monitorCores, lastStatus);
 			txrx.setReinjectionEmergencyTimeout(monitorCores, lastStatus);
 			txrx.setReinjection(monitorCores, lastStatus);
-			log.info("switched board at {} to standard mode", firstChip);
+			log.debug("switched board at {} to standard mode", firstChip);
 			return;
 		} catch (Exception e) {
 			log.error("error resetting router timeouts", e);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
@@ -84,13 +84,20 @@ public class NoDropPacketContext implements AutoCloseable {
 		lastStatus = txrx.getReinjectionStatus(firstCore);
 		log.info("switching board at {} to non-drop mode (saved status: {})",
 				firstChip, lastStatus);
-		// Set to not inject dropped packets
-		txrx.setReinjection(monitorCores, false);
-		// Clear any outstanding packets from reinjection
-		txrx.clearReinjectionQueues(monitorCores);
-		// Set time outs
-		txrx.setReinjectionEmergencyTimeout(monitorCores, SHORT_TIMEOUT);
-		txrx.setReinjectionTimeout(monitorCores, LONG_TIMEOUT);
+		log.info("will switch {} cores", monitorCores.size());
+		try {
+			// Set to not inject dropped packets
+			txrx.setReinjection(monitorCores, false);
+			// Clear any outstanding packets from reinjection
+			txrx.clearReinjectionQueues(monitorCores);
+			// Set time outs
+			txrx.setReinjectionEmergencyTimeout(monitorCores, SHORT_TIMEOUT);
+			txrx.setReinjectionTimeout(monitorCores, LONG_TIMEOUT);
+		} catch (IOException | ProcessException e) {
+			log.error("failed to switch board at {} to non-drop mode",
+					firstChip, e);
+			throw e;
+		}
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionsDescriptor.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionsDescriptor.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.lang.Integer.toHexString;
+import static java.lang.Long.toHexString;
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
 import java.io.IOException;
@@ -81,8 +82,9 @@ final class RecordingRegionsDescriptor {
 			long address) throws IOException, ProcessException {
 		// Read the descriptor from SpiNNaker
 		int nr = txrx.readMemory(chip, address, WORD_SIZE).getInt();
-		RecordingRegionDataGatherer.log.info("{} recording regions at {} of {}",
-				nr, address, chip);
+		RecordingRegionDataGatherer.log.info(
+				"{} recording regions at 0x{} of {}", nr, toHexString(address),
+				chip);
 		int size = WORD_SIZE * (REGION_POINTERS_START + 2 * nr);
 		ByteBuffer buffer = txrx.readMemory(chip, address, size);
 		this.chip = chip.asChipLocation();

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -281,7 +281,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 	 *             If IO fails.
 	 */
 	public synchronized void writeReport(HasChipLocation chip, long timeDiff,
-			int size, int baseAddress, List<?> missingNumbers)
+			int size, int baseAddress, Object missingNumbers)
 			throws IOException {
 		if (!reportPath.exists()) {
 			try (PrintWriter w = open(reportPath, false)) {
@@ -423,7 +423,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				int start = malloc(ctl, size);
 				log.info(
 						"generated {} bytes to load onto {} into memory "
-								+ "starting at {}",
+								+ "starting at 0x{}",
 						size, ctl.core, toHexString(toUnsignedLong(start)));
 				int written = writeHeader(ctl.core, executor, start);
 
@@ -529,9 +529,13 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				fastWrite(core, baseAddress, data);
 			}
 			long end = nanoTime();
-			if (writeReports && written >= VERY_SMALL_WRITE_THRESHOLD) {
+			if (writeReports) {
+				Object detail = missingSequenceNumbers;
+				if (written < VERY_SMALL_WRITE_THRESHOLD) {
+					detail = "written via SCP";
+				}
 				writeReport(core, end - start, data.limit(), baseAddress,
-						missingSequenceNumbers);
+						detail);
 			}
 			missingSequenceNumbers = null;
 			return written;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -703,7 +703,6 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 						haveMissing = false;
 						if (seqNums == null) {
 							log.info("full timeout; resending initial packets");
-							connection.restart();
 							continue outerLoop;
 						}
 						retransmitMissingPackets(protocol, data, seqNums);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.front_end.dse;
 
+import static java.lang.Integer.toUnsignedLong;
+import static java.lang.Long.toHexString;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -199,7 +201,6 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 		try (BoardLocal c = new BoardLocal(board.location)) {
 			BoardWorker worker = new BoardWorker(board, storage, bar);
 			for (CoreToLoad ctl : storage.listCoresToLoad(board)) {
-				log.info("loading data onto {}", ctl.core);
 				worker.loadCore(ctl);
 			}
 		}
@@ -211,7 +212,6 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 		try (BoardLocal c = new BoardLocal(board.location)) {
 			BoardWorker worker = new BoardWorker(board, storage, bar);
 			for (CoreToLoad ctl : storage.listCoresToLoad(board, system)) {
-				log.info("loading data onto {}", ctl.core);
 				worker.loadCore(ctl);
 			}
 		}
@@ -271,6 +271,9 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 				executor.execute();
 				int size = executor.getConstructedDataSize();
 				int start = malloc(ctl, size);
+				log.info("loading data onto {} ({} bytes at 0x{})",
+						ctl.core.asChipLocation(), toUnsignedLong(size),
+						toHexString(toUnsignedLong(start)));
 				int written = writeHeader(ctl.core, executor, start);
 
 				for (MemoryRegion r : executor.regions()) {
@@ -285,7 +288,7 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 				storage.saveLoadingMetadata(ctl, start, size, written);
 			} catch (DataSpecificationException e) {
 				throw new DataSpecificationException(
-						"failed to execute data specification on core "
+						"failed to execute data specification for core "
 								+ ctl.core + " of board " + board.location
 								+ " (" + board.ethernetAddress + ")",
 						e);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/SystemRouterTableContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/SystemRouterTableContext.java
@@ -64,8 +64,15 @@ public class SystemRouterTableContext implements AutoCloseable {
 
 		log.info("switching multicast routing on board at {} to system mode",
 				firstChip);
-		txrx.saveApplicationRouterTables(monitorCores);
-		txrx.loadSystemRouterTables(monitorCores);
+		log.info("will switch {} cores", monitorCores.size());
+		try {
+			txrx.saveApplicationRouterTables(monitorCores);
+			txrx.loadSystemRouterTables(monitorCores);
+		} catch (IOException | ProcessException e) {
+			log.error("failed to switch multicast routing on {} to system",
+					firstChip, e);
+			throw e;
+		}
 	}
 
 	/**
@@ -137,8 +144,9 @@ public class SystemRouterTableContext implements AutoCloseable {
 
 		try {
 			txrx.loadApplicationRouterTables(monitorCores);
-		} catch (Exception e) {
+		} catch (IOException | ProcessException e) {
 			log.error("error restoring multicast router tables", e);
+			throw e;
 		}
 	}
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -68,6 +68,8 @@ public class ThrottledConnection implements Closeable {
 	/** In milliseconds. */
 	private static final int IPTAG_INTERATTEMPT_DELAY = 50;
 	private static final ScheduledExecutorService CLOSER;
+	private static final byte[] INADDR_ANY = new byte[4];
+	private static final int ANY_PORT = 0;
 	static {
 		CLOSER = newSingleThreadScheduledExecutor(r -> {
 			Thread t = new Thread(r, "ThrottledConnection.Closer");
@@ -126,9 +128,8 @@ public class ThrottledConnection implements Closeable {
 	 */
 	public void reprogramTag(IPTag iptag)
 			throws IOException, UnexpectedResponseCodeException {
-		IPTagSet tagSet = new IPTagSet(location,
-				connection.getLocalIPAddress().getAddress(),
-				connection.getLocalPort(), iptag.getTag(), true, true);
+		IPTagSet tagSet = new IPTagSet(location, INADDR_ANY, ANY_PORT,
+				iptag.getTag(), true, true);
 		log.info("reprogramming tag #{} to point to {}:{}", iptag.getTag(),
 				connection.getLocalIPAddress(), connection.getLocalPort());
 		tagSet.scpRequestHeader.issueSequenceNumber(emptySet());

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -67,8 +67,6 @@ public class ThrottledConnection implements Closeable {
 	private static final int IPTAG_REPROGRAM_ATTEMPTS = 3;
 	/** In milliseconds. */
 	private static final int IPTAG_INTERATTEMPT_DELAY = 50;
-	/** Lets the OS have time to close down a socket. In milliseconds. */
-	private static final int SOCKET_RESTART_SLEEP = 50;
 	private static final ScheduledExecutorService CLOSER;
 	static {
 		CLOSER = newSingleThreadScheduledExecutor(r -> {
@@ -160,27 +158,6 @@ public class ThrottledConnection implements Closeable {
 		if (e != null) {
 			throw e;
 		}
-	}
-
-	/**
-	 * Shut down and reopen the connection. It sometimes unsticks things
-	 * apparently.
-	 *
-	 * @throws IOException
-	 *             If IO fails
-	 */
-	public void restart() throws IOException {
-		log.info("restarting UDP connection");
-		InetAddress localAddr = connection.getLocalIPAddress();
-		int localPort = connection.getLocalPort();
-		connection.close();
-		try {
-			sleep(SOCKET_RESTART_SLEEP);
-		} catch (InterruptedException ignore) {
-			log.debug("interrupted while sleeping");
-		}
-		connection = new SCPConnection(location, localAddr, localPort, addr,
-				SCP_SCAMP_PORT);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -68,7 +68,6 @@ public class ThrottledConnection implements Closeable {
 	/** In milliseconds. */
 	private static final int IPTAG_INTERATTEMPT_DELAY = 50;
 	private static final ScheduledExecutorService CLOSER;
-	private static final byte[] INADDR_ANY = new byte[4];
 	private static final int ANY_PORT = 0;
 	static {
 		CLOSER = newSingleThreadScheduledExecutor(r -> {
@@ -128,8 +127,8 @@ public class ThrottledConnection implements Closeable {
 	 */
 	public void reprogramTag(IPTag iptag)
 			throws IOException, UnexpectedResponseCodeException {
-		IPTagSet tagSet = new IPTagSet(location, INADDR_ANY, ANY_PORT,
-				iptag.getTag(), true, true);
+		IPTagSet tagSet = new IPTagSet(location, null, ANY_PORT, iptag.getTag(),
+				true, true);
 		log.info("reprogramming tag #{} to point to {}:{}", iptag.getTag(),
 				connection.getLocalIPAddress(), connection.getLocalPort());
 		tagSet.scpRequestHeader.issueSequenceNumber(emptySet());

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -57,7 +57,7 @@ import uk.ac.manchester.spinnaker.storage.DSEStorage.Ethernet;
 public class ThrottledConnection implements Closeable {
 	private static final Logger log = getLogger(ThrottledConnection.class);
 	/** The minimum interval between messages, in <em>nanoseconds</em>. */
-	public static final int THROTTLE_NS = 35000;
+	public static final int THROTTLE_NS = 410000;
 	/** The {@link #receive()} timeout, in milliseconds. */
 	private static final int TIMEOUT_MS = 1000;
 	private static final int IPTAG_REPROGRAM_TIMEOUT = 1000;
@@ -65,15 +65,20 @@ public class ThrottledConnection implements Closeable {
 	private static final int IPTAG_INTERATTEMPT_DELAY = 50;
 	private static final ScheduledExecutorService CLOSER =
 			newSingleThreadScheduledExecutor(r -> {
-				Thread t = new Thread(r);
+				Thread t = new Thread(r, "ThrottledConnection.Closer");
 				t.setDaemon(true);
 				return t;
 			});
+	static {
+		log.info("inter-message minimum time set to {}us",
+				THROTTLE_NS / 1000.0);
+	}
 
 	private final ChipLocation location;
 	private final InetAddress addr;
 	private SCPConnection connection;
 	private long lastSend;
+	private int throttleFactor = 1;
 
 	/**
 	 * Create a throttled connection for talking to a board.
@@ -184,9 +189,10 @@ public class ThrottledConnection implements Closeable {
 					.mapToObj(i -> hexbyte(payload.get(i))).collect(toList()));
 		}
 		long waited = nanoTime() - lastSend;
-		if (waited < THROTTLE_NS) {
+		long delay = THROTTLE_NS * throttleFactor;
+		if (waited < delay) {
 			// BUSY LOOP! https://stackoverflow.com/q/11498585/301832
-			while (nanoTime() - lastSend < THROTTLE_NS) {
+			while (nanoTime() - lastSend < delay) {
 				// Make the loop slightly less heavy
 				yield();
 			}
@@ -207,5 +213,12 @@ public class ThrottledConnection implements Closeable {
 				log.warn("failed to close connection", e);
 			}
 		}, 1, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Increase the amount of time required for the inter-message throttling.
+	 */
+	public void increaseThrottleDelay() {
+		throttleFactor++;
 	}
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -67,6 +67,8 @@ public class ThrottledConnection implements Closeable {
 	private static final int IPTAG_REPROGRAM_ATTEMPTS = 3;
 	/** In milliseconds. */
 	private static final int IPTAG_INTERATTEMPT_DELAY = 50;
+	/** Lets the OS have time to close down a socket. In milliseconds. */
+	private static final int SOCKET_RESTART_SLEEP = 50;
 	private static final ScheduledExecutorService CLOSER;
 	static {
 		CLOSER = newSingleThreadScheduledExecutor(r -> {
@@ -172,6 +174,11 @@ public class ThrottledConnection implements Closeable {
 		InetAddress localAddr = connection.getLocalIPAddress();
 		int localPort = connection.getLocalPort();
 		connection.close();
+		try {
+			sleep(SOCKET_RESTART_SLEEP);
+		} catch (InterruptedException ignore) {
+			log.debug("interrupted while sleeping");
+		}
 		connection = new SCPConnection(location, localAddr, localPort, addr,
 				SCP_SCAMP_PORT);
 	}

--- a/SpiNNaker-front-end/src/main/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/main/resources/log4j.properties
@@ -37,7 +37,7 @@ log4j.appender.tofile.file=initial.log
 log4j.appender.tofile.threshold=${logging.level}
 log4j.appender.tofile.layout=org.apache.log4j.PatternLayout
 log4j.appender.tofile.layout.ConversionPattern=\
-	%d{HH:mm:ss} %-5p %C{1}:%L - %m%n
+	%d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Special logger that handles gatherer thread contexts
 log4j.appender.parallog=org.apache.log4j.FileAppender
@@ -46,7 +46,7 @@ log4j.appender.parallog.file=initial.log
 log4j.appender.parallog.threshold=${logging.level}
 log4j.appender.parallog.layout=org.apache.log4j.PatternLayout
 log4j.appender.parallog.layout.ConversionPattern=\
-    %d{HH:mm:ss.SSS} %p %C{1}:%L %X{boardRoot} %m%n
+    %d{HH:mm:ss.SSS} %p %c{1}:%L %X{boardRoot} %m%n
 
 # Errors go to stdout in abbreviated form
 log4j.appender.con=org.apache.log4j.ConsoleAppender

--- a/SpiNNaker-front-end/src/main/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/main/resources/log4j.properties
@@ -24,6 +24,9 @@ log4j.additivity.uk.ac.manchester.spinnaker.front_end.download.RecordingRegionDa
 log4j.logger.uk.ac.manchester.spinnaker.front_end.dse.FastExecuteDataSpecification=\
 	DEBUG, parallog, con
 log4j.additivity.uk.ac.manchester.spinnaker.front_end.dse.FastExecuteDataSpecification=false
+log4j.logger.uk.ac.manchester.spinnaker.front_end.dse.HostExecuteDataSpecification=\
+	DEBUG, parallog, con
+log4j.additivity.uk.ac.manchester.spinnaker.front_end.dse.HostExecuteDataSpecification=false
 # See https://stackoverflow.com/q/19788839/301832 for how this configuration
 # works. The tail of the property name must match the full class name.
 log4j.logger.uk.ac.manchester.spinnaker.connections.UDPConnection=\
@@ -37,7 +40,7 @@ log4j.appender.tofile.file=initial.log
 log4j.appender.tofile.threshold=${logging.level}
 log4j.appender.tofile.layout=org.apache.log4j.PatternLayout
 log4j.appender.tofile.layout.ConversionPattern=\
-	%d{HH:mm:ss} %-5p %c{1}:%L - %m%n
+	%d{HH:mm:ss.SSS} %-5p %c{1}:%L - %m%n
 
 # Special logger that handles gatherer thread contexts
 log4j.appender.parallog=org.apache.log4j.FileAppender
@@ -46,7 +49,7 @@ log4j.appender.parallog.file=initial.log
 log4j.appender.parallog.threshold=${logging.level}
 log4j.appender.parallog.layout=org.apache.log4j.PatternLayout
 log4j.appender.parallog.layout.ConversionPattern=\
-    %d{HH:mm:ss.SSS} %p %c{1}:%L %X{boardRoot} %m%n
+    %d{HH:mm:ss.SSS} %-5p %c{1}:%L %X{boardRoot} %m%n
 
 # Errors go to stdout in abbreviated form
 log4j.appender.con=org.apache.log4j.ConsoleAppender

--- a/SpiNNaker-front-end/src/main/resources/log4j.properties
+++ b/SpiNNaker-front-end/src/main/resources/log4j.properties
@@ -29,9 +29,8 @@ log4j.logger.uk.ac.manchester.spinnaker.front_end.dse.HostExecuteDataSpecificati
 log4j.additivity.uk.ac.manchester.spinnaker.front_end.dse.HostExecuteDataSpecification=false
 # See https://stackoverflow.com/q/19788839/301832 for how this configuration
 # works. The tail of the property name must match the full class name.
-log4j.logger.uk.ac.manchester.spinnaker.connections.UDPConnection=\
-	INFO, tofile
-log4j.additivity.uk.ac.manchester.spinnaker.connections.UDPConnection=false
+log4j.logger.uk.ac.manchester.spinnaker.connections.UDPConnection=INFO
+log4j.logger.uk.ac.manchester.spinnaker.data_spec.Executor=INFO
 
 # Direct log messages to file
 log4j.appender.tofile=org.apache.log4j.FileAppender
@@ -42,7 +41,7 @@ log4j.appender.tofile.layout=org.apache.log4j.PatternLayout
 log4j.appender.tofile.layout.ConversionPattern=\
 	%d{HH:mm:ss.SSS} %-5p %c{1}:%L - %m%n
 
-# Special logger that handles gatherer thread contexts
+# Special logger that handles board-specific thread contexts
 log4j.appender.parallog=org.apache.log4j.FileAppender
 log4j.appender.parallog.append=true
 log4j.appender.parallog.file=initial.log

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/UnitConstants.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/UnitConstants.java
@@ -45,6 +45,9 @@ public final class UnitConstants {
     /** The number of minute per hour. */
 	public static final int MINUTE_PER_HOUR = 60;
 
+	/** The number of nanoseconds per microsecond. */
+	public static final double NSEC_PER_USEC = 1000.0;
+
     /**
      * Formats a Duration with hours, minutes seconds and milliseconds
      *      as required.


### PR DESCRIPTION
Tunes the logging and turns down the inter-message throttle period to 35µs, allowing machine-bound data transfers to reach about 45Mbps over the campus network.

Minor changes:
* made regions know their index (for better logging in DSE)
* adjusted report format to be a TSV (tab-separated values) file, which spreadsheets can consume natively
* shuffled file transfers so that, _for a particular core's regions_, all the transfers by SCP are done before any of the ones by Fast Data In. Improves the logging slightly.
* delay closing of sockets in some cases so that different boards are more clearly separated.
* added a new system property (`logging.executor`) that turns on a very verbose set of DEBUG-level logging when set (to anything). You probably aren't interested in logging at that level; I know I'm not (usually)!