### PR TITLE
Move magic number into a private named constant

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostSendSequencedData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/HostSendSequencedData.java
@@ -33,6 +33,8 @@ public class HostSendSequencedData extends EIEIOCommandMessage {
 	public final int sequenceNum;
 	/** The data. */
 	public final EIEIODataMessage eieioDataMessage;
+	/** The length of the payload of the message. */
+	private static final int PAYLOAD_LENGTH = 2;
 
 	/**
 	 * Create a message.
@@ -62,7 +64,7 @@ public class HostSendSequencedData extends EIEIOCommandMessage {
 
 	@Override
 	public int minPacketLength() {
-		return super.minPacketLength() + 2;
+		return super.minPacketLength() + PAYLOAD_LENGTH;
 	}
 
 	@Override


### PR DESCRIPTION
fixes #173

I'm not convinced that we need the `minPacketLength()` method at all on the Java side at all, but that's a whole 'nother kettle of fish.