### PR TITLE
Fewer timeouts

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -67,7 +67,6 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	private static final Logger log = getLogger(UDPConnection.class);
 	private static final int RECEIVE_BUFFER_SIZE = 1048576;
-	private static final int ETHERNET_MTU = 1500;
 	private static final int PING_COUNT = 5;
 	private static final int PACKET_MAX_SIZE = 300;
 	private static final ThreadLocal<Selector> SELECTOR_FACTORY =
@@ -172,7 +171,6 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		chan.bind(createLocalAddress(localHost, localPort));
 		chan.configureBlocking(false);
 		chan.setOption(SO_RCVBUF, RECEIVE_BUFFER_SIZE);
-		chan.setOption(SO_SNDBUF, ETHERNET_MTU);
 		if (canSend) {
 			remoteIPAddress = (Inet4Address) remoteHost;
 			remoteAddress = new InetSocketAddress(remoteIPAddress, remotePort);
@@ -397,7 +395,10 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		if (log.isDebugEnabled()) {
 			logSend(data, getRemoteAddress());
 		}
-		int sent = channel.send(data, remoteAddress);
+		int sent = 0;
+		while (sent == 0) {
+		    sent = channel.send(data, remoteAddress);
+		}
 		log.debug("sent {} bytes", sent);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -19,7 +19,6 @@ package uk.ac.manchester.spinnaker.connections;
 import static java.net.InetAddress.getByAddress;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardSocketOptions.SO_RCVBUF;
-import static java.net.StandardSocketOptions.SO_SNDBUF;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteBuffer.wrap;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -813,8 +813,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private int sendInitialPackets(int baseAddress, ByteBuffer data,
 				GathererProtocol protocol, int transactionId, int numPackets)
 				throws IOException {
-		    log.info("Streaming {} bytes in {} packets using transaction {}",
-		            data.remaining(), numPackets, transactionId);
+			log.info("Streaming {} bytes in {} packets using transaction {}",
+					data.remaining(), numPackets, transactionId);
 			log.debug("sending packet #{}", 0);
 			connection.send(protocol.dataToLocation(baseAddress, numPackets,
 					transactionId));

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -831,8 +831,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				ByteBuffer dataToSend, BitSet missingSeqNums, int transactionId,
 				int baseAddress, int numPackets) throws IOException {
 
-		    log.info("retransmitting {} packets",
-		            missingSeqNums.cardinality());
+			log.info("retransmitting {} packets",
+					missingSeqNums.cardinality());
 
 			missingSeqNums.stream().forEach(seqNum -> {
 				log.debug("resending packet #{}", seqNum);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -739,37 +739,37 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 						            numPackets);
 						}
 						SeenFlags flags =
-						        addMissedSeqNums(received, missing, numPackets);
+								addMissedSeqNums(received, missing, numPackets);
 
 						/*
 						 * Check that you've seen something that implies ready
 						 * to retransmit.
 						 */
 						if (flags.seenAll || flags.seenEnd) {
-						    retransmitMissingPackets(protocol, data, missing,
+							retransmitMissingPackets(protocol, data, missing,
 									transactionId, baseAddress, numPackets);
-						    missing.clear();
+							missing.clear();
 						}
 					} catch (SocketTimeoutException e) {
 						if (timeoutCount++ > TIMEOUT_RETRY_LIMIT) {
-						    log.error("ran out of attempts on transaction {}"
-						            + " due to timeouts.", transactionId);
+							log.error("ran out of attempts on transaction {}"
+									+ " due to timeouts.", transactionId);
 							throw e;
 						}
 						// If we never received a packet, we will never have
 						// created the buffer, so send everything again
 						if (missing == null) {
-						    log.debug("full timeout; resending initial "
-						            + "packets for stream with transaction "
+							log.debug("full timeout; resending initial "
+									+ "packets for stream with transaction "
 									+ "id {}", transactionId);
 							continue outerLoop;
 						}
 						log.info("timeout {} on transaction {} sending to {}"
-						        + " via {}", timeoutCount, transactionId, core,
-						        gather.asCoreLocation());
-					    retransmitMissingPackets(protocol, data, missing,
+								+ " via {}", timeoutCount, transactionId, core,
+								gather.asCoreLocation());
+						retransmitMissingPackets(protocol, data, missing,
 								transactionId, baseAddress, numPackets);
-					    missing.clear();
+						missing.clear();
 					}
 				}
 			}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -688,9 +688,9 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				// Do the initial blast of data
 				sendInitialPackets(baseAddress, data, protocol, transactionId,
 						numPackets);
-                // Don't create a missing buffer until at least one packet has
-                // come back.
-                BitSet missing = null;
+				// Don't create a missing buffer until at least one packet has
+				// come back.
+				BitSet missing = null;
 
 				// Wait for confirmation and do required retransmits
 				innerLoop: while (true) {
@@ -734,42 +734,42 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 						 * numbers. Accumulate and dispatch transactionId when
 						 * we've got them all.
 						 */
-                        if (missing == null) {
-                            missing = missingSequenceNumbers.issueNew(
-                                    numPackets);
-                        }
+						if (missing == null) {
+						    missing = missingSequenceNumbers.issueNew(
+						            numPackets);
+						}
 						SeenFlags flags =
-                                addMissedSeqNums(received, missing, numPackets);
+						        addMissedSeqNums(received, missing, numPackets);
 
 						/*
 						 * Check that you've seen something that implies ready
 						 * to retransmit.
 						 */
 						if (flags.seenAll || flags.seenEnd) {
-                            retransmitMissingPackets(protocol, data, missing,
+						    retransmitMissingPackets(protocol, data, missing,
 									transactionId, baseAddress, numPackets);
-                            missing.clear();
+						    missing.clear();
 						}
 					} catch (SocketTimeoutException e) {
 						if (timeoutCount++ > TIMEOUT_RETRY_LIMIT) {
-                            log.error("ran out of attempts on transaction {}"
-                                    + " due to timeouts.", transactionId);
+						    log.error("ran out of attempts on transaction {}"
+						            + " due to timeouts.", transactionId);
 							throw e;
 						}
-                        // If we never received a packet, we will never have
-                        // created the buffer, so send everything again
-                        if (missing == null) {
-                            log.debug("full timeout; resending initial "
-                                    + "packets for stream with transaction "
+						// If we never received a packet, we will never have
+						// created the buffer, so send everything again
+						if (missing == null) {
+						    log.debug("full timeout; resending initial "
+						            + "packets for stream with transaction "
 									+ "id {}", transactionId);
 							continue outerLoop;
 						}
-                        log.info("timeout {} on transaction {} sending to {}"
-                                + " via {}", timeoutCount, transactionId, core,
-                                gather.asCoreLocation());
-                        retransmitMissingPackets(protocol, data, missing,
+						log.info("timeout {} on transaction {} sending to {}"
+						        + " via {}", timeoutCount, transactionId, core,
+						        gather.asCoreLocation());
+					    retransmitMissingPackets(protocol, data, missing,
 								transactionId, baseAddress, numPackets);
-                        missing.clear();
+					    missing.clear();
 					}
 				}
 			}
@@ -813,8 +813,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private int sendInitialPackets(int baseAddress, ByteBuffer data,
 				GathererProtocol protocol, int transactionId, int numPackets)
 				throws IOException {
-            log.info("Streaming {} bytes in {} packets using transaction {}",
-                    data.remaining(), numPackets, transactionId);
+		    log.info("Streaming {} bytes in {} packets using transaction {}",
+		            data.remaining(), numPackets, transactionId);
 			log.debug("sending packet #{}", 0);
 			connection.send(protocol.dataToLocation(baseAddress, numPackets,
 					transactionId));
@@ -831,8 +831,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				ByteBuffer dataToSend, BitSet missingSeqNums, int transactionId,
 				int baseAddress, int numPackets) throws IOException {
 
-            log.info("retransmitting {} packets",
-                    missingSeqNums.cardinality());
+		    log.info("retransmitting {} packets",
+		            missingSeqNums.cardinality());
 
 			missingSeqNums.stream().forEach(seqNum -> {
 				log.debug("resending packet #{}", seqNum);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -685,10 +685,12 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 			int transactionId = gather.getNextTransactionId();
 
 			outerLoop: while (true) {
-				BitSet seqNums = missingSequenceNumbers.issueNew(numPackets);
 				// Do the initial blast of data
 				sendInitialPackets(baseAddress, data, protocol, transactionId,
 						numPackets);
+                // Don't create a missing buffer until at least one packet has
+                // come back.
+                BitSet missing = null;
 
 				// Wait for confirmation and do required retransmits
 				innerLoop: while (true) {
@@ -732,32 +734,42 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 						 * numbers. Accumulate and dispatch transactionId when
 						 * we've got them all.
 						 */
-
+                        if (missing == null) {
+                            missing = missingSequenceNumbers.issueNew(
+                                    numPackets);
+                        }
 						SeenFlags flags =
-								addMissedSeqNums(received, seqNums, numPackets);
+                                addMissedSeqNums(received, missing, numPackets);
 
 						/*
 						 * Check that you've seen something that implies ready
 						 * to retransmit.
 						 */
 						if (flags.seenAll || flags.seenEnd) {
-							retransmitMissingPackets(protocol, data, seqNums,
+                            retransmitMissingPackets(protocol, data, missing,
 									transactionId, baseAddress, numPackets);
+                            missing.clear();
 						}
 					} catch (SocketTimeoutException e) {
 						if (timeoutCount++ > TIMEOUT_RETRY_LIMIT) {
-							log.error("ran out of attempts due to timeouts.");
+                            log.error("ran out of attempts on transaction {}"
+                                    + " due to timeouts.", transactionId);
 							throw e;
 						}
-						if (seqNums.isEmpty()) {
-							log.info("full timeout; resending initial "
-									+ "packets for stream with trasnaction "
+                        // If we never received a packet, we will never have
+                        // created the buffer, so send everything again
+                        if (missing == null) {
+                            log.debug("full timeout; resending initial "
+                                    + "packets for stream with transaction "
 									+ "id {}", transactionId);
 							continue outerLoop;
 						}
-						retransmitMissingPackets(protocol, data, seqNums,
+                        log.info("timeout {} on transaction {} sending to {}"
+                                + " via {}", timeoutCount, transactionId, core,
+                                gather.asCoreLocation());
+                        retransmitMissingPackets(protocol, data, missing,
 								transactionId, baseAddress, numPackets);
-						seqNums.clear();
+                        missing.clear();
 					}
 				}
 			}
@@ -801,8 +813,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private int sendInitialPackets(int baseAddress, ByteBuffer data,
 				GathererProtocol protocol, int transactionId, int numPackets)
 				throws IOException {
-			log.debug("streaming {} bytes in {} packets", data.remaining(),
-					numPackets);
+            log.info("Streaming {} bytes in {} packets using transaction {}",
+                    data.remaining(), numPackets, transactionId);
 			log.debug("sending packet #{}", 0);
 			connection.send(protocol.dataToLocation(baseAddress, numPackets,
 					transactionId));
@@ -818,11 +830,9 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private void retransmitMissingPackets(GathererProtocol protocol,
 				ByteBuffer dataToSend, BitSet missingSeqNums, int transactionId,
 				int baseAddress, int numPackets) throws IOException {
-			log.info("resending the location packet");
-			connection.send(protocol.dataToLocation(baseAddress, numPackets,
-					transactionId));
 
-			log.info("retransmitting {} packets", missingSeqNums.size());
+            log.info("retransmitting {} packets",
+                    missingSeqNums.cardinality());
 
 			missingSeqNums.stream().forEach(seqNum -> {
 				log.debug("resending packet #{}", seqNum);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -253,9 +253,9 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 	}
 
 	private int malloc(CoreToLoad ctl, Integer bytesUsed)
-            throws IOException, ProcessException {
-        return txrx.mallocSDRAM(ctl.core, bytesUsed, new AppID(ctl.appID));
-    }
+			throws IOException, ProcessException {
+		return txrx.mallocSDRAM(ctl.core, bytesUsed, new AppID(ctl.appID));
+	}
 
 	@Override
 	public void close() throws IOException {
@@ -688,8 +688,10 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 				// Do the initial blast of data
 				sendInitialPackets(baseAddress, data, protocol, transactionId,
 						numPackets);
-				// Don't create a missing buffer until at least one packet has
-				// come back.
+				/*
+				 * Don't create a missing buffer until at least one packet has
+				 * come back.
+				 */
 				BitSet missing = null;
 
 				// Wait for confirmation and do required retransmits
@@ -735,8 +737,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 						 * we've got them all.
 						 */
 						if (missing == null) {
-						    missing = missingSequenceNumbers.issueNew(
-						            numPackets);
+							missing =
+									missingSequenceNumbers.issueNew(numPackets);
 						}
 						SeenFlags flags =
 								addMissedSeqNums(received, missing, numPackets);
@@ -756,8 +758,10 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 									+ " due to timeouts.", transactionId);
 							throw e;
 						}
-						// If we never received a packet, we will never have
-						// created the buffer, so send everything again
+						/*
+						 * If we never received a packet, we will never have
+						 * created the buffer, so send everything again
+						 */
 						if (missing == null) {
 							log.debug("full timeout; resending initial "
 									+ "packets for stream with transaction "
@@ -813,7 +817,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private int sendInitialPackets(int baseAddress, ByteBuffer data,
 				GathererProtocol protocol, int transactionId, int numPackets)
 				throws IOException {
-			log.info("Streaming {} bytes in {} packets using transaction {}",
+			log.info("streaming {} bytes in {} packets using transaction {}",
 					data.remaining(), numPackets, transactionId);
 			log.debug("sending packet #{}", 0);
 			connection.send(protocol.dataToLocation(baseAddress, numPackets,
@@ -830,9 +834,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 		private void retransmitMissingPackets(GathererProtocol protocol,
 				ByteBuffer dataToSend, BitSet missingSeqNums, int transactionId,
 				int baseAddress, int numPackets) throws IOException {
-
-			log.info("retransmitting {} packets",
-					missingSeqNums.cardinality());
+			log.info("retransmitting {} packets", missingSeqNums.cardinality());
 
 			missingSeqNums.stream().forEach(seqNum -> {
 				log.debug("resending packet #{}", seqNum);


### PR DESCRIPTION
These changes result in fewer timeouts when using the fast data in protocol.  This correspondingly improves the speed of operation.

This is achieved by:
 - Use the default send buffer size
 - Check that data is actually sent on send
 - Fix what happens on a timeout (don't send all the packets if you have heard from the machine in this transaction).
