### PR TITLE
Better auth challenge

### DIFF
--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<packaging>war</packaging>
 	<properties>
 		<spring.boot.version>2.4.7</spring.boot.version>
-		<spring.version>5.3.7</spring.version>
+		<spring.version>5.3.8</spring.version>
 		<jackson.version>2.12.3</jackson.version>
 		<swagger.version>3.50.0</swagger.version>
 		<jsontaglib.version>1.0.5</jsontaglib.version>
@@ -319,6 +319,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<version>${log4j.version}</version>
 				<scope>runtime</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>swagger-ui</artifactId>
+				<version>${swagger.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.livesense</groupId>
+				<artifactId>org.liveSense.scripting.jsp.taglib.jsonatg</artifactId>
+				<version>${jsontaglib.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -326,10 +337,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>java-hamcrest</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -403,7 +416,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>swagger-ui</artifactId>
-			<version>${swagger.version}</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.skyscreamer</groupId>
@@ -427,7 +440,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>com.github.livesense</groupId>
 			<artifactId>org.liveSense.scripting.jsp.taglib.jsonatg</artifactId>
-			<version>${jsontaglib.version}</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -453,6 +466,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/AppAuthTransformationFilter.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/AppAuthTransformationFilter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021-2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static uk.ac.manchester.spinnaker.alloc.LocalAuthProviderImpl.isUnsupportedAuthTokenClass;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import uk.ac.manchester.spinnaker.alloc.SecurityConfig.LocalAuthenticationProvider;
+
+/**
+ * A filter to apply authentication transformation as supplied by the
+ * {@link LocalAuthenticationProvider}. Relies on the session ID being updated
+ * to ensure that stale login information is not retained.
+ *
+ * @see LocalAuthenticationProvider#updateAuthentication(SecurityContext)
+ */
+@Component
+public class AppAuthTransformationFilter extends OncePerRequestFilter {
+	/**
+	 * The name of session fixation tokens supported by this class.
+	 */
+	private static final String TOKEN =
+			AppAuthTransformationFilter.class.getName();
+
+	@Autowired
+	private LocalAuthenticationProvider localAuthProvider;
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request)
+			throws ServletException {
+		Authentication a =
+				SecurityContextHolder.getContext().getAuthentication();
+		return isNull(a) || isUnsupportedAuthTokenClass(a.getClass());
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+			HttpServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpSession s = request.getSession(false);
+		SecurityContext ctx = SecurityContextHolder.getContext();
+		Authentication savedAuth = getSavedToken(s);
+		Authentication originalAuth = ctx.getAuthentication();
+		if (nonNull(savedAuth)) {
+			ctx.setAuthentication(savedAuth);
+		} else {
+			Authentication a = localAuthProvider.updateAuthentication(ctx);
+			if (nonNull(a)) {
+				saveToken(s, a);
+			}
+		}
+		try {
+			chain.doFilter(request, response);
+		} finally {
+			ctx.setAuthentication(originalAuth);
+		}
+	}
+
+	private static Authentication getSavedToken(HttpSession session) {
+		if (nonNull(session)) {
+			Object o = session.getAttribute(TOKEN);
+			if (o instanceof Token) {
+				Token t = (Token) o;
+				if (t.isValid(session)) {
+					return t.getAuth();
+				}
+			}
+		}
+		return null;
+	}
+
+	private static void saveToken(HttpSession session, Authentication auth) {
+		if (nonNull(session)) {
+			session.setAttribute(TOKEN, new Token(session, auth));
+		}
+	}
+
+	/**
+	 * Ensure that any authentication token that was bound into the session is
+	 * removed.
+	 *
+	 * @param request
+	 *            the HTTP request; used for looking up the session
+	 */
+	public static void clearToken(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (nonNull(session)) {
+			session.removeAttribute(TOKEN);
+		}
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/LocalAuthProviderImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/LocalAuthProviderImpl.java
@@ -220,13 +220,14 @@ public class LocalAuthProviderImpl extends DatabaseAwareBean
 					log.debug("filter updated security from {} to {}", current,
 							updated);
 					ctx.setAuthentication(updated);
+					return updated;
 				}
 			} else if (!isUnsupportedAuthTokenClass(current.getClass())) {
 				log.warn("unexpected authentication type {} (token: {})",
 						current.getClass(), current);
 			}
 		}
-		return current;
+		return null;
 	}
 
 	/** The classes that we know what to do about. */

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SecurityConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SecurityConfig.java
@@ -30,8 +30,7 @@ import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
-import static uk.ac.manchester.spinnaker.alloc.LocalAuthProviderImpl.isUnsupportedAuthTokenClass;
-import static uk.ac.manchester.spinnaker.alloc.SecurityConfig.AppAuthTransformationFilter.clearToken;
+import static uk.ac.manchester.spinnaker.alloc.AppAuthTransformationFilter.clearToken;
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfig.TrustLevel.USER;
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfigUtils.installInjectableTrustStoreAsDefault;
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfigUtils.loadTrustStore;
@@ -66,7 +65,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -109,7 +107,6 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -397,91 +394,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.addLogoutHandler((req, resp, auth) -> clearToken(req))
 				.deleteCookies(SESSION_COOKIE).invalidateHttpSession(true)
 				.logoutSuccessUrl(loginUrl);
-	}
-
-	/**
-	 * A filter to apply authentication transformation as supplied by the
-	 * {@link LocalAuthenticationProvider}. Relies on the session ID being
-	 * updated to ensure that stale login information is not retained.
-	 *
-	 * @see LocalAuthenticationProvider#updateAuthentication(SecurityContext)
-	 */
-	@Component
-	public static class AppAuthTransformationFilter
-			extends OncePerRequestFilter {
-		/**
-		 * The name of session fixation tokens supported by this class.
-		 */
-		private static final String TOKEN =
-				AppAuthTransformationFilter.class.getName();
-
-		@Autowired
-		private LocalAuthenticationProvider localAuthProvider;
-
-		@Override
-		protected boolean shouldNotFilter(HttpServletRequest request)
-				throws ServletException {
-			Authentication a =
-					SecurityContextHolder.getContext().getAuthentication();
-			return isNull(a) || isUnsupportedAuthTokenClass(a.getClass());
-		}
-
-		@Override
-		protected void doFilterInternal(HttpServletRequest request,
-				HttpServletResponse response, FilterChain chain)
-				throws IOException, ServletException {
-			HttpSession s = request.getSession(false);
-			SecurityContext ctx = SecurityContextHolder.getContext();
-			Authentication savedAuth = getSavedToken(s);
-			Authentication originalAuth = ctx.getAuthentication();
-			if (nonNull(savedAuth)) {
-				ctx.setAuthentication(savedAuth);
-			} else {
-				Authentication a = localAuthProvider.updateAuthentication(ctx);
-				if (nonNull(a)) {
-					saveToken(s, a);
-				}
-			}
-			try {
-				chain.doFilter(request, response);
-			} finally {
-				ctx.setAuthentication(originalAuth);
-			}
-		}
-
-		private static Authentication getSavedToken(HttpSession session) {
-			if (nonNull(session)) {
-				Object o = session.getAttribute(TOKEN);
-				if (o instanceof Token) {
-					Token t = (Token) o;
-					if (t.isValid(session)) {
-						return t.getAuth();
-					}
-				}
-			}
-			return null;
-		}
-
-		private static void saveToken(HttpSession session,
-				Authentication auth) {
-			if (nonNull(session)) {
-				session.setAttribute(TOKEN, new Token(session, auth));
-			}
-		}
-
-		/**
-		 * Ensure that any authentication token that was bound into the session
-		 * is removed.
-		 *
-		 * @param request
-		 *            the HTTP request; used for looking up the session
-		 */
-		public static void clearToken(HttpServletRequest request) {
-			HttpSession session = request.getSession(false);
-			if (nonNull(session)) {
-				session.removeAttribute(TOKEN);
-			}
-		}
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -20,6 +20,8 @@ import static java.util.Objects.nonNull;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.validation.Valid;
 import javax.validation.constraints.AssertTrue;
@@ -808,6 +810,11 @@ public class SpallocProperties {
 		private String domain;
 
 		/**
+		 * The scopes desired. Referred to elsewhere in the configuration file.
+		 */
+		private Set<String> scopes;
+
+		/**
 		 * The application installation identity. Required for allowing people
 		 * to use HBP/EBRAINS identities.
 		 */
@@ -834,6 +841,7 @@ public class SpallocProperties {
 		@SuppressWarnings("checkstyle:ParameterNumber")
 		public OpenIDProperties(@DefaultValue("false") boolean enable,
 				@DefaultValue("") String domain, //
+				Set<String> scopes, //
 				@DefaultValue("") String id, //
 				@DefaultValue("") String secret,
 				@DefaultValue("openid.") String usernamePrefix,
@@ -843,6 +851,7 @@ public class SpallocProperties {
 				@DefaultValue("") String truststorePassword) {
 			this.enable = enable;
 			this.domain = domain;
+			this.setScopes(scopes != null ? scopes : new HashSet<>());
 			this.id = id;
 			this.secret = secret;
 			this.usernamePrefix = usernamePrefix;
@@ -920,6 +929,19 @@ public class SpallocProperties {
 
 		public void setDomain(String domain) {
 			this.domain = domain;
+		}
+
+		/**
+		 * The scopes desired. Referred to elsewhere in the configuration file.
+		 *
+		 * @return The OpenID scopes.
+		 */
+		public Set<String> getScopes() {
+			return scopes;
+		}
+
+		public void setScopes(Set<String> scopes) {
+			this.scopes = scopes;
 		}
 
 		/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -618,6 +618,11 @@ public class SpallocProperties {
 		private boolean basic;
 
 		/**
+		 * The authentication realm. Must not contain quote characters!
+		 */
+		private String realm;
+
+		/**
 		 * Whether to enable HTTP form+session authentication. Much faster than
 		 * BASIC, but requires a more complex client. You must enable this if
 		 * you are supporting the Web UI.
@@ -659,6 +664,7 @@ public class SpallocProperties {
 		@SuppressWarnings("checkstyle:ParameterNumber")
 		public AuthProperties(//
 				@DefaultValue("true") boolean basic,
+				@DefaultValue("SpallocService") String realm,
 				@DefaultValue("true") boolean localForm,
 				@DefaultValue("false") boolean addDummyUser,
 				@DefaultValue("true") boolean dummyRandomPass,
@@ -668,6 +674,7 @@ public class SpallocProperties {
 				@DefaultValue("60s") Duration unlockPeriod,
 				@DefaultValue OpenIDProperties openid) {
 			this.basic = basic;
+			this.realm = realm;
 			this.localForm = localForm;
 			this.addDummyUser = addDummyUser;
 			this.dummyRandomPass = dummyRandomPass;
@@ -690,6 +697,19 @@ public class SpallocProperties {
 
 		public void setBasic(boolean basic) {
 			this.basic = basic;
+		}
+
+		/**
+		 * The authentication realm. Must not contain quote characters!
+		 *
+		 * @return the realm.
+		 */
+		public String getRealm() {
+			return realm;
+		}
+
+		public void setRealm(String realm) {
+			this.realm = realm;
 		}
 
 		/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminAPI.java
@@ -22,6 +22,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfig.IS_ADMIN;
 import static uk.ac.manchester.spinnaker.alloc.admin.AdminAPI.Paths.USER;
+import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.SERV;
 
 import java.net.URI;
 import java.util.Map;
@@ -65,7 +66,7 @@ public interface AdminAPI {
 	 */
 	interface Paths {
 		/** The location of the admin "service". */
-		String BASE_PATH = "/admin";
+		String BASE_PATH = SERV + "/admin";
 
 		/** Service root. */
 		String ROOT = "/";

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminController.java
@@ -36,6 +36,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import uk.ac.manchester.spinnaker.alloc.model.BoardRecord;
 import uk.ac.manchester.spinnaker.alloc.model.UserRecord;
+import uk.ac.manchester.spinnaker.alloc.web.SystemController;
 
 /**
  * The API for the controller for the admin user interface.
@@ -46,7 +47,7 @@ import uk.ac.manchester.spinnaker.alloc.model.UserRecord;
 @PreAuthorize(IS_ADMIN)
 public interface AdminController {
 	/** The base path of this interface within the MVC domain. */
-	String BASE_PATH = "/admin";
+	String BASE_PATH = SystemController.ROOT_PATH + "/admin";
 
 	/** Path to all-users operations. */
 	String USERS_PATH = "/users";

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminControllerImpl.java
@@ -26,6 +26,7 @@ import static org.springframework.web.servlet.support.ServletUriComponentsBuilde
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfig.IS_ADMIN;
 import static uk.ac.manchester.spinnaker.alloc.SecurityConfig.MVC_ERROR;
 import static uk.ac.manchester.spinnaker.alloc.db.Row.string;
+import static uk.ac.manchester.spinnaker.alloc.web.SystemController.USER_MAY_CHANGE_PASSWORD;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +43,9 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -145,6 +149,10 @@ public class AdminControllerImpl extends DatabaseAwareBean
 		mav.addObject("createUserUri", uri(SELF.getUserCreationForm()));
 		mav.addObject("boardsUri", uri(SELF.boards()));
 		mav.addObject("machineUri", uri(SELF.machineUploadForm()));
+		Authentication auth =
+				SecurityContextHolder.getContext().getAuthentication();
+		mav.addObject(USER_MAY_CHANGE_PASSWORD,
+				auth instanceof UsernamePasswordAuthenticationToken);
 		return mav;
 	}
 
@@ -206,17 +214,15 @@ public class AdminControllerImpl extends DatabaseAwareBean
 			return errors("database access failed: " + e.getMessage());
 		}
 
-		ModelAndView mav = new ModelAndView(USER_LIST_VIEW);
-		mav.addObject("userlist", unmodifiableMap(result));
-		return addStandardContext(mav);
+		return addStandardContext(new ModelAndView(USER_LIST_VIEW, "userlist",
+				unmodifiableMap(result)));
 	}
 
 	@Override
 	@GetMapping(CREATE_USER_PATH)
 	public ModelAndView getUserCreationForm() {
-		ModelAndView mav = new ModelAndView(CREATE_USER_VIEW);
-		mav.addObject(USER_OBJ, new UserRecord());
-		return addStandardContext(mav);
+		return addStandardContext(
+				new ModelAndView(CREATE_USER_VIEW, USER_OBJ, new UserRecord()));
 	}
 
 	@Override

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
@@ -50,6 +50,12 @@ public interface SystemController {
 	String USER_PASSWORD_CHANGE_ATTR = "user";
 
 	/**
+	 * The name of the boolean view attribute describing whether the password
+	 * change form may be used. Only local users may change their password!
+	 */
+	String USER_MAY_CHANGE_PASSWORD = "userMayChangePassword";
+
+	/**
 	 * Get the view for the main page of the service.
 	 *
 	 * @return View name

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
@@ -41,8 +41,11 @@ import uk.ac.manchester.spinnaker.alloc.model.PasswordChangeRecord;
  *
  * @author Donal Fellows
  */
-@RequestMapping("/system")
+@RequestMapping(SystemController.ROOT_PATH)
 public interface SystemController {
+	/** The root path to the controller within the overall application. */
+	String ROOT_PATH = "/system";
+
 	/** The name of the main attribute supporting a password change form. */
 	String USER_PASSWORD_CHANGE_ATTR = "user";
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
@@ -68,7 +68,7 @@ import uk.ac.manchester.spinnaker.alloc.model.PasswordChangeRecord;
  * @author Donal Fellows
  */
 @Controller
-@RequestMapping("/system")
+@RequestMapping(SystemController.ROOT_PATH)
 public class SystemControllerImpl implements SystemController {
 	private static final Logger log = getLogger(SystemControllerImpl.class);
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
@@ -51,7 +51,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 
-import uk.ac.manchester.spinnaker.alloc.SecurityConfig.AppAuthTransformationFilter;
+import uk.ac.manchester.spinnaker.alloc.AppAuthTransformationFilter;
 import uk.ac.manchester.spinnaker.alloc.SecurityConfig.Permit;
 import uk.ac.manchester.spinnaker.alloc.ServiceConfig.URLPathMaker;
 import uk.ac.manchester.spinnaker.alloc.ServiceVersion;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
@@ -51,6 +51,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 
+import uk.ac.manchester.spinnaker.alloc.SecurityConfig.AppAuthTransformationFilter;
 import uk.ac.manchester.spinnaker.alloc.SecurityConfig.Permit;
 import uk.ac.manchester.spinnaker.alloc.ServiceConfig.URLPathMaker;
 import uk.ac.manchester.spinnaker.alloc.ServiceVersion;
@@ -156,6 +157,7 @@ public class SystemControllerImpl implements SystemController {
 	public String performLogout(HttpServletRequest request,
 			HttpServletResponse response) {
 		Authentication auth = getContext().getAuthentication();
+		AppAuthTransformationFilter.clearToken(request);
 		if (nonNull(auth)) {
 			log.info("logging out {}", auth.getPrincipal());
 			logoutHandler.logout(request, response, auth);

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -15,7 +15,8 @@
 
 logging:
   file:
-    name: ${spalloc.working-directory}/spalloc.log
+    name: spalloc.log
+    path: ${spalloc.working-directory}
   level:
     root: INFO
     # "[org.apache.catalina]": DEBUG
@@ -57,6 +58,10 @@ spring:
 
 server:
   port: 8080
+  servlet:
+    session:
+      # NOTE: Make sure this is longer than spalloc.keepalive.max
+      timeout: 30m
 
 cxf:
   path: /spalloc/srv

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -145,7 +145,10 @@ spalloc:
       # Support OIDC
       enable: true
       domain: https://iam.ebrains.eu/auth/realms/hbp
-      scopes: [ openid, profile, email ]
+      scopes: &oidcscopes
+        - openid
+        - profile
+        - email
       # The credentials for HBP/EBRAINS go here
       id: spinnaker-spalloc
       secret: XYZZY_OVERRIDE_THIS
@@ -212,8 +215,7 @@ spring:
           hbp-ebrains:
             client-id: ${spalloc.auth.openid.id}
             client-secret: ${spalloc.auth.openid.secret}
-            # Repeated from spalloc.auth.openid.scopes, but can't share!
-            scope: [ openid, profile, email ]
+            scope: *oidcscopes
             authorization-grant-type: authorization_code
             redirect-uri: https://{baseHost}{basePort}{basePath}/system/perform_oidc/{action}/code/{registrationId}
         provider:

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -145,10 +145,7 @@ spalloc:
       # Support OIDC
       enable: true
       domain: https://iam.ebrains.eu/auth/realms/hbp
-      scopes: &oidcscopes
-        - openid
-        - profile
-        - email
+      scopes: [ openid, profile, email ]
       # The credentials for HBP/EBRAINS go here
       id: spinnaker-spalloc
       secret: XYZZY_OVERRIDE_THIS
@@ -215,7 +212,8 @@ spring:
           hbp-ebrains:
             client-id: ${spalloc.auth.openid.id}
             client-secret: ${spalloc.auth.openid.secret}
-            scope: *oidcscopes
+            # Repeated from spalloc.auth.openid.scopes, but can't share!
+            scope: [ openid, profile, email ]
             authorization-grant-type: authorization_code
             redirect-uri: https://{baseHost}{basePort}{basePath}/system/perform_oidc/{action}/code/{registrationId}
         provider:

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -202,7 +202,9 @@ spalloc:
 # sheer nastiness of interacting with Keycloak and the fact that it is done
 # during application boot. Putting it here makes things more reliable.
 spring:
-  profiles: default
+  config:
+    activate:
+      on-profile: default
   security:
     oauth2:
       client:

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -210,7 +210,8 @@ spring:
           hbp-ebrains:
             client-id: ${spalloc.auth.openid.id}
             client-secret: ${spalloc.auth.openid.secret}
-            scope: ${spalloc.auth.openid.scopes}
+            # Repeated from spalloc.auth.openid.scopes, but can't share!
+            scope: [ openid, profile, email ]
             authorization-grant-type: authorization_code
             redirect-uri: https://{baseHost}{basePort}{basePath}/system/perform_oidc/{action}/code/{registrationId}
         provider:

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -138,6 +138,7 @@ spalloc:
       # Support OIDC
       enable: true
       domain: https://iam.ebrains.eu/auth/realms/hbp
+      scopes: [ openid, profile, email ]
       # The credentials for HBP/EBRAINS go here
       id: spinnaker-spalloc
       secret: XYZZY_OVERRIDE_THIS
@@ -202,7 +203,7 @@ spring:
           hbp-ebrains:
             client-id: ${spalloc.auth.openid.id}
             client-secret: ${spalloc.auth.openid.secret}
-            scope: [ openid, profile, email ]
+            scope: ${spalloc.auth.openid.scopes}
             authorization-grant-type: authorization_code
             redirect-uri: https://{baseHost}{basePort}{basePath}/system/perform_oidc/{action}/code/{registrationId}
         provider:

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -117,8 +117,10 @@ spalloc:
       to: SPINNAKER@listserv.manchester.ac.uk
       subject: Spalloc Board Issue
   auth:
-    # Support HTTP Basic Authentication (bad for browsers, OK for code)
+    # Support HTTP Basic Authentication (bad for browsers, OK for code, slow)
     basic: true
+    # The authentication realm, used for both Basic and Bearer (openid) auth
+    realm: SpallocService
     # Support HTTP Form Authentication (pretty necessary)
     local-form: true
     # Force a known local admin user to exist with a known password

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/basicfooter.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/basicfooter.jsp
@@ -18,8 +18,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <footer>
 <hr>
 <a href="<c:url value="/spalloc/system/"/>">Main page</a>
+<c:if test="${ userMayChangePassword }">
 &mdash;
 <a href="<c:url value="/spalloc/system/change_password"/>">Change password</a>
+</c:if>
 &mdash;
 <a href="<c:url value="/spalloc/system/perform_logout"/>">Log out</a>
 </footer>


### PR DESCRIPTION
Improve the auth challenge so that it says that both HTTP Basic and OIDC Bearer tokens are supported as auth methods. 