### PR TITLE
Configurable retry count

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -25,8 +25,10 @@ import static java.lang.Thread.yield;
 import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.messages.Constants.SCP_RETRY_DEFAULT;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT_DEFAULT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
+import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -46,7 +48,6 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 import uk.ac.manchester.spinnaker.transceiver.RetryTracker;
-import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
 
 /**
  * Allows a set of SCP requests to be grouped together in a communication across
@@ -70,6 +71,13 @@ public class SCPRequestPipeline {
 	 * to wait before timing out a communication.
 	 */
 	private static final String TIMEOUT_PROPERTY = "spinnaker.scp_timeout";
+	/**
+	 * The name of a <em>system property</em> that can override the default
+	 * retries. If specified as an integer, it gives the number of retries to
+	 * perform (on timeout of receiving a reply) before timing out a
+	 * communication.
+	 */
+	private static final String RETRY_PROPERTY = "spinnaker.scp_retries";
 	private static final Logger log = getLogger(SCPRequestPipeline.class);
 	/** The default number of requests to send before checking for responses. */
 	public static final int DEFAULT_NUM_CHANNELS = 1;
@@ -82,7 +90,7 @@ public class SCPRequestPipeline {
 	 * The default number of times to resend any packet for any reason before an
 	 * error is triggered.
 	 */
-	public static final int DEFAULT_RETRIES = 3;
+	public static final int SCP_RETRIES;
 	/**
 	 * How long to wait between retries, in milliseconds.
 	 */
@@ -97,6 +105,7 @@ public class SCPRequestPipeline {
 
 	static {
 		SCP_TIMEOUT = getInteger(TIMEOUT_PROPERTY, SCP_TIMEOUT_DEFAULT);
+		SCP_RETRIES = getInteger(RETRY_PROPERTY, SCP_RETRY_DEFAULT);
 	}
 
 	/** The connection over which the communication is to take place. */
@@ -268,7 +277,7 @@ public class SCPRequestPipeline {
 	public SCPRequestPipeline(SCPConnection connection,
 			RetryTracker retryTracker) {
 		this(connection, DEFAULT_NUM_CHANNELS,
-				DEFAULT_INTERMEDIATE_TIMEOUT_WAITS, DEFAULT_RETRIES,
+				DEFAULT_INTERMEDIATE_TIMEOUT_WAITS, SCP_RETRIES,
 				SCP_TIMEOUT, retryTracker);
 	}
 
@@ -288,7 +297,7 @@ public class SCPRequestPipeline {
 	public SCPRequestPipeline(SCPConnection connection, int packetTimeout,
 			RetryTracker retryTracker) {
 		this(connection, DEFAULT_NUM_CHANNELS,
-				DEFAULT_INTERMEDIATE_TIMEOUT_WAITS, DEFAULT_RETRIES,
+				DEFAULT_INTERMEDIATE_TIMEOUT_WAITS, SCP_RETRIES,
 				packetTimeout, retryTracker);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
@@ -82,6 +82,8 @@ public abstract class Constants {
 	public static final double BMP_POST_POWER_ON_SLEEP_TIME = 5.0;
 	/** This is the default timeout when using SCP, in milliseconds. */
 	public static final int SCP_TIMEOUT_DEFAULT = 1000;
+	/** This is the default retry limit when using SCP. */
+	public static final int SCP_RETRY_DEFAULT = 3;
 
 	/** Number of bytes in a SpiNNaker word. */
 	public static final int WORD_SIZE = 4;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/ApplicationRunProcess.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public class ApplicationRunProcess
 	public ApplicationRunProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			RetryTracker retryTracker) {
-		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
+		super(connectionSelector, SCP_RETRIES, SCP_TIMEOUT,
 				DEFAULT_NUM_CHANNELS, DEFAULT_INTERMEDIATE_CHANNEL_WAITS,
 				retryTracker);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/GetMachineProcess.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_REGISTER_P2P_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.CPUState.IDLE;
@@ -106,7 +107,7 @@ public class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 			Map<ChipLocation, Set<Integer>> ignoreCoresMap,
 			Map<ChipLocation, Set<Direction>> ignoreLinksMap,
 			Integer maxSDRAMSize, RetryTracker retryTracker) {
-		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT, THROTTLED,
+		super(connectionSelector, SCP_RETRIES, SCP_TIMEOUT, THROTTLED,
 				THROTTLED - 1, retryTracker);
 		this.ignoreChips = def(ignoreChips);
 		this.ignoreCoresMap = def(ignoreCoresMap);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/MultiConnectionProcess.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 
 import java.io.IOException;
@@ -38,8 +39,6 @@ import uk.ac.manchester.spinnaker.transceiver.RetryTracker;
  */
 public abstract class MultiConnectionProcess<T extends SCPConnection>
 		extends Process {
-	/** The default for the number of retries. */
-	public static final int DEFAULT_NUM_RETRIES = 3;
 	/** The default for the number of parallel channels. */
 	public static final int DEFAULT_NUM_CHANNELS = 8;
 	/** The default for the number of instantaneously active channels. */
@@ -66,9 +65,8 @@ public abstract class MultiConnectionProcess<T extends SCPConnection>
 	 */
 	protected MultiConnectionProcess(ConnectionSelector<T> connectionSelector,
 			RetryTracker retryTracker) {
-		this(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
-				DEFAULT_NUM_CHANNELS, DEFAULT_INTERMEDIATE_CHANNEL_WAITS,
-				retryTracker);
+		this(connectionSelector, SCP_RETRIES, SCP_TIMEOUT, DEFAULT_NUM_CHANNELS,
+				DEFAULT_INTERMEDIATE_CHANNEL_WAITS, retryTracker);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleBMPCommandProcess.java
@@ -20,7 +20,7 @@ import static java.lang.String.format;
 import static java.lang.Thread.sleep;
 import static java.util.Collections.synchronizedMap;
 import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.DEFAULT_RETRIES;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.RETRY_DELAY_MS;
 import static uk.ac.manchester.spinnaker.messages.Constants.BMP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
@@ -169,7 +169,7 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 			/** retry reason. */
 			private final List<String> retryReason = new ArrayList<>();
 			/** number of retries for the packet. */
-			private int retries = DEFAULT_RETRIES;
+			private int retries = SCP_RETRIES;
 
 			private Request(BMPRequest<R> request, Consumer<R> callback) {
 				this.request = request;
@@ -362,7 +362,7 @@ public class SendSingleBMPCommandProcess<R extends BMPResponse> {
 			super(format(
 					"Errors sending request %s to %d,%d,%d over %d retries: %s",
 					hdr.command, core.getX(), core.getY(), core.getP(),
-					DEFAULT_RETRIES, retryReason));
+					SCP_RETRIES, retryReason));
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/SendSingleSCPCommandProcess.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 
 import java.io.IOException;
@@ -45,8 +46,7 @@ public class SendSingleSCPCommandProcess
 	public SendSingleSCPCommandProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			RetryTracker retryTracker) {
-		this(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT,
-				retryTracker);
+		this(connectionSelector, SCP_RETRIES, SCP_TIMEOUT, retryTracker);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/processes/WriteMemoryProcess.java
@@ -16,9 +16,11 @@
  */
 package uk.ac.manchester.spinnaker.transceiver.processes;
 
-import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.nio.ByteBuffer.allocate;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
+import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 
 import java.io.BufferedInputStream;
@@ -68,8 +70,8 @@ public class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	public WriteMemoryProcess(
 			ConnectionSelector<SCPConnection> connectionSelector,
 			int numChannels, RetryTracker retryTracker) {
-		super(connectionSelector, DEFAULT_NUM_RETRIES, SCP_TIMEOUT, numChannels,
-				Math.max(numChannels / 2, 1), retryTracker);
+		super(connectionSelector, SCP_RETRIES, SCP_TIMEOUT, numChannels,
+				max(numChannels / 2, 1), retryTracker);
 	}
 
 	/**


### PR DESCRIPTION
Adds a Java system property (`spinnaker.scp_retries`) for controlling the retry count. Defaults to 3, which is the value used up to now. Hopefully will let people make things work more reliably on busy networks.