### PR TITLE
Better error message

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
@@ -54,8 +54,9 @@ public enum FastDataInCommandID {
 	 *
 	 * @param value
 	 *            The protocol ID
-	 * @return The matching constant, or {@code null} if the value is
-	 *         unrecognised.
+	 * @return The matching constant.
+	 * @throws IllegalArgumentException
+	 *             if the value isn't one of the ones accepted by this class.
 	 */
 	public static FastDataInCommandID forValue(int value) {
 		if (MAP.isEmpty()) {
@@ -63,6 +64,11 @@ public enum FastDataInCommandID {
 				MAP.put(c.value, c);
 			}
 		}
-		return MAP.get(value);
+		FastDataInCommandID id = MAP.get(value);
+		if (id == null) {
+			throw new IllegalArgumentException(
+					"unexpected command code: " + value);
+		}
+		return id;
 	}
 }


### PR DESCRIPTION
Produce a better error message when things go completely wrong at the protocol level (because of random weird stuff in the hardware?). This is because `NullPointerException` is particularly cryptic, whereas `IllegalArgumentException` is more informative (but still not very; can't be helped).