### PR TITLE
Factor out versions

### DIFF
--- a/SpiNNaker-allocator/pom.xml
+++ b/SpiNNaker-allocator/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-allocator</artifactId>
 	<packaging>jar</packaging>

--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-allocserv</artifactId>
 	<packaging>war</packaging>

--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-comms</artifactId>
 	<description>How to actually talk to a SpiNNaker machine and to Spalloc, the allocation service.</description>

--- a/SpiNNaker-data-specification/pom.xml
+++ b/SpiNNaker-data-specification/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-data-specification</artifactId>
 	<description>Data specification generator and executor</description>

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -20,8 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-front-end</artifactId>
 	<properties>

--- a/SpiNNaker-machine/pom.xml
+++ b/SpiNNaker-machine/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-machine</artifactId>
 	<dependencies>

--- a/SpiNNaker-pacman/pom.xml
+++ b/SpiNNaker-pacman/pom.xml
@@ -20,8 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-pacman</artifactId>
 	<description>Implementation of the Partitioning and Configuration Manager (PACMAN).</description>

--- a/SpiNNaker-py2json/pom.xml
+++ b/SpiNNaker-py2json/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-py2json</artifactId>
 	<name>Python Configuration to JSON Converter</name>

--- a/SpiNNaker-storage/pom.xml
+++ b/SpiNNaker-storage/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-storage</artifactId>
 	<dependencies>

--- a/SpiNNaker-utils/pom.xml
+++ b/SpiNNaker-utils/pom.xml
@@ -21,8 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>SpiNNaker-utils</artifactId>
 	<description>General utilities for the SpiNNaker runtime.</description>

--- a/keycloak-management-client/pom.xml
+++ b/keycloak-management-client/pom.xml
@@ -22,8 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
-		<artifactId>SpiNNaker</artifactId>
+		<artifactId>versions</artifactId>
 		<version>6.0.1-SNAPSHOT</version>
+		<relativePath>../versions</relativePath>
 	</parent>
 	<artifactId>keycloak-management-client</artifactId>
 	<name>Keycloak Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<artifactId>SpiNNaker</artifactId>
 	<version>6.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<name>SpiNNaker Java Host</name>
+	<description>Implementation of the host software for SpiNNaker in Java.</description>
+	<inceptionYear>2018</inceptionYear>
+	<url>http://spinnakermanchester.github.io/</url>
+	<organization>
+		<name>SpiNNaker Team @ University of Manchester</name>
+		<url>http://apt.cs.manchester.ac.uk/projects/SpiNNaker/</url>
+	</organization>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -62,202 +70,118 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<exec.version>3.0.0</exec.version>
 	</properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-bom</artifactId>
-				<version>${log4j.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson</groupId>
-				<artifactId>jackson-bom</artifactId>
-				<version>${jackson.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-framework-bom</artifactId>
-				<version>${spring.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.hamcrest</groupId>
-				<artifactId>java-hamcrest</artifactId>
-				<version>2.0.0.0</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>uk.ac.manchester.spinnaker</groupId>
-				<artifactId>SpiNNaker-utils</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>uk.ac.manchester.spinnaker</groupId>
-				<artifactId>SpiNNaker-machine</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>uk.ac.manchester.spinnaker</groupId>
-				<artifactId>SpiNNaker-storage</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>uk.ac.manchester.spinnaker</groupId>
-				<artifactId>SpiNNaker-comms</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>uk.ac.manchester.spinnaker</groupId>
-				<artifactId>SpiNNaker-data-specification</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>${slf4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-api</artifactId>
-				<version>${log4j.version}</version>
-				<scope>runtime</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-slf4j-impl</artifactId>
-				<version>${log4j.version}</version>
-				<scope>runtime</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.module</groupId>
-				<artifactId>jackson-module-jaxb-annotations</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>20211205</version>
-			</dependency>
-			<dependency>
-				<groupId>org.skyscreamer</groupId>
-				<artifactId>jsonassert</artifactId>
-				<version>1.5.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-configuration2</artifactId>
-				<version>2.7</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-beanutils</groupId>
-				<artifactId>commons-beanutils</artifactId>
-				<version>1.9.4</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.11.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.12.0</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-cli</groupId>
-				<artifactId>commons-cli</artifactId>
-				<version>1.5.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-math3</artifactId>
-				<version>3.6.1</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-text</artifactId>
-				<version>1.9</version>
-			</dependency>
-			<dependency>
-				<groupId>org.xerial</groupId>
-				<artifactId>sqlite-jdbc</artifactId>
-				<version>${sqlite.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.googlecode.java-diff-utils</groupId>
-				<artifactId>diffutils</artifactId>
-				<version>1.3.0</version>
-			</dependency>
-			<dependency>
-				<groupId>net.jcip</groupId>
-				<artifactId>jcip-annotations</artifactId>
-				<version>1.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.cxf</groupId>
-				<artifactId>cxf-rt-frontend-jaxrs</artifactId>
-				<version>${cxf.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-core</artifactId>
-				<version>${spring.security.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax</groupId>
-				<artifactId>javaee-api</artifactId>
-				<version>8.0.1</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.cxf</groupId>
-				<artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
-				<version>${cxf.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-test</artifactId>
-				<version>${spring.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>info.picocli</groupId>
-				<artifactId>picocli</artifactId>
-				<version>4.6.1</version>
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-client-registration-api</artifactId>
-				<version>${keycloak.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.webjars</groupId>
-				<artifactId>swagger-ui</artifactId>
-				<version>${swagger.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.github.livesense</groupId>
-				<artifactId>org.liveSense.scripting.jsp.taglib.jsonatg</artifactId>
-				<version>${jsontaglib.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.python</groupId>
-				<artifactId>jython-slim</artifactId>
-				<version>${jython.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+	<licenses>
+		<license>
+			<url>https://www.gnu.org/licenses/gpl-3.0.en.html</url>
+			<name>GNU General Public License, version 3</name>
+			<distribution>manual</distribution>
+		</license>
+	</licenses>
+	<scm>
+		<connection>scm:git:https://github.com/SpiNNakerManchester/JavaSpiNNaker.git</connection>
+		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker</url>
+	</scm>
+	<issueManagement>
+		<system>github</system>
+		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>github</system>
+		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker/actions</url>
+	</ciManagement>
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/SpiNNakerManchester/JavaSpiNNaker</url>
+		</repository>
+		<site>
+			<id>github-pages</id>
+			<name>GitHub Pages</name>
+			<url>http://spinnakermanchester.github.io/JavaSpiNNaker</url>
+		</site>
+	</distributionManagement>
+	<mailingLists>
+		<mailingList>
+			<name>SpiNNaker Users Group</name>
+			<post>spinnakerusers@googlegroups.com</post>
+			<subscribe>spinnakerusers+subscribe@googlegroups.com</subscribe>
+			<unsubscribe>spinnakerusers+unsubscribe@googlegroups.com</unsubscribe>
+			<archive>https://groups.google.com/g/spinnakerusers</archive>
+		</mailingList>
+	</mailingLists>
+	<developers>
+		<!-- IDs are github logins -->
+		<developer>
+			<id>andrewgait</id>
+			<name>Andrew Gait</name>
+			<roles>
+				<role>New Feature Development</role>
+				<role>User Support</role>
+			</roles>
+			<organization>The University of Manchester</organization>
+			<url>https://personalpages.manchester.ac.uk/staff/Andrew.Gait/</url>
+		</developer>
+		<developer>
+			<id>agr</id>
+			<name>Andrew Rowley</name>
+			<roles>
+				<role>New Feature Development</role>
+				<role>Architectural Design</role>
+				<role>Project Liaison</role>
+				<role>Dissemination</role>
+			</roles>
+			<organization>The University of Manchester</organization>
+		</developer>
+		<developer>
+			<id>Christian-B</id>
+			<name>Christian Brenninkmeijer</name>
+			<roles>
+				<role>New Feature Development</role>
+				<role>Software Testing</role>
+				<role>Continuous Integration Control</role>
+			</roles>
+			<organization>The University of Manchester</organization>
+		</developer>
+		<developer>
+			<id>dkfellows</id>
+			<name>Donal Fellows</name>
+			<roles>
+				<role>New Feature Development</role>
+				<role>Low-Level Maintenance</role>
+				<role>Software Quality Control</role>
+				<role>Continuous Integration Control</role>
+			</roles>
+			<organization>The University of Manchester</organization>
+			<url>https://github.com/dkfellows</url>
+		</developer>
+		<developer>
+			<id>sfurber</id>
+			<name>Steve Furber</name>
+			<roles>
+				<role>Head of SpiNNaker Project</role>
+			</roles>
+			<organization>The University of Manchester</organization>
+			<url>http://apt.cs.manchester.ac.uk/people/sfurber/</url>
+		</developer>
+		<developer>
+			<id>alan-stokes</id>
+			<name>Alan Stokes</name>
+			<roles>
+				<role>Emeritus</role>
+			</roles>
+			<organization>STFC (ex University of Manchester)</organization>
+		</developer>
+		<developer>
+			<id>oliverrhodes</id>
+			<name>Oliver Rhodes</name>
+			<roles>
+				<role>Emeritus</role>
+			</roles>
+			<url>https://www.research.manchester.ac.uk/portal/oliver.rhodes.html</url>
+			<organization>The University of Manchester</organization>
+		</developer>
+	</developers>
 
 	<build>
 		<pluginManagement>
@@ -573,6 +497,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	</build>
 
 	<modules>
+		<module>versions</module>
 		<module>SpiNNaker-utils</module>
 		<module>SpiNNaker-machine</module>
 		<module>SpiNNaker-storage</module>
@@ -584,126 +509,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<module>SpiNNaker-py2json</module>
 		<module>SpiNNaker-allocator</module>
 	</modules>
-	<name>SpiNNaker Java Host</name>
-	<description>Implementation of the host software for SpiNNaker in Java.</description>
-	<inceptionYear>2018</inceptionYear>
-	<url>http://spinnakermanchester.github.io/</url>
-	<organization>
-		<name>SpiNNaker Team @ University of Manchester</name>
-		<url>http://apt.cs.manchester.ac.uk/projects/SpiNNaker/</url>
-	</organization>
-	<licenses>
-		<license>
-			<url>https://www.gnu.org/licenses/gpl-3.0.en.html</url>
-			<name>GNU General Public License, version 3</name>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-	<scm>
-		<connection>scm:git:https://github.com/SpiNNakerManchester/JavaSpiNNaker.git</connection>
-		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker</url>
-	</scm>
-	<issueManagement>
-		<system>github</system>
-		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues</url>
-	</issueManagement>
-	<ciManagement>
-		<system>github</system>
-		<url>https://github.com/SpiNNakerManchester/JavaSpiNNaker/actions</url>
-	</ciManagement>
-	<distributionManagement>
-		<repository>
-			<id>github</id>
-			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/SpiNNakerManchester/JavaSpiNNaker</url>
-		</repository>
-		<site>
-			<id>github-pages</id>
-			<name>GitHub Pages</name>
-			<url>http://spinnakermanchester.github.io/JavaSpiNNaker</url>
-		</site>
-	</distributionManagement>
-	<mailingLists>
-		<mailingList>
-			<name>SpiNNaker Users Group</name>
-			<post>spinnakerusers@googlegroups.com</post>
-			<subscribe>spinnakerusers+subscribe@googlegroups.com</subscribe>
-			<unsubscribe>spinnakerusers+unsubscribe@googlegroups.com</unsubscribe>
-			<archive>https://groups.google.com/g/spinnakerusers</archive>
-		</mailingList>
-	</mailingLists>
-	<developers>
-		<!-- IDs are github logins -->
-		<developer>
-			<id>andrewgait</id>
-			<name>Andrew Gait</name>
-			<roles>
-				<role>New Feature Development</role>
-				<role>User Support</role>
-			</roles>
-			<organization>The University of Manchester</organization>
-			<url>https://personalpages.manchester.ac.uk/staff/Andrew.Gait/</url>
-		</developer>
-		<developer>
-			<id>agr</id>
-			<name>Andrew Rowley</name>
-			<roles>
-				<role>New Feature Development</role>
-				<role>Architectural Design</role>
-				<role>Project Liaison</role>
-				<role>Dissemination</role>
-			</roles>
-			<organization>The University of Manchester</organization>
-		</developer>
-		<developer>
-			<id>Christian-B</id>
-			<name>Christian Brenninkmeijer</name>
-			<roles>
-				<role>New Feature Development</role>
-				<role>Software Testing</role>
-				<role>Continuous Integration Control</role>
-			</roles>
-			<organization>The University of Manchester</organization>
-		</developer>
-		<developer>
-			<id>dkfellows</id>
-			<name>Donal Fellows</name>
-			<roles>
-				<role>New Feature Development</role>
-				<role>Low-Level Maintenance</role>
-				<role>Software Quality Control</role>
-				<role>Continuous Integration Control</role>
-			</roles>
-			<organization>The University of Manchester</organization>
-			<url>https://github.com/dkfellows</url>
-		</developer>
-		<developer>
-			<id>sfurber</id>
-			<name>Steve Furber</name>
-			<roles>
-				<role>Head of SpiNNaker Project</role>
-			</roles>
-			<organization>The University of Manchester</organization>
-			<url>http://apt.cs.manchester.ac.uk/people/sfurber/</url>
-		</developer>
-		<developer>
-			<id>alan-stokes</id>
-			<name>Alan Stokes</name>
-			<roles>
-				<role>Emeritus</role>
-			</roles>
-			<organization>STFC (ex University of Manchester)</organization>
-		</developer>
-		<developer>
-			<id>oliverrhodes</id>
-			<name>Oliver Rhodes</name>
-			<roles>
-				<role>Emeritus</role>
-			</roles>
-			<url>https://www.research.manchester.ac.uk/portal/oliver.rhodes.html</url>
-			<organization>The University of Manchester</organization>
-		</developer>
-	</developers>
 
 	<reporting>
 		<plugins>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2018 The University of Manchester
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>uk.ac.manchester.spinnaker</groupId>
+		<artifactId>SpiNNaker</artifactId>
+		<version>6.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>versions</artifactId>
+	<packaging>pom</packaging>
+	<name>Dependency Version Configuration</name>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${log4j.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>${spring.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>java-hamcrest</artifactId>
+				<version>2.0.0.0</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>uk.ac.manchester.spinnaker</groupId>
+				<artifactId>SpiNNaker-utils</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>uk.ac.manchester.spinnaker</groupId>
+				<artifactId>SpiNNaker-machine</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>uk.ac.manchester.spinnaker</groupId>
+				<artifactId>SpiNNaker-storage</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>uk.ac.manchester.spinnaker</groupId>
+				<artifactId>SpiNNaker-comms</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>uk.ac.manchester.spinnaker</groupId>
+				<artifactId>SpiNNaker-data-specification</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${log4j.version}</version>
+				<scope>runtime</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-slf4j-impl</artifactId>
+				<version>${log4j.version}</version>
+				<scope>runtime</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-jaxb-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>20211205</version>
+			</dependency>
+			<dependency>
+				<groupId>org.skyscreamer</groupId>
+				<artifactId>jsonassert</artifactId>
+				<version>1.5.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-configuration2</artifactId>
+				<version>2.7</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.11.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>1.5.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-math3</artifactId>
+				<version>3.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.xerial</groupId>
+				<artifactId>sqlite-jdbc</artifactId>
+				<version>${sqlite.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.googlecode.java-diff-utils</groupId>
+				<artifactId>diffutils</artifactId>
+				<version>1.3.0</version>
+			</dependency>
+			<dependency>
+				<groupId>net.jcip</groupId>
+				<artifactId>jcip-annotations</artifactId>
+				<version>1.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-rt-frontend-jaxrs</artifactId>
+				<version>${cxf.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.security</groupId>
+				<artifactId>spring-security-core</artifactId>
+				<version>${spring.security.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>javax</groupId>
+				<artifactId>javaee-api</artifactId>
+				<version>8.0.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
+				<version>${cxf.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-test</artifactId>
+				<version>${spring.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>info.picocli</groupId>
+				<artifactId>picocli</artifactId>
+				<version>4.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-client-registration-api</artifactId>
+				<version>${keycloak.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>swagger-ui</artifactId>
+				<version>${swagger.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.livesense</groupId>
+				<artifactId>org.liveSense.scripting.jsp.taglib.jsonatg</artifactId>
+				<version>${jsontaglib.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.python</groupId>
+				<artifactId>jython-slim</artifactId>
+				<version>${jython.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+</project>


### PR DESCRIPTION
Moves the version binding of most dependencies into its own package.

Unfortunately, this doesn't seem to be working quite as well as I hoped. It functions correctly… but it still has to leave lots of things in the parent, specifically the version bindings for the plugin (and reporting) dependencies, and I don't think all of those can be moved. (Some can. Maybe. Some definitely can't.)

I plan to leave this here as a record that we _can_ do this, but a recommendation that we don't bother.