### PR TITLE
Allow SCP timeouts to be overridden

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.connections;
 
+import static java.lang.Integer.getInteger;
 import static java.lang.Short.toUnsignedInt;
 import static java.lang.String.format;
 import static java.lang.System.nanoTime;
@@ -24,7 +25,7 @@ import static java.lang.Thread.yield;
 import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;
+import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT_DEFAULT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
 
 import java.io.IOException;
@@ -63,6 +64,12 @@ import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
  * @author Donal Fellows
  */
 public class SCPRequestPipeline {
+	/**
+	 * The name of a <em>system property</em> that can override the default
+	 * timeouts. If specified as an integer, it gives the number of milliseconds
+	 * to wait before timing out a communication.
+	 */
+	private static final String TIMEOUT_PROPERTY = "spinnaker.scp_timeout";
 	private static final Logger log = getLogger(SCPRequestPipeline.class);
 	/** The default number of requests to send before checking for responses. */
 	public static final int DEFAULT_NUM_CHANNELS = 1;
@@ -85,6 +92,12 @@ public class SCPRequestPipeline {
 	 * Packet minimum send interval, in <em>nanoseconds</em>.
 	 */
 	private static final int INTER_SEND_INTERVAL_NS = 60000;
+	/** The default for the timeout (in ms). */
+	public static final int SCP_TIMEOUT;
+
+	static {
+		SCP_TIMEOUT = getInteger(TIMEOUT_PROPERTY, SCP_TIMEOUT_DEFAULT);
+	}
 
 	/** The connection over which the communication is to take place. */
 	private SCPConnection connection;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
@@ -81,7 +81,7 @@ public abstract class Constants {
 	/** Time to sleep after powering on boards (in seconds). */
 	public static final double BMP_POST_POWER_ON_SLEEP_TIME = 5.0;
 	/** This is the default timeout when using SCP, in milliseconds. */
-	public static final int SCP_TIMEOUT = 1000;
+	public static final int SCP_TIMEOUT_DEFAULT = 1000;
 
 	/** Number of bytes in a SpiNNaker word. */
 	public static final int WORD_SIZE = 4;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
+
 import java.io.IOException;
 
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
@@ -42,7 +44,7 @@ public class ApplicationRunProcess
 	public ApplicationRunProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			RetryTracker retryTracker) {
-		super(connectionSelector, DEFAULT_NUM_RETRIES, DEFAULT_TIMEOUT,
+		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
 				DEFAULT_NUM_CHANNELS, DEFAULT_INTERMEDIATE_CHANNEL_WAITS,
 				retryTracker);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_REGISTER_P2P_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.CPUState.IDLE;
 import static uk.ac.manchester.spinnaker.messages.model.P2PTable.getColumnOffset;
@@ -105,8 +106,8 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 			Map<ChipLocation, Set<Integer>> ignoreCoresMap,
 			Map<ChipLocation, Set<Direction>> ignoreLinksMap,
 			Integer maxSDRAMSize, RetryTracker retryTracker) {
-		super(connectionSelector, DEFAULT_NUM_RETRIES, DEFAULT_TIMEOUT,
-				THROTTLED, THROTTLED - 1, retryTracker);
+		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT, THROTTLED,
+				THROTTLED - 1, retryTracker);
 		this.ignoreChips = def(ignoreChips);
 		this.ignoreCoresMap = def(ignoreCoresMap);
 		this.ignoreLinksMap = def(ignoreLinksMap);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
@@ -16,7 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
-import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -40,8 +40,6 @@ public abstract class MultiConnectionProcess<T extends SCPConnection>
 		extends Process {
 	/** The default for the number of retries. */
 	public static final int DEFAULT_NUM_RETRIES = 3;
-	/** The default for the timeout (in ms). */
-	public static final int DEFAULT_TIMEOUT = SCP_TIMEOUT;
 	/** The default for the number of parallel channels. */
 	public static final int DEFAULT_NUM_CHANNELS = 8;
 	/** The default for the number of instantaneously active channels. */
@@ -68,7 +66,7 @@ public abstract class MultiConnectionProcess<T extends SCPConnection>
 	 */
 	protected MultiConnectionProcess(ConnectionSelector<T> connectionSelector,
 			RetryTracker retryTracker) {
-		this(connectionSelector, DEFAULT_NUM_RETRIES, DEFAULT_TIMEOUT,
+		this(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
 				DEFAULT_NUM_CHANNELS, DEFAULT_INTERMEDIATE_CHANNEL_WAITS,
 				retryTracker);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
+
 import java.io.IOException;
 
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
@@ -43,7 +45,7 @@ public class SendSingleSCPCommandProcess
 	public SendSingleSCPCommandProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			RetryTracker retryTracker) {
-		this(connectionSelector, DEFAULT_NUM_RETRIES, DEFAULT_TIMEOUT,
+		this(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
 				retryTracker);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SingleConnectionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SingleConnectionProcess.java
@@ -16,7 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
-import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 
 import java.io.IOException;
 import java.util.function.Consumer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 import static java.lang.Math.min;
 import static java.nio.ByteBuffer.allocate;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
@@ -67,8 +68,7 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	public WriteMemoryProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			int numChannels, RetryTracker retryTracker) {
-		super(connectionSelector, MultiConnectionProcess.DEFAULT_NUM_RETRIES,
-				MultiConnectionProcess.DEFAULT_TIMEOUT, numChannels,
+		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT, numChannels,
 				Math.max(numChannels / 2, 1), retryTracker);
 	}
 


### PR DESCRIPTION
This is to allow Simon to override the timeouts to be longer so that heavily loaded networks (sands on occasion) won't cause so many failures.