### PR TITLE
Publish maven packages 

### DIFF
--- a/.github/workflows/publish-pkgs.yml
+++ b/.github/workflows/publish-pkgs.yml
@@ -1,0 +1,20 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest 
+    permissions: 
+      contents: read
+      packages: write 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-pkgs.yml
+++ b/.github/workflows/publish-pkgs.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 name: Publish package to GitHub Packages
 on:
   release:

--- a/.github/workflows/publish-pkgs.yml
+++ b/.github/workflows/publish-pkgs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Publish package
         run: mvn --batch-mode deploy
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<url>http://spinnakermanchester.github.io/JavaSpiNNaker</url>
 		</site>
 	</distributionManagement>
-
 	<mailingLists>
 		<mailingList>
 			<name>SpiNNaker Users Group</name>

--- a/pom.xml
+++ b/pom.xml
@@ -431,12 +431,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker/actions</url>
 	</ciManagement>
 	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/SpiNNakerManchester/JavaSpiNNaker</url>
+		</repository>
 		<site>
 			<id>github-pages</id>
 			<name>GitHub Pages</name>
 			<url>http://spinnakermanchester.github.io/JavaSpiNNaker</url>
 		</site>
 	</distributionManagement>
+
 	<mailingLists>
 		<mailingList>
 			<name>SpiNNaker Users Group</name>
@@ -579,14 +585,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			</plugin>
 		</plugins>
 	</reporting>
-
-	<distributionManagement>
-		<repository>
-			<id>github</id>
-			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/SpiNNakerManchester/JavaSpiNNaker</url>
-		</repository>
-	</distributionManagement>
 
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		</plugins>
 	</reporting>
 
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/SpiNNakerManchester/JavaSpiNNaker</url>
+		</repository>
+	</distributionManagement>
+
 	<profiles>
 		<profile>
 			<id>MergedBuild</id>


### PR DESCRIPTION
It'd be nice to publish the Java packages automatically. Unfortunately, publishing to Maven Central requires some DNS trickery to get started and I'm _really_ not willing to try to prod that side of things! But… Github hosts a Maven repository system too. That'd surely do for our basic needs.

This PR adds a workflow so that when we do a release (i.e., approximately whenever we tag a release) that release _automatically_ gets published.

----

See https://docs.github.com/en/actions/guides/publishing-java-packages-with-maven for details of what's going on in this PR.
