### PR TITLE
Some tests just aren't thread-safe

### DIFF
--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -83,6 +83,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<artifactId>commons-beanutils</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.jcip</groupId>
+			<artifactId>jcip-annotations</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/ManualSpalloc.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/ManualSpalloc.java
@@ -29,19 +29,19 @@ import uk.ac.manchester.spinnaker.spalloc.messages.JobDescription;
  * @author Christian-B
  */
 public class ManualSpalloc {
+	private static final String SPALLOC = "spinnaker.cs.man.ac.uk";
 
-
-	public static void main(String... args) throws IOException, SpallocServerException, Exception {
-        SpallocClient client = new SpallocClient("spinnaker.cs.man.ac.uk", 22244);
-        try (AutoCloseable c = client.withConnection()) {
-            List<JobDescription> jobs = client.listJobs();
-            for (JobDescription job: jobs) {
-                System.out.println(job);
-            }
-        }
-        int two = 2;
-        System.out.println(3/two);
-        client.close();
-    }
-
+	public static void main(String... args)
+			throws IOException, SpallocServerException, Exception {
+		SpallocClient client = new SpallocClient(SPALLOC, 22244);
+		try (AutoCloseable c = client.withConnection()) {
+			List<JobDescription> jobs = client.listJobs();
+			for (JobDescription job : jobs) {
+				System.out.println(job);
+			}
+		}
+		int two = 2;
+		System.out.println(3 / two);
+		client.close();
+	}
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/ReliabilityITCase.java
@@ -17,6 +17,9 @@
 package uk.ac.manchester.spinnaker.transceiver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.jcip.annotations.NotThreadSafe;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetAddress;
@@ -37,6 +40,7 @@ import uk.ac.manchester.spinnaker.transceiver.processes.ProcessException;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.FIVE;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
+@NotThreadSafe
 class ReliabilityITCase {
     static Machine jsonMachine;
 	private static final Logger log = getLogger(ReliabilityITCase.class);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/SpallocMachineTest.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/SpallocMachineTest.java
@@ -17,6 +17,9 @@
 package uk.ac.manchester.spinnaker.transceiver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.jcip.annotations.NotThreadSafe;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetAddress;
@@ -39,6 +42,7 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocJob;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.FIVE;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
+@NotThreadSafe
 class SpallocMachineTest {
 	static Machine jsonMachine;
 

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import net.jcip.annotations.NotThreadSafe;
 import testconfig.BoardTestConfiguration;
 import uk.ac.manchester.spinnaker.connections.BootConnection;
 import uk.ac.manchester.spinnaker.connections.EIEIOConnection;
@@ -55,6 +56,7 @@ import uk.ac.manchester.spinnaker.machine.VirtualMachine;
 import uk.ac.manchester.spinnaker.transceiver.UDPTransceiver.ConnectionFactory;
 import uk.ac.manchester.spinnaker.utils.InetFactory;
 
+@NotThreadSafe
 class TestTransceiver {
 	static BoardTestConfiguration boardConfig;
 

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 import org.slf4j.Logger;
 
+import net.jcip.annotations.NotThreadSafe;
 import testconfig.BoardTestConfiguration;
 import testconfig.Utils.Field;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
@@ -96,6 +97,7 @@ import uk.ac.manchester.spinnaker.spalloc.SpallocJob;
  * @author Andrew Rowley
  * @author Donal Fellows
  */
+@NotThreadSafe
 public class TransceiverITCase {
 	private static final Logger log = getLogger(TransceiverITCase.class);
 	// TODO Stop printing to System.out

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<artifactId>diffutils</artifactId>
 				<version>1.3.0</version>
 			</dependency>
+			<dependency>
+				<groupId>net.jcip</groupId>
+				<artifactId>jcip-annotations</artifactId>
+				<version>1.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
[This](https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html) says that the JCIP `@NotThreadSafe` annotation is respected. That's nice, given that we have tests that are categorically not thread safe due to accessing monolithic global resources by name.