### PR TITLE
Add testing support for OpenJDK 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jobs:
   include:
     - dist: focal
       jdk: openjdk11
+    - dist: focal
+      jdk: openjdk14
     - dist: xenial
       jdk: openjdk8
 cache:

--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -105,6 +105,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 					<configuration>
 						<!-- Some tests are timing-sensitive. -->
 						<rerunFailingTestsCount>5</rerunFailingTestsCount>
+						<systemProperties>
+							<property>
+								<!-- Silence a stupid message: BEANUTILS-477 resolution was idiotic, but we're stuck with it -->
+								<name>java.util.logging.config.file</name>
+								<value>${project.build.testOutputDirectory}/logging.properties</value>
+							</property>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<configuration>
+						<systemProperties>
+							<property>
+								<!-- Silence a stupid message: BEANUTILS-477 resolution was idiotic, but we're stuck with it -->
+								<name>java.util.logging.config.file</name>
+								<value>${project.build.testOutputDirectory}/logging.properties</value>
+							</property>
+						</systemProperties>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -21,7 +21,6 @@ import static java.lang.Short.toUnsignedInt;
 import static java.lang.String.format;
 import static java.lang.System.nanoTime;
 import static java.lang.Thread.sleep;
-import static java.lang.Thread.yield;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
@@ -30,6 +29,7 @@ import static uk.ac.manchester.spinnaker.messages.Constants.SCP_RETRY_DEFAULT;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_TIMEOUT_DEFAULT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
 import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
+import static uk.ac.manchester.spinnaker.utils.WaitUtils.waitUntil;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -190,13 +190,9 @@ public class SCPRequestPipeline {
 		}
 
 		private void send() throws IOException {
-			long now = nanoTime();
-			while (now - nextSendTime < 0) {
-				yield();
-				now = nanoTime();
-			}
-			nextSendTime = now + INTER_SEND_INTERVAL_NS;
+			waitUntil(nextSendTime);
 			connection.send(requestData.asReadOnlyBuffer());
+			nextSendTime = nanoTime() + INTER_SEND_INTERVAL_NS;
 		}
 
 		/**

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/SupportUtils.java
@@ -51,7 +51,12 @@ abstract class SupportUtils {
 		Thread t = new Daemon(() -> {
 			try {
 				s.connect();
-			} catch (Exception e) {
+			} catch (IOException e) {
+				// Just totally ignore early closing of sockets
+				if (!e.getMessage().equals("Socket closed")) {
+					e.printStackTrace(System.err);
+				}
+			} catch (RuntimeException e) {
 				e.printStackTrace(System.err);
 			}
 		}, "background accept");

--- a/SpiNNaker-comms/src/test/resources/logging.properties
+++ b/SpiNNaker-comms/src/test/resources/logging.properties
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+.level=INFO
+org.apache.commons.beanutils.level=WARNING

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -120,6 +120,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 									</manifestEntries>
 								</transformer>
 							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<!-- Strip unwanted junk -->
+										<exclude>META-INF/MANIFEST.MF</exclude>
+										<exclude>META-INF/LICENSE</exclude>
+										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>META-INF/NOTICE</exclude>
+										<exclude>META-INF/NOTICE.txt</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
@@ -16,8 +16,10 @@
  */
 package uk.ac.manchester.spinnaker.front_end.download;
 
+import static java.lang.System.nanoTime;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
+import static uk.ac.manchester.spinnaker.utils.WaitUtils.waitUntil;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -62,11 +64,9 @@ final class GatherDownloadConnection extends SDPConnection {
 	}
 
 	private void sendMsg(SDPMessage msg) throws IOException {
-		while (System.nanoTime() < lastSend + INTER_SEND_INTERVAL_NS) {
-			Thread.yield();
-		}
-		lastSend = System.nanoTime();
+		waitUntil(lastSend + INTER_SEND_INTERVAL_NS);
 		send(msg);
+		lastSend = nanoTime();
 	}
 
 	/**

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/WaitUtils.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/WaitUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.utils;
+
+import static java.lang.System.nanoTime;
+
+/**
+ * Utilities for waiting very short periods of time.
+ *
+ * @author Donal Fellows
+ */
+public abstract class WaitUtils {
+	private WaitUtils() {
+	}
+
+	/**
+	 * Wait until the given time has passed. May decide to not wait at all.
+	 *
+	 * @param nanoTimestamp
+	 *            The first time at which the code may return. If in the past,
+	 *            returns immediately.
+	 * @see java.lang.System#nanoTime()
+	 */
+	public static void waitUntil(long nanoTimestamp) {
+		// Critical: this is static so JRE can inline this code!
+
+		// BUSY LOOP! https://stackoverflow.com/q/11498585/301832
+		while (nanoTime() < nanoTimestamp) {
+			// The yield makes this a bit less CPU intensive
+			Thread.yield();
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>3.2.0</version>
+					<version>3.1.1</version>
 					<configuration>
 						<configLocation>src/support/checkstyle/style.xml</configLocation>
 					</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+
 		<spinnaker.version>5.1.1-SNAPSHOT</spinnaker.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<log4j.version>2.13.0</log4j.version>
 		<junit.version>5.6.0</junit.version>
 		<checkstyle.version>8.29</checkstyle.version>
+
+		<testing.version>3.0.0-M4</testing.version>
+		<jacoco.version>0.8.5</jacoco.version>
   	</properties>
 
 	<dependencyManagement>
@@ -173,7 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.7.0</version>
+					<version>3.8.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -193,12 +197,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.2.1</version>
+					<version>3.2.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.0</version>
+					<version>${testing.version}</version>
 					<configuration>
 						<trimStackTrace>false</trimStackTrace>
 					</configuration>
@@ -206,12 +210,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.2</version>
+					<version>3.2.3</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.0</version>
 					<configuration>
 						<configLocation>src/support/checkstyle/style.xml</configLocation>
 					</configuration>
@@ -257,7 +261,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.22.0</version>
+					<version>${testing.version}</version>
 					<executions>
 						<execution>
 							<id>integration-test</id>
@@ -276,7 +280,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.2</version>
+					<version>${jacoco.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.rat</groupId>


### PR DESCRIPTION
This adds in testing of our code with OpenJDK 14, the current Long Term Support release.

It also fixes (or quietens, where a fix is impractical) a number of warnings found during the process.