### PR TITLE
Make coveralls work again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,6 @@ jobs:
         java: [8, 11, 14]
     steps:
     - uses: actions/checkout@v2
-    - name: Set branch name and PR number
-      id: refs
-      env:
-        BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
-      run: |
-        echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
-        echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ on:
     - cron: "40 4 * * *"
 env:
   SETTINGS_FILE: .github/settings.xml
-  CI_NAME: "Github Actions"
 
 jobs:
   test:
@@ -36,11 +35,9 @@ jobs:
       id: refs
       env:
         BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
-        COVERALLS_SECRET: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |
         echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
         echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-        echo "::set-output name=secret_present::$(test -n "$COVERALLS_SECRET"; echo $?)"
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
@@ -61,14 +58,16 @@ jobs:
     - name: "Check: Test"
       run: mvn verify --settings $SETTINGS_FILE -Dmaven.javadoc.skip=true jacoco:report
     - name: "Report: Coverage via coveralls.io"
-      if: steps.refs.outputs.secret_present > 0
-      run: mvn coveralls:report --settings $SETTINGS_FILE --no-transfer-progress -DrepoToken=$COVERALLS_SECRET
+      run: |
+        export CI_BRANCH=${BRANCH_NAME_OR_REF#refs/heads/}
+        export CI_PULL_REQUEST=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        mvn coveralls:report --settings $SETTINGS_FILE --no-transfer-progress -DrepoToken=$COVERALLS_SECRET
       env:
+        CI_NAME: github
+        BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
         CI_BUILD_NUMBER: ${{ github.run_id }}
         CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
-        CI_BRANCH: ${{ steps.refs.outputs.branch_name }}
-        CI_PULL_REQUEST: ${{ steps.refs.outputs.pr_number }}
-        COVERALLS_SECRET: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Build (JDK 8 only)
       if: matrix.java == 8
       uses: actions/upload-artifact@v2
@@ -90,15 +89,6 @@ jobs:
         java: [8]
     steps:
     - uses: actions/checkout@v2
-    - name: Set branch name and PR number
-      id: refs
-      env:
-        BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
-        COVERALLS_SECRET: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
-        echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-        echo "::set-output name=secret_present::$(test -n "$COVERALLS_SECRET"; echo $?)"
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Need to fix the CI name (to `github`, which is special to coveralls these days) and the secret (to the Github main token, which coveralls needs to be able to comment back on the PR).