### PR TITLE
Make IPTag useSender actually work right.

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.connections;
+
+/**
+ * An SCP connection that actually delegates message sending and receiving to
+ * another connection. Note that closing a delegating connection does nothing;
+ * the socket is only closed when the real underlying connection is closed.
+ *
+ * @author Donal Fellows
+ */
+public class DelegatingSCPConnection extends SCPConnection {
+	/**
+	 * Create a connection that delegates actual communications to another
+	 * connection.
+	 *
+	 * @param connection
+	 *            The connection to delegate to.
+	 */
+	public DelegatingSCPConnection(SDPConnection connection) {
+		super(connection);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -31,8 +31,6 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 /** A UDP connection to SC&amp;MP on the board. */
 public class SCPConnection extends SDPConnection
 		implements SCPSenderReceiver {
-	private final SDPConnection delegate;
-
 	/**
 	 * Create a connection to a particular instance of SCAMP.
 	 *
@@ -127,7 +125,6 @@ public class SCPConnection extends SDPConnection
 		super(chip, localHost, localPort, requireNonNull(remoteHost,
 				"SCPConnection only meaningful with a real remote host"),
 				(remotePort == null) ? SCP_SCAMP_PORT : remotePort);
-		delegate = null;
 	}
 
 	/**
@@ -139,24 +136,16 @@ public class SCPConnection extends SDPConnection
 	 */
 	SCPConnection(SDPConnection connection) {
 		super(connection);
-		delegate = connection;
 	}
 
 	@Override
 	public SCPResultMessage receiveSCPResponse(Integer timeout)
 			throws IOException {
-		if (delegate != null) {
-			return new SCPResultMessage(delegate.receive(timeout));
-		}
 		return new SCPResultMessage(receive(timeout));
 	}
 
 	@Override
 	public void sendSCPRequest(SCPRequest<?> scpRequest) throws IOException {
-		if (delegate != null) {
-			delegate.send(getSCPData(scpRequest));
-		} else {
-			send(getSCPData(scpRequest));
-		}
+		send(getSCPData(scpRequest));
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -31,6 +31,8 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 /** A UDP connection to SC&amp;MP on the board. */
 public class SCPConnection extends SDPConnection
 		implements SCPSenderReceiver {
+	private final SDPConnection delegate;
+
 	/**
 	 * Create a connection to a particular instance of SCAMP.
 	 *
@@ -125,16 +127,36 @@ public class SCPConnection extends SDPConnection
 		super(chip, localHost, localPort, requireNonNull(remoteHost,
 				"SCPConnection only meaningful with a real remote host"),
 				(remotePort == null) ? SCP_SCAMP_PORT : remotePort);
+		delegate = null;
+	}
+
+	/**
+	 * Create a connection that delegates actual communications to another
+	 * connection.
+	 *
+	 * @param connection
+	 *            The connection to delegate to.
+	 */
+	public SCPConnection(SDPConnection connection) {
+		super(connection);
+		delegate = connection;
 	}
 
 	@Override
 	public SCPResultMessage receiveSCPResponse(Integer timeout)
 			throws IOException {
+		if (delegate != null) {
+			return new SCPResultMessage(delegate.receive(timeout));
+		}
 		return new SCPResultMessage(receive(timeout));
 	}
 
 	@Override
 	public void sendSCPRequest(SCPRequest<?> scpRequest) throws IOException {
-		send(getSCPData(scpRequest));
+		if (delegate != null) {
+			delegate.send(getSCPData(scpRequest));
+		} else {
+			send(getSCPData(scpRequest));
+		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -137,7 +137,7 @@ public class SCPConnection extends SDPConnection
 	 * @param connection
 	 *            The connection to delegate to.
 	 */
-	public SCPConnection(SDPConnection connection) {
+	SCPConnection(SDPConnection connection) {
 		super(connection);
 		delegate = connection;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -127,17 +127,6 @@ public class SCPConnection extends SDPConnection
 				(remotePort == null) ? SCP_SCAMP_PORT : remotePort);
 	}
 
-	/**
-	 * Create a connection that delegates actual communications to another
-	 * connection.
-	 *
-	 * @param connection
-	 *            The connection to delegate to.
-	 */
-	SCPConnection(SDPConnection connection) {
-		super(connection);
-	}
-
 	@Override
 	public SCPResultMessage receiveSCPResponse(Integer timeout)
 			throws IOException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -31,6 +31,15 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 public class SDPConnection extends UDPConnection<SDPMessage>
 		implements SDPReceiver, SDPSender {
 	private ChipLocation chip;
+	private final SDPConnection delegate;
+	/*
+	 * Special constructor used only in delegated connections.
+	 */
+	SDPConnection(SDPConnection connection) {
+		super(connection);
+		delegate = connection;
+		chip = delegate.chip;
+	}
 
 	/**
 	 * @param remoteChip
@@ -72,18 +81,28 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 			Integer localPort, InetAddress remoteHost, Integer remotePort)
 			throws IOException {
 		super(localHost, localPort, remoteHost, remotePort);
+		this.delegate = null;
 		this.chip = remoteChip.asChipLocation();
 	}
 
 	@Override
 	public void sendSDPMessage(SDPMessage sdpMessage) throws IOException {
-		send(sdpMessage.getMessageData(chip));
+		if (delegate != null) {
+			delegate.send(sdpMessage.getMessageData(chip));
+		} else {
+			send(sdpMessage.getMessageData(chip));
+		}
 	}
 
 	@Override
 	public SDPMessage receiveMessage(Integer timeout)
 			throws IOException, InterruptedIOException {
-		ByteBuffer buffer = receive();
+		ByteBuffer buffer;
+		if (delegate != null) {
+			buffer = delegate.receive(timeout);
+		} else {
+			buffer = receive(timeout);
+		}
 		buffer.getShort(); // SKIP TWO PADDING BYTES
 		return new SDPMessage(buffer);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -31,14 +31,12 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 public class SDPConnection extends UDPConnection<SDPMessage>
 		implements SDPReceiver, SDPSender {
 	private ChipLocation chip;
-	private final SDPConnection delegate;
 	/*
 	 * Special constructor used only in delegated connections.
 	 */
 	SDPConnection(SDPConnection connection) {
 		super(connection);
-		delegate = connection;
-		chip = delegate.chip;
+		chip = connection.chip;
 	}
 
 	/**
@@ -81,28 +79,18 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 			Integer localPort, InetAddress remoteHost, Integer remotePort)
 			throws IOException {
 		super(localHost, localPort, remoteHost, remotePort);
-		this.delegate = null;
 		this.chip = remoteChip.asChipLocation();
 	}
 
 	@Override
 	public void sendSDPMessage(SDPMessage sdpMessage) throws IOException {
-		if (delegate != null) {
-			delegate.send(sdpMessage.getMessageData(chip));
-		} else {
-			send(sdpMessage.getMessageData(chip));
-		}
+		send(sdpMessage.getMessageData(chip));
 	}
 
 	@Override
 	public SDPMessage receiveMessage(Integer timeout)
 			throws IOException, InterruptedIOException {
-		ByteBuffer buffer;
-		if (delegate != null) {
-			buffer = delegate.receive(timeout);
-		} else {
-			buffer = receive(timeout);
-		}
+		ByteBuffer buffer = receive(timeout);
 		buffer.getShort(); // SKIP TWO PADDING BYTES
 		return new SDPMessage(buffer);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -33,18 +33,6 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 	private ChipLocation chip;
 
 	/**
-	 * Create a connection that delegates actual communications to another
-	 * connection.
-	 *
-	 * @param connection
-	 *            The connection to delegate to.
-	 */
-	SDPConnection(SDPConnection connection) {
-		super(connection);
-		chip = connection.chip;
-	}
-
-	/**
 	 * @param remoteChip
 	 *            Which chip are we talking to? This is not necessarily the chip
 	 *            that is connected to the Ethernet connector on the SpiNNaker

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -31,8 +31,13 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 public class SDPConnection extends UDPConnection<SDPMessage>
 		implements SDPReceiver, SDPSender {
 	private ChipLocation chip;
-	/*
-	 * Special constructor used only in delegated connections.
+
+	/**
+	 * Create a connection that delegates actual communications to another
+	 * connection.
+	 *
+	 * @param connection
+	 *            The connection to delegate to.
 	 */
 	SDPConnection(SDPConnection connection) {
 		super(connection);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -127,7 +127,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 				return null;
 			}
 		});
-		if (log.isDebugEnabled()) {
+		if (channel != null && log.isDebugEnabled()) {
 			InetSocketAddress us = null;
 			try {
 				us = getLocalAddress();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -87,10 +87,17 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	private final ThreadLocal<SelectionKey> selectionKeyFactory;
 	private final UDPConnection<T> delegate;
 
+	/**
+	 * Create a connection that delegates actual communications to another
+	 * connection.
+	 *
+	 * @param connection
+	 *            The connection to delegate to.
+	 */
 	UDPConnection(UDPConnection<T> connection) {
 		this.delegate = connection;
-		this.channel = null;
-		this.selectionKeyFactory = null;
+		this.channel = null; // unused
+		this.selectionKeyFactory = null; // unused
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -23,6 +23,8 @@ import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteBuffer.wrap;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.channels.SelectionKey.OP_READ;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.Constants.IPV4_SIZE;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
@@ -44,8 +46,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.List;
+import java.util.function.IntFunction;
 
 import org.slf4j.Logger;
 
@@ -502,18 +504,18 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 
 	private void logSend(ByteBuffer data, SocketAddress addr) {
 		log.debug("sending data of length {} to {}", data.remaining(), addr);
-		byte[] bytes = new byte[data.remaining()];
-		data.duplicate().get(bytes);
-		log.debug("message data: {}", IntStream.range(0, bytes.length)
-				.mapToObj(i -> hexbyte(bytes[i])).collect(Collectors.toList()));
+		log.debug("message data: {}", describe(data));
 	}
 
 	private void logRecv(ByteBuffer data, SocketAddress addr) {
 		log.debug("received data of length {} from {}", data.remaining(), addr);
-		byte[] bytes = new byte[data.remaining()];
-		data.duplicate().get(bytes);
-		log.debug("message data: {}", IntStream.range(0, bytes.length)
-				.mapToObj(i -> hexbyte(bytes[i])).collect(Collectors.toList()));
+		log.debug("message data: {}", describe(data));
+	}
+
+	private List<String> describe(ByteBuffer data) {
+		int pos = data.position();
+		IntFunction<String> foo = i -> hexbyte(data.get(pos + i));
+		return range(0, data.remaining()).mapToObj(foo).collect(toList());
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.BootConnection;
+import uk.ac.manchester.spinnaker.connections.DelegatingSCPConnection;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.SDPConnection;
 import uk.ac.manchester.spinnaker.connections.UDPConnection;
@@ -1922,7 +1923,7 @@ public class Transceiver extends UDPTransceiver
 		ChipLocation[] chip = new ChipLocation[1];
 		connections.forEach(c -> chip[0] = c.getChip());
 
-		try (SCPConnection s = new SCPConnection(connection)) {
+		try (SCPConnection s = new DelegatingSCPConnection(connection)) {
 			new SendSingleSCPCommandProcess(r -> s, this).execute(new IPTagSet(
 					chip[0], null, 0, tag.getTag(), tag.isStripSDP(), true));
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1874,8 +1874,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafeWithCare
-	public void setIPTag(IPTag tag, boolean useSender)
-			throws IOException, ProcessException {
+	public void setIPTag(IPTag tag) throws IOException, ProcessException {
 		// Check that the tag has a port assigned
 		if (tag.getPort() == null) {
 			throw new IllegalArgumentException(
@@ -1894,22 +1893,38 @@ public class Transceiver extends UDPTransceiver
 		}
 
 		for (SCPConnection connection : connections) {
-			IPTagSet tagSet;
-
-			if (useSender) {
-				tagSet = new IPTagSet(connection.getChip(), null, 0,
-						tag.getTag(), tag.isStripSDP(), true);
-			} else {
-				// Convert the host string
-				InetAddress host = tag.getIPAddress();
-				if (host == null || host.isAnyLocalAddress()
-						|| host.isLoopbackAddress()) {
-					host = connection.getLocalIPAddress();
-				}
-				tagSet = new IPTagSet(connection.getChip(), host.getAddress(),
-						tag.getPort(), tag.getTag(), tag.isStripSDP(), false);
+			// Convert the host string
+			InetAddress host = tag.getIPAddress();
+			if (host == null || host.isAnyLocalAddress()
+					|| host.isLoopbackAddress()) {
+				host = connection.getLocalIPAddress();
 			}
+			IPTagSet tagSet = new IPTagSet(connection.getChip(),
+					host.getAddress(), tag.getPort(), tag.getTag(),
+					tag.isStripSDP(), false);
 			simpleProcess().execute(tagSet);
+		}
+	}
+
+	@Override
+	@ParallelSafeWithCare
+	public void setIPTag(IPTag tag, SDPConnection connection)
+			throws IOException, ProcessException {
+		/*
+		 * Check that the connection is actually pointing to somewhere we know.
+		 */
+		Collection<SCPConnection> connections =
+				getConnectionList(connection.getRemoteIPAddress());
+		if (connections == null || connections.isEmpty()) {
+			throw new IllegalArgumentException(
+					"The given board address is not recognised");
+		}
+		ChipLocation[] chip = new ChipLocation[1];
+		connections.forEach(c -> chip[0] = c.getChip());
+
+		try (SCPConnection s = new SCPConnection(connection)) {
+			new SendSingleSCPCommandProcess(r -> s, this).execute(new IPTagSet(
+					chip[0], null, 0, tag.getTag(), tag.isStripSDP(), true));
 		}
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1131,6 +1131,22 @@ public class Transceiver extends UDPTransceiver
 		return new SendSingleSCPCommandProcess(scpSelector, this);
 	}
 
+	/**
+	 * A neater way of getting a process for running simple SCP requests.
+	 *
+	 * @param connector
+	 *            The specific connector to talk to the board along.
+	 * @return The SCP runner process
+	 * @throws IOException If anything fails (unexpected).
+	 */
+	private SendSingleSCPCommandProcess simpleProcess(SDPConnection connector)
+			throws IOException {
+		return new SendSingleSCPCommandProcess(
+				new SingletonConnectionSelector<>(
+						new DelegatingSCPConnection(connector)),
+				this);
+	}
+
 	@Override
 	@ParallelUnsafe
 	public VersionInfo ensureBoardIsReady(int numRetries,
@@ -1920,13 +1936,9 @@ public class Transceiver extends UDPTransceiver
 			throw new IllegalArgumentException(
 					"The given board address is not recognised");
 		}
-		ChipLocation[] chip = new ChipLocation[1];
-		connections.forEach(c -> chip[0] = c.getChip());
 
-		try (SCPConnection s = new DelegatingSCPConnection(connection)) {
-			new SendSingleSCPCommandProcess(r -> s, this).execute(new IPTagSet(
-					chip[0], null, 0, tag.getTag(), tag.isStripSDP(), true));
-		}
+		simpleProcess(connection).execute(new IPTagSet(connection.getChip(),
+				null, 0, tag.getTag(), tag.isStripSDP(), true));
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -3749,25 +3749,23 @@ public interface TransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default void setIPTag(IPTag tag) throws IOException, ProcessException {
-		setIPTag(tag, false);
-	}
+	void setIPTag(IPTag tag) throws IOException, ProcessException;
 
 	/**
-	 * Set up an IP tag.
+	 * Set up an IP tag to deliver messages to a particular connection.
 	 *
 	 * @param tag
-	 *            The tag to set up; note its board address can be {@code null},
-	 *            in which case, the tag will be assigned to all boards.
-	 * @param useSender
-	 *            if the sender's IP address and port should be used.
+	 *            The tag to set up.
+	 * @param connection
+	 *            The connection to deliver messages to, which must already be
+	 *            set up to talk to the correct board.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	void setIPTag(IPTag tag, boolean useSender)
+	void setIPTag(IPTag tag, SDPConnection connection)
 			throws IOException, ProcessException;
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -59,7 +59,6 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
-import uk.ac.manchester.spinnaker.machine.tags.TrafficIdentifier;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage.Region;
 import uk.ac.manchester.spinnaker.storage.StorageException;
@@ -112,9 +111,6 @@ public abstract class DataGatherer extends BoardLocalSupport {
 	/** Message used to report problems. */
 	private static final String TIMEOUT_MESSAGE = "failed to hear from the "
 			+ "machine (please try removing firewalls)";
-	/** The traffic ID for this protocol. */
-	private static final TrafficIdentifier TRAFFIC_ID =
-			TrafficIdentifier.getInstance("DATA_SPEED_UP");
 	private static final String SPINNAKER_COMPARE_DOWNLOAD =
 			System.getProperty("spinnaker.compare.download");
 
@@ -328,7 +324,7 @@ public abstract class DataGatherer extends BoardLocalSupport {
 			}
 			GatherDownloadConnection conn =
 					new GatherDownloadConnection(gathererChip, g.getIptag());
-			reconfigureIPtag(g.getIptag(), gathererChip, conn);
+			reconfigureIPtag(g.getIptag(), conn);
 			connections.put(gathererChip, conn);
 		}
 		return connections;
@@ -590,8 +586,6 @@ public abstract class DataGatherer extends BoardLocalSupport {
 	 *
 	 * @param iptag
 	 *            The tag to configure
-	 * @param gathererLocation
-	 *            Where the tag is.
 	 * @param conn
 	 *            How to talk to the gatherer.
 	 * @throws IOException
@@ -599,17 +593,13 @@ public abstract class DataGatherer extends BoardLocalSupport {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	private void reconfigureIPtag(IPTag iptag, ChipLocation gathererLocation,
+	private void reconfigureIPtag(IPTag iptag,
 			GatherDownloadConnection conn)
 			throws IOException, ProcessException {
-		IPTag tag = new IPTag(iptag.getBoardAddress(), gathererLocation,
-				iptag.getTag(), iptag.getIPAddress(), conn.getLocalPort(), true,
-				TRAFFIC_ID);
-		txrx.setIPTag(tag);
-		log.info("reconfigured {} to {}", iptag, tag);
+		txrx.setIPTag(iptag, conn);
 		if (log.isDebugEnabled()) {
 			log.debug("all tags for board: {}", txrx.getTags(
-					txrx.locateSpinnakerConnection(tag.getBoardAddress())));
+					txrx.locateSpinnakerConnection(conn.getRemoteIPAddress())));
 		}
 	}
 


### PR DESCRIPTION
When using the `useSender` flag of the `IPTagSet` operation, you _categorically_ need to send the message on the connection that you wish to receive messages on because SCAMP uses _both_ the IP address _and_ the port of the _sending_ connection. Because of that, there is no point in setting the flag except when you know what connection will be receiving, and the API should therefore take the connection that will be doing the receiving at that point (which needs to be an `SDPConnection`, but no more).

fixes #246