### PR TITLE
Move initialise to static

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
@@ -39,10 +39,8 @@ public enum FastDataInCommandID {
 	private static final Map<Integer, FastDataInCommandID> MAP =
 			new HashMap<>();
 	static {
-		if (MAP.isEmpty()) {
-			for (FastDataInCommandID c : values()) {
-				MAP.put(c.value, c);
-			}
+		for (FastDataInCommandID c : values()) {
+			MAP.put(c.value, c);
 		}
 	}
 	

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
@@ -38,6 +38,14 @@ public enum FastDataInCommandID {
 
 	private static final Map<Integer, FastDataInCommandID> MAP =
 			new HashMap<>();
+	static {
+		if (MAP.isEmpty()) {
+			for (FastDataInCommandID c : values()) {
+				MAP.put(c.value, c);
+			}
+		}
+	}
+	
 	/** The protocol ID of this constant. */
 	public final int value;
 
@@ -55,11 +63,6 @@ public enum FastDataInCommandID {
 	 *             if the value isn't one of the ones accepted by this class.
 	 */
 	public static FastDataInCommandID forValue(int value) {
-		if (MAP.isEmpty()) {
-			for (FastDataInCommandID c : values()) {
-				MAP.put(c.value, c);
-			}
-		}
 		FastDataInCommandID id = MAP.get(value);
 		if (id == null) {
 			throw new IllegalArgumentException(

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInCommandID.java
@@ -43,7 +43,7 @@ public enum FastDataInCommandID {
 			MAP.put(c.value, c);
 		}
 	}
-	
+
 	/** The protocol ID of this constant. */
 	public final int value;
 


### PR DESCRIPTION
(Hopefully) fixes an issue with the integration tests seen on occasion:
```
java.lang.IllegalArgumentException: unexpected command code: 2003

	at uk.ac.manchester.spinnaker.front_end.dse.FastDataInCommandID.forValue(FastDataInCommandID.java:65) ~[spinnaker-exe.jar:?]

	at uk.ac.manchester.spinnaker.front_end.dse.FastExecuteDataSpecification$BoardWorker.fastWrite(FastExecuteDataSpecification.java:705) 
```

