### PR TITLE
Scamp for memory

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -254,7 +254,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 
 	private int malloc(CoreToLoad ctl, Integer bytesUsed)
 			throws IOException, ProcessException {
-		return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed, 
+		return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed,
 				new AppID(ctl.appID));
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -233,7 +233,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 			for (CoreToLoad ctl : cores) {
 				int start = malloc(ctl, ctl.sizeToWrite);
 				int user0 = txrx.getUser0RegisterAddress(ctl.core);
-				txrx.writeMemory(ctl.core, user0, start);
+				txrx.writeMemory(ctl.core.getScampCore(), user0, start);
 				addresses.put(ctl, start);
 			}
 
@@ -254,7 +254,8 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 
 	private int malloc(CoreToLoad ctl, Integer bytesUsed)
 			throws IOException, ProcessException {
-		return txrx.mallocSDRAM(ctl.core, bytesUsed, new AppID(ctl.appID));
+		return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed, 
+				new AppID(ctl.appID));
 	}
 
 	@Override


### PR DESCRIPTION
This uses the SCAMP core for SDRAM memory writes during fast data execution.  This could probably also be done in other parts of the code too, as well as anywhere that reads SDRAM; going to the core itself is just an extra hop that is not needed.  Not sure if this is the correct solution; alternatives include doing this at the lower levels.

Note that this is particularly useful on large machines. Why, you ask?  Because when a large machine has been on long enough, there is a reasonable probability that one of the "idle" cores (running SARK) will have been crashed by a Single Event Upset (I have seen this happen on one machine).  If you then try to speak to that core directly, it will fail, but when the binary is loaded later it will start to work again!  As SCAMP is just one of the cores, the probability of an SEU taking out the SCAMP core is less (and this happens, you can't recover from this as easily anyway).  So speaking to SCAMP cores for SDRAM interaction is a good idea!