### PR TITLE
Use the default UDP send buffer size

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -19,7 +19,6 @@ package uk.ac.manchester.spinnaker.connections;
 import static java.net.InetAddress.getByAddress;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardSocketOptions.SO_RCVBUF;
-import static java.net.StandardSocketOptions.SO_SNDBUF;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteBuffer.wrap;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -67,7 +66,6 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	private static final Logger log = getLogger(UDPConnection.class);
 	private static final int RECEIVE_BUFFER_SIZE = 1048576;
-	private static final int ETHERNET_MTU = 1500;
 	private static final int PING_COUNT = 5;
 	private static final int PACKET_MAX_SIZE = 300;
 	private static final ThreadLocal<Selector> SELECTOR_FACTORY =
@@ -172,7 +170,6 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		chan.bind(createLocalAddress(localHost, localPort));
 		chan.configureBlocking(false);
 		chan.setOption(SO_RCVBUF, RECEIVE_BUFFER_SIZE);
-		chan.setOption(SO_SNDBUF, ETHERNET_MTU);
 		if (canSend) {
 			remoteIPAddress = (Inet4Address) remoteHost;
 			remoteAddress = new InetSocketAddress(remoteIPAddress, remotePort);


### PR DESCRIPTION
It turns out that this is *larger* than the value we were using (at least on macOS — where it defaults to 9216 rather than the value we were using of 1500 — and probably on Linux and Windows too), and this is useful when the network is a bit congested.

----
Background:
--
There's a _lot_ of confusion in this area (especially as UDP is far less understood than TCP by general , but it is important to remember that the value for `SO_SNDBUF` is used by the OS and not by Java (or other user code) to determine the size of the buffer before the data hits the network hardware, and the buffering can be required either because the network itself is busy or because there's other activity going on on the machine, or because there needs to be an ARP handling for the address, or … and because we're in non-block mode, the only option for dealing with a full buffer is to drop the packet.

* https://stackoverflow.com/questions/28692511/so-sndbuf-and-so-rcvbuf-settings-for-udp
* https://stackoverflow.com/questions/16156326/so-sndbuf-and-so-rcvbuf-on-linux-sockets

I hate dealing with this level of ignorance, which often occurs when you're in the close vicinity of something popular but don't actually need the popular thing.