### PR TITLE
Proxy

### DIFF
--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -352,6 +352,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
 		</dependency>

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -82,6 +82,8 @@ public class SpallocProperties {
 
 	private CompatibilityProperties compat;
 
+	private ProxyProperties proxy;
+
 	public SpallocProperties(//
 			@DefaultValue("spalloc.sqlite3") File databasePath,
 			@DefaultValue("30s") Duration wait,
@@ -92,6 +94,7 @@ public class SpallocProperties {
 			@DefaultValue CompatibilityProperties compat,
 			@DefaultValue HistoricalDataProperties historicalData,
 			@DefaultValue KeepaliveProperties keepalive,
+			@DefaultValue ProxyProperties proxy,
 			@DefaultValue QuotaProperties quota,
 			@DefaultValue DBProperties sqlite,
 			@DefaultValue TxrxProperties transceiver) {
@@ -104,6 +107,7 @@ public class SpallocProperties {
 		this.compat = compat;
 		this.historicalData = historicalData;
 		this.keepalive = keepalive;
+		this.proxy = proxy;
 		this.quota = quota;
 		this.sqlite = sqlite;
 		this.transceiver = transceiver;
@@ -227,6 +231,17 @@ public class SpallocProperties {
 
 	public void setAuth(AuthProperties auth) {
 		this.auth = auth;
+	}
+
+	/**
+	 * @return Properties relating to the SDP proxying.
+	 */
+	public ProxyProperties getProxy() {
+		return proxy;
+	}
+
+	public void setProxy(ProxyProperties proxy) {
+		this.proxy = proxy;
 	}
 
 	/**
@@ -1713,6 +1728,45 @@ public class SpallocProperties {
 
 		public void setDefaultKeepalive(Duration value) {
 			this.defaultKeepalive = value;
+		}
+	}
+
+	/** Settings for the proxies. */
+	public static class ProxyProperties {
+		/** Whether to enable the UDP proxy subsystem. */
+		private boolean enable;
+
+		/**
+		 * Whether to log the number of packets read and written on each
+		 * channel.
+		 */
+		private boolean logWriteCounts;
+
+		public ProxyProperties(@DefaultValue("true") boolean enable,
+				@DefaultValue("false") boolean logWriteCounts) {
+			this.enable = enable;
+			this.logWriteCounts = logWriteCounts;
+		}
+
+		/** @return Whether to enable the UDP proxy subsystem. */
+		public boolean isEnable() {
+			return enable;
+		}
+
+		public void setEnable(boolean enable) {
+			this.enable = enable;
+		}
+
+		/**
+		 * @return Whether to log the number of packets read and written on each
+		 *         channel.
+		 */
+		public boolean isLogWriteCounts() {
+			return logWriteCounts;
+		}
+
+		public void setLogWriteCounts(boolean logWriteCounts) {
+			this.logWriteCounts = logWriteCounts;
 		}
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/AdminControllerImpl.java
@@ -736,4 +736,10 @@ public class AdminControllerImpl extends DatabaseAwareBean
 					"problem with processing file: " + e.getMessage());
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(GroupType t) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/UserControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/UserControl.java
@@ -916,4 +916,10 @@ public class UserControl extends DatabaseAwareBean {
 		});
 		return mr;
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(SQLQueries q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -96,7 +96,7 @@ public class AllocatorTask extends DatabaseAwareBean
 	private HistoricalDataProperties historyProps;
 
 	@Autowired
-	private Spalloc spallocCore;
+	private ProxyRememberer rememberer;
 
 	/**
 	 * Helper class representing a rectangle of triads.
@@ -575,7 +575,7 @@ public class AllocatorTask extends DatabaseAwareBean
 			sql.killAlloc.call(id);
 			return sql.markAsDestroyed.call(reason, id) > 0;
 		} finally {
-			spallocCore.killProxies(id);
+			rememberer.killProxies(id);
 		}
 	}
 
@@ -870,7 +870,7 @@ public class AllocatorTask extends DatabaseAwareBean
 		log.debug("allocated {} boards to {}; issuing power up commands",
 				boardsToAllocate.size(), jobId);
 		// Any proxies that existed are now defunct; user must make anew
-		spallocCore.killProxies(jobId);
+		rememberer.killProxies(jobId);
 		return setPower(sql, jobId, ON, READY);
 	}
 
@@ -882,7 +882,7 @@ public class AllocatorTask extends DatabaseAwareBean
 			}
 		});
 		if (updated) {
-			spallocCore.killProxies(jobId);
+			rememberer.killProxies(jobId);
 			epochs.nextMachineEpoch();
 			epochs.nextJobsEpoch();
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -964,4 +964,10 @@ public class AllocatorTask extends DatabaseAwareBean
 
 		return numPending > 0;
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(SQLQueries q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -95,6 +95,9 @@ public class AllocatorTask extends DatabaseAwareBean
 	@Autowired
 	private HistoricalDataProperties historyProps;
 
+	@Autowired
+	private Spalloc spallocCore;
+
 	/**
 	 * Helper class representing a rectangle of triads.
 	 *
@@ -571,6 +574,8 @@ public class AllocatorTask extends DatabaseAwareBean
 			setPower(sql, id, OFF, DESTROYED);
 			sql.killAlloc.call(id);
 			return sql.markAsDestroyed.call(reason, id) > 0;
+		} finally {
+			spallocCore.killProxies(id);
 		}
 	}
 
@@ -864,6 +869,8 @@ public class AllocatorTask extends DatabaseAwareBean
 				boardsToAllocate.get(0), boardsToAllocate.size(), jobId);
 		log.debug("allocated {} boards to {}; issuing power up commands",
 				boardsToAllocate.size(), jobId);
+		// Any proxies that existed are now defunct; user must make anew
+		spallocCore.killProxies(jobId);
 		return setPower(sql, jobId, ON, READY);
 	}
 
@@ -875,6 +882,7 @@ public class AllocatorTask extends DatabaseAwareBean
 			}
 		});
 		if (updated) {
+			spallocCore.killProxies(jobId);
 			epochs.nextMachineEpoch();
 			epochs.nextJobsEpoch();
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/ProxyRememberer.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/ProxyRememberer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc.allocator;
+
+import static java.util.Objects.nonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PreDestroy;
+
+import org.springframework.stereotype.Component;
+
+import uk.ac.manchester.spinnaker.alloc.proxy.ProxyCore;
+
+/**
+ * Remembers websocket proxies so that they can be closed when the state of a
+ * job invalidates them. This class takes care to be thread-safe. The
+ * information it holds is <em>not</em> persistent.
+ *
+ * @author Donal Fellows
+ */
+@Component
+class ProxyRememberer {
+	private final Map<Integer, List<ProxyCore>> proxies = new HashMap<>();
+
+	/**
+	 * Called when service is shutting down. Kill <em>everything!</em>
+	 */
+	@PreDestroy
+	private void closeAllProxies() {
+		synchronized (proxies) {
+			proxies.values().forEach(list -> list.forEach(ProxyCore::close));
+			proxies.clear(); // Just in case
+		}
+	}
+
+	/**
+	 * Note down that a job has a websocket proxy active.
+	 *
+	 * @param jobId
+	 *            The job ID.
+	 * @param proxy
+	 *            The websocket proxy.
+	 */
+	void rememberProxyForJob(Integer jobId, ProxyCore proxy) {
+		synchronized (proxies) {
+			proxies.computeIfAbsent(jobId, ignored -> new ArrayList<>())
+					.add(proxy);
+		}
+	}
+
+	/**
+	 * Stop remembering a job's particular websocket proxy.
+	 *
+	 * @param jobId
+	 *            The job ID.
+	 * @param proxy
+	 *            The websocket proxy.
+	 */
+	void removeProxyForJob(Integer jobId, ProxyCore proxy) {
+		synchronized (proxies) {
+			List<ProxyCore> list = proxies.get(jobId);
+			if (nonNull(list)) {
+				list.remove(proxy);
+			}
+		}
+	}
+
+	private List<ProxyCore> removeProxyListForJob(Integer jobId) {
+		synchronized (proxies) {
+			return proxies.remove(jobId);
+		}
+	}
+
+	/**
+	 * Close all remembered websocket proxies for a job. This is called when the
+	 * state of a job changes significantly (i.e., when the set of boards that
+	 * may be communicated with changes).
+	 *
+	 * @param jobId
+	 *            The job ID.
+	 */
+	void killProxies(Integer jobId) {
+		List<ProxyCore> list = removeProxyListForJob(jobId);
+		if (nonNull(list)) {
+			list.forEach(ProxyCore::close);
+		}
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
@@ -966,3 +966,8 @@ public interface SpallocAPI {
 		void setPower(PowerState powerState);
 	}
 }
+
+abstract class SpallocAPIUseInJavadoc {
+	SpallocAPIUseInJavadoc(V1CompatService q1, HasCoreLocation q2) {
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
@@ -38,6 +38,7 @@ import uk.ac.manchester.spinnaker.alloc.model.JobState;
 import uk.ac.manchester.spinnaker.alloc.model.MachineDescription;
 import uk.ac.manchester.spinnaker.alloc.model.MachineListEntryRecord;
 import uk.ac.manchester.spinnaker.alloc.model.PowerState;
+import uk.ac.manchester.spinnaker.alloc.proxy.ProxyCore;
 import uk.ac.manchester.spinnaker.alloc.security.Permit;
 import uk.ac.manchester.spinnaker.alloc.web.IssueReportRequest;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
@@ -666,6 +667,25 @@ public interface SpallocAPI {
 		 * @return The text part of the response
 		 */
 		String reportIssue(IssueReportRequest reqBody, Permit permit);
+
+		/**
+		 * Note that a proxy has been set up for the job. This allows the proxy
+		 * to be closed when the job state changes. (The proxy may already be
+		 * closed at that point.)
+		 *
+		 * @param proxy
+		 *            The proxy.
+		 */
+		void rememberProxy(ProxyCore proxy);
+
+		/**
+		 * Note that a proxy has been dropped from the job and doesn't need to
+		 * be remembered any more.
+		 *
+		 * @param proxy
+		 *            The proxy.
+		 */
+		void forgetProxy(ProxyCore proxy);
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -957,4 +957,10 @@ public class BMPController extends DatabaseAwareBean {
 			return true;
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(ThreadFactory q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
@@ -68,8 +68,7 @@ public interface SpiNNakerControl {
 	 * @throws IOException
 	 *             If network I/O fails.
 	 */
-	void setLinkOff(Link link)
-			throws ProcessException, IOException;
+	void setLinkOff(Link link) throws ProcessException, IOException;
 
 	/**
 	 * Turn off boards managed by a BMP. Turning off a board also turns off its
@@ -96,4 +95,27 @@ public interface SpiNNakerControl {
 	 *            board.
 	 */
 	void setIdToBoardMap(Map<Integer, Integer> idToBoard);
+
+	/**
+	 * A guide for how to make a BMP controller.
+	 *
+	 * @author Donal Fellows
+	 */
+	@FunctionalInterface
+	interface Factory {
+		/**
+		 * Create a SpiNNaker board controller. Note that this is only provided
+		 * for reference. It is up to the caller to ensure that the controller
+		 * is the only controller that talks to a particular BMP; <em>it is
+		 * <strong>essential</strong> that only one controller and one thread
+		 * accesses a BMP in order to prevent the BMP from crashing!</em>
+		 *
+		 * @param machine
+		 *            The machine that this will be managing.
+		 * @param coords
+		 *            The coordinates of the BMP that this will manage.
+		 * @return The board controller.
+		 */
+		SpiNNakerControl create(Machine machine, BMPCoords coords);
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -2008,3 +2008,13 @@ public abstract class SQLQueries {
 	@Value("classpath:queries/copy-allocs-to-historical-data.sql")
 	protected Resource copyAllocsToHistoricalData;
 }
+
+interface SQLQueriesUseImportsForCheckstyle {
+	/** For Checkstyle. */
+	Class<?>[] CLASSES = {
+		DirInfo.class, MachineDefinitionLoader.class, MachineStateControl.class,
+		UserControl.class, AllocatorTask.class, QuotaManager.class,
+		Spalloc.class, BMPController.class, BoardIssueReport.class,
+		LocalAuthProviderImpl.class
+	};
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/TerminationNotifyingThreadFactory.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/TerminationNotifyingThreadFactory.java
@@ -61,4 +61,10 @@ public class TerminationNotifyingThreadFactory implements ThreadFactory {
 			}
 		});
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(Executors q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/UncheckedConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/UncheckedConnection.java
@@ -601,4 +601,10 @@ class UncheckedConnection implements Connection {
 			throw mapException(e, null);
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(DataAccessException q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/BoardIssueReport.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/BoardIssueReport.java
@@ -105,4 +105,10 @@ public class BoardIssueReport {
 	public void setTimestamp(Instant timestamp) {
 		this.timestamp = timestamp;
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(SQLQueries q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/UserRecord.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/UserRecord.java
@@ -312,4 +312,10 @@ public final class UserRecord {
 			setLocked(false);
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(SQLQueries q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -137,7 +137,7 @@ public class ProxyCore implements AutoCloseable {
 
 	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
 
-	private IntSupplier idIssuer;
+	private final IntSupplier idIssuer;
 
 	private final ThreadGroup threadGroup;
 
@@ -155,6 +155,7 @@ public class ProxyCore implements AutoCloseable {
 			ThreadGroup threadGroup, IntSupplier idIssuer) {
 		session = s;
 		this.threadGroup = threadGroup;
+		this.idIssuer = idIssuer;
 		for (ConnectionInfo ci : connections) {
 			try {
 				hosts.put(ci.getChip(),

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -309,11 +309,14 @@ public class ProxyCore implements AutoCloseable {
 	 */
 	protected ByteBuffer sendMessage(ByteBuffer message) throws IOException {
 		Integer id = message.getInt();
+		log.info("got message for channel {}", id);
 		ProxyUDPConnection conn;
 		synchronized (conns) {
 			conn = conns.get(id);
 		}
 		if (conn != null && !conn.isClosed()) {
+			log.info("sending message to {} of length {}", conn,
+					message.remaining());
 			conn.send(message.slice());
 		}
 		return null;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc.proxy;
+
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.springframework.web.socket.CloseStatus.BAD_DATA;
+import static org.springframework.web.socket.CloseStatus.SERVER_ERROR;
+import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import uk.ac.manchester.spinnaker.alloc.model.ConnectionInfo;
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
+
+/**
+ * The main proxy class for a particular web socket session. It's bound to a
+ * job, which should be running at the time that the web socket is opened. The
+ * protocol that is supported is a binary protocol that has three messages:
+ * <table border>
+ * <tr>
+ * <th>Name</th>
+ * <th>Request Layout (words)</th>
+ * <th>Response Layout (words)</th>
+ * <th>Meaning</th>
+ * </tr>
+ * <tr>
+ * <td>{@linkplain #openConnection(ByteBuffer) Open Connection}</td>
+ * <td><table border>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN 0}
+ * <td>Chip X
+ * <td>Chip Y
+ * <td>UDP Port on Chip
+ * </tr>
+ * </table>
+ * </td>
+ * <td><table border>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN 0}
+ * <td>Connection ID
+ * </tr>
+ * </table>
+ * </td>
+ * <td>Establish a UDP socket that will talk to the given Ethernet chip within
+ * the allocation. Returns an ID that can be used to refer to that connection.
+ * Note that opening a socket declares that you are prepared to receive messages
+ * from SpiNNaker on it, but does not mean that SpiNNaker will send any messages
+ * that way.</td>
+ * </tr>
+ * <tr>
+ * <td>{@linkplain #closeConnection(ByteBuffer) Close Connection}</td>
+ * <td><table border>
+ * <tr>
+ * <td>{@link ProxyOp#CLOSE 1}
+ * <td>Connection ID
+ * </tr>
+ * </table>
+ * </td>
+ * <td><table border>
+ * <tr>
+ * <td>{@link ProxyOp#CLOSE 1}
+ * <td>Connection ID (if closed)
+ * </tr>
+ * </table>
+ * </td>
+ * <td>Close an established UDP socket, given its ID. Returns the ID on success,
+ * and an empty message on failure (e.g., because the socket is already
+ * closed).</td>
+ * </tr>
+ * <tr>
+ * <td>{@linkplain #sendMessage(ByteBuffer) Send Message}</td>
+ * <td><table border>
+ * <tr>
+ * <td>{@link ProxyOp#MESSAGE 2}
+ * <td>Connection ID
+ * <td>Raw message bytes...
+ * </tr>
+ * </table>
+ * </td>
+ * <td>N/A</td>
+ * <td>Send a message to SpiNNaker on a particular established UDP
+ * configuration. This is technically one-way, but messages come back in the
+ * same format (i.e., a 4 byte prefix to say that it is a message, and another 4
+ * bytes to say what socket this is talking about). The raw message bytes
+ * (<em>including</em> the half-word of ethernet frame padding) follow the
+ * header.</td>
+ * </tr>
+ * </table>
+ *
+ * @author Donal Fellows
+ */
+public class ProxyCore implements AutoCloseable {
+	private static final int MAX_PORT = 65535;
+
+	private final WebSocketSession session;
+
+	private final Map<ChipLocation, InetAddress> hosts = new HashMap<>();
+
+	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
+
+	private int count;
+
+	private final ThreadGroup threadGroup;
+
+	ProxyCore(WebSocketSession s, List<ConnectionInfo> connections,
+			ThreadGroup threadGroup) {
+		session = s;
+		this.threadGroup = threadGroup;
+		for (ConnectionInfo ci : connections) {
+			try {
+				hosts.put(ci.getChip(),
+						InetAddress.getByName(ci.getHostname()));
+			} catch (UnknownHostException e) {
+				// TODO log this
+			}
+		}
+	}
+
+	/**
+	 * Handle a message sent to this service on the web socket associated with
+	 * this object.
+	 *
+	 * @param message
+	 *            The content of the message.
+	 * @throws IOException
+	 */
+	public void handleClientMessage(ByteBuffer message) throws IOException {
+		try {
+			ByteBuffer reply;
+			switch (ProxyOp.values()[message.getInt()]) {
+			case OPEN:
+				reply = openConnection(message);
+				break;
+			case CLOSE:
+				reply = closeConnection(message);
+				break;
+			case MESSAGE:
+				reply = sendMessage(message);
+				break;
+			default:
+				reply = null;
+			}
+			if (reply != null) {
+				reply.flip();
+				session.sendMessage(new BinaryMessage(reply));
+			}
+		} catch (IOException e) {
+			session.close(SERVER_ERROR);
+		} catch (IllegalArgumentException | BufferUnderflowException e) {
+			session.close(BAD_DATA);
+		}
+	}
+
+	/**
+	 * Open a connection. Note that no control over the local (to the service)
+	 * port number or address is provided, nor is a mechanism given to easily
+	 * make available what address is used (though it can be obtained from the
+	 * IPTag).
+	 *
+	 * @param message
+	 *            The message received. The initial 4-byte type code will have
+	 *            been already read out of the buffer.
+	 * @return The response message to send, in the bytes leading up to the
+	 *         position. The caller will {@linkplain ByteBuffer#flip() flip} the
+	 *         message. If {@code null}, no response will be sent.
+	 * @throws IOException
+	 *             If the proxy connection can't be opened.
+	 * @throws IllegalArgumentException
+	 *             If bad arguments are supplied.
+	 */
+	protected ByteBuffer openConnection(ByteBuffer message) throws IOException {
+		int x = message.getInt();
+		int y = message.getInt();
+		int port = message.getInt();
+		if (port < 1 || port > MAX_PORT) {
+			throw new IllegalArgumentException("bad port number");
+		}
+		InetAddress who = hosts.get(new ChipLocation(x, y));
+		if (who == null) {
+			throw new IllegalArgumentException("unrecognised ethernet chip");
+		}
+
+		int id = ++count;
+		ProxyUDPConnection conn =
+				new ProxyUDPConnection(session, who, port, id);
+		conns.put(id, conn);
+
+		// Start sending messages received from the board
+		Thread t = new Thread(threadGroup, conn::receiveLoop,
+				"WS handler for " + who);
+		t.setDaemon(true);
+		t.start();
+
+		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
+		msg.putInt(ProxyOp.OPEN.ordinal());
+		msg.putInt(id);
+		return msg;
+	}
+
+	/**
+	 * Close a connection. It's not an error to close a connection twice
+	 *
+	 * @param message
+	 *            The message received. The initial 4-byte type code will have
+	 *            been already read out of the buffer.
+	 * @return The response message to send, in the bytes leading up to the
+	 *         position. The caller will {@linkplain ByteBuffer#flip() flip} the
+	 *         message. If {@code null}, no response will be sent.
+	 * @throws IOException
+	 *             If the proxy connection can't be opened.
+	 */
+	protected ByteBuffer closeConnection(ByteBuffer message)
+			throws IOException {
+		Integer id = message.getInt();
+		ProxyUDPConnection conn = conns.remove(id);
+		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
+		msg.putInt(ProxyOp.CLOSE.ordinal());
+		if (conn != null && !conn.isClosed()) {
+			conn.close();
+			msg.putInt(id);
+		}
+		return msg;
+		// Thread will shut down now that the proxy is closed
+	}
+
+	/**
+	 * Send a message on a connection. It's not an error to send on a
+	 * non-existant or closed connection.
+	 *
+	 * @param message
+	 *            The message received. The initial 4-byte type code will have
+	 *            been already read out of the buffer.
+	 * @return The response message to send, in the bytes leading up to the
+	 *         position. The caller will {@linkplain ByteBuffer#flip() flip} the
+	 *         message. If {@code null}, no response will be sent (expected case
+	 *         for this operation!)
+	 * @throws IOException
+	 *             If the proxy connection can't be opened.
+	 */
+	protected ByteBuffer sendMessage(ByteBuffer message) throws IOException {
+		Integer id = message.getInt();
+		ProxyUDPConnection conn = conns.get(id);
+		if (conn != null && !conn.isClosed()) {
+			conn.send(message.slice());
+		}
+		return null;
+	}
+
+	@Override
+	public void close() {
+		// Take a copy immediately
+		for (ProxyUDPConnection conn : new ArrayList<>(conns.values())) {
+			if (conn != null && !conn.isClosed()) {
+				try {
+					conn.close();
+				} catch (IOException e) {
+					// Don't stop what we're doing; everything must go!
+					// TODO Auto-generated catch block
+				}
+			}
+		}
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntSupplier;
 
 import org.slf4j.Logger;
 import org.springframework.web.socket.BinaryMessage;
@@ -128,12 +129,12 @@ public class ProxyCore implements AutoCloseable {
 
 	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
 
-	private int count;
+	private IntSupplier idIssuer;
 
 	private final ThreadGroup threadGroup;
 
 	ProxyCore(WebSocketSession s, List<ConnectionInfo> connections,
-			ThreadGroup threadGroup) {
+			ThreadGroup threadGroup, IntSupplier idIssuer) {
 		session = s;
 		this.threadGroup = threadGroup;
 		for (ConnectionInfo ci : connections) {
@@ -211,7 +212,7 @@ public class ProxyCore implements AutoCloseable {
 			throw new IllegalArgumentException("unrecognised ethernet chip");
 		}
 
-		int id = ++count;
+		int id = idIssuer.getAsInt();
 		ProxyUDPConnection conn = new ProxyUDPConnection(session, who, port, id,
 				() -> removeDeadConnection(id));
 		synchronized (conns) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -309,13 +309,13 @@ public class ProxyCore implements AutoCloseable {
 	 */
 	protected ByteBuffer sendMessage(ByteBuffer message) throws IOException {
 		Integer id = message.getInt();
-		log.info("got message for channel {}", id);
+		log.debug("got message for channel {}", id);
 		ProxyUDPConnection conn;
 		synchronized (conns) {
 			conn = conns.get(id);
 		}
 		if (conn != null && !conn.isClosed()) {
-			log.info("sending message to {} of length {}", conn,
+			log.debug("sending message to {} of length {}", conn,
 					message.remaining());
 			conn.send(message.slice());
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -316,7 +316,7 @@ public class ProxyCore implements AutoCloseable {
 		}
 		conn.close();
 		// Thread will shut down now that the proxy is closed
-		log.info("closed proxy connection {}:{}", session, id);
+		log.debug("closed proxy connection {}:{}", session, id);
 		if (writeCounts) {
 			conn.writeCountsToLog();
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc.proxy;
+
+/**
+ * Message codes used in proxy operations.
+ *
+ * @author Donal Fellows
+ */
+public enum ProxyOp {
+	/**
+	 * Ask for a bidirectional connection to a board to be opened. Also the
+	 * response to such a request.
+	 */
+	OPEN,
+	/**
+	 * Ask for a bidirectional connection to a board to be closed. Also the
+	 * response to such a request.
+	 */
+	CLOSE,
+	/** A message going to or from a board. Connection must be open already. */
+	MESSAGE
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -85,6 +85,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 * Core SpiNNaker message receive and dispatch-to-websocket loop.
 	 */
 	protected void receiveLoop() {
+		log.info("launched listener {}", this);
 		ByteBuffer workingBuffer =
 				allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
 		// Fixed header from this particular connection
@@ -101,6 +102,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 					// Timeout; go round the loop again.
 					continue;
 				}
+				log.info("{} received message {}", this, msg.get());
 				ByteBuffer outgoing = workingBuffer.duplicate();
 				outgoing.put(msg.get());
 				outgoing.flip();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -85,7 +85,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 * Core SpiNNaker message receive and dispatch-to-websocket loop.
 	 */
 	protected void receiveLoop() {
-		log.info("launched listener {}", this);
+		log.info("launched listener {} for channel {}", this, id);
 		ByteBuffer workingBuffer =
 				allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
 		// Fixed header from this particular connection
@@ -95,6 +95,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 		try {
 			while (!isClosed()) {
 				Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
+				log.info("{}/{} received basic message {}", this, id, msg);
 				if (!session.isOpen()) {
 					break;
 				}
@@ -102,7 +103,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 					// Timeout; go round the loop again.
 					continue;
 				}
-				log.info("{} received message {}", this, msg.get());
+				log.info("{}/{} received message {}", this, id, msg.get());
 				ByteBuffer outgoing = workingBuffer.duplicate();
 				outgoing.put(msg.get());
 				outgoing.flip();
@@ -116,6 +117,8 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 				e.addSuppressed(e1);
 			}
 			log.warn("problem in SpiNNaker-to-client", e);
+		} finally {
+			log.info("shutting down listener {} for channel {}", this, id);
 		}
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -82,7 +82,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 *         socket timed out (not an error!)
 	 */
 	@Override
-	public Optional<ByteBuffer> receiveMessage(Integer timeout)
+	public Optional<ByteBuffer> receiveMessage(int timeout)
 			throws IOException {
 		try {
 			// Raw buffer, including header bytes

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc.proxy;
+
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import uk.ac.manchester.spinnaker.connections.UDPConnection;
+
+/**
+ * The low-level handler for proxy connections.
+ *
+ * @author Donal Fellows
+ */
+public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
+	private static final int TIMEOUT = 1000;
+
+	// Plenty of room; SpiNNaker messages are quite a bit smaller than this
+	private static final int WORKING_BUFFER_SIZE = 1024;
+
+	private final WebSocketSession session;
+
+	private final int id;
+
+	ProxyUDPConnection(WebSocketSession session, InetAddress remoteHost,
+			int remotePort, int id) throws IOException {
+		super(null, null, remoteHost, remotePort);
+		this.session = session;
+		this.id = id;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return The wrapped message bytes, or {@link Optional#empty()} if the
+	 *         socket timed out (not an error!)
+	 */
+	@Override
+	public Optional<ByteBuffer> receiveMessage(Integer timeout)
+			throws IOException {
+		try {
+			// Raw buffer, including header bytes
+			return Optional.of(receive(timeout));
+		} catch (SocketTimeoutException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Core SpiNNaker message receive and dispatch-to-websocket loop.
+	 */
+	protected void receiveLoop() {
+		ByteBuffer workingBuffer =
+				allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
+		// Fixed header from this particular connection
+		workingBuffer.putInt(ProxyOp.MESSAGE.ordinal());
+		workingBuffer.putInt(id);
+
+		try {
+			while (!isClosed()) {
+				Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
+				if (!session.isOpen()) {
+					break;
+				}
+				if (!msg.isPresent()) {
+					// Timeout; go round the loop again.
+					continue;
+				}
+				ByteBuffer outgoing = workingBuffer.duplicate();
+				outgoing.put(msg.get());
+				outgoing.flip();
+				session.sendMessage(new BinaryMessage(outgoing));
+			}
+		} catch (IOException e) {
+			try {
+				// TODO remove from connections?
+				close();
+			} catch (IOException e1) {
+				// TODO log this!
+			}
+		}
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.alloc.proxy;
 
+import static java.lang.Thread.currentThread;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -48,31 +49,31 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 
 	private final WebSocketSession session;
 
-	/**
-	 * The ID. Visible so we can remove the connection from the set of
-	 * connections elsewhere.
-	 */
-	private final int id;
-
 	private final Runnable emergencyRemove;
 
 	private final ByteBuffer workingBuffer;
 
 	private final String name;
 
+	/** The number of <em>successfully</em> sent packets. */
+	private long sendCount;
+
+	/** The number of <em>successfully</em> received packets. */
+	private long receiveCount;
+
 	ProxyUDPConnection(WebSocketSession session, InetAddress remoteHost,
 			int remotePort, int id, Runnable emergencyRemove)
 			throws IOException {
 		super(null, null, remoteHost, remotePort);
 		this.session = session;
-		this.id = id;
 		this.emergencyRemove = emergencyRemove;
 		workingBuffer = allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
 		// Fixed header for this particular connection
 		workingBuffer.putInt(ProxyOp.MESSAGE.ordinal());
 		workingBuffer.putInt(id);
-		// Get the name now so it remains useful after close()
-		name = toString();
+		// Make the name now so it remains useful after close()
+		name = session.getUri() + "#" + id + " " + remoteHost + "/"
+				+ remotePort;
 	}
 
 	/**
@@ -82,36 +83,50 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 *         socket timed out (not an error!)
 	 */
 	@Override
-	public Optional<ByteBuffer> receiveMessage(int timeout)
-			throws IOException {
+	public Optional<ByteBuffer> receiveMessage(int timeout) throws IOException {
 		try {
 			// Raw buffer, including header bytes
-			return Optional.of(receive(timeout));
+			ByteBuffer msg = receive(timeout);
+			receiveCount++;
+			return Optional.of(msg);
 		} catch (SocketTimeoutException e) {
 			return Optional.empty();
 		}
 	}
 
 	/**
+	 * Send a message on this connection.
+	 *
+	 * @param msg
+	 *            The message to send.
+	 * @throws IOException
+	 *             If sending fails.
+	 */
+	public void sendMessage(ByteBuffer msg) throws IOException {
+		send(msg);
+		sendCount++;
+	}
+
+	protected void writeCountsToLog() {
+		log.info("{} message counts: sent {} received {}", name, sendCount,
+				receiveCount);
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	/**
 	 * Core SpiNNaker message receive and dispatch-to-websocket loop.
 	 */
-	protected void receiveLoop() {
-		log.info("launched listener {} for channel {}", name, id);
+	protected void receiverTask() {
+		Thread me = currentThread();
+		String oldThreadName = me.getName();
+		me.setName("ws/udp " + name);
+		log.debug("launched listener {}", name);
 		try {
-			mainLoop:
-			while (!isClosed()) {
-				while (!isReadyToReceive(TIMEOUT)) {
-					if (!session.isOpen() || isClosed()) {
-						break mainLoop;
-					}
-				}
-				Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
-				if (!msg.isPresent()) {
-					// Timeout; go round the loop again.
-					continue;
-				}
-				handleReceivedMessage(msg.get());
-			}
+			mainLoop();
 		} catch (IOException e) {
 			try {
 				close();
@@ -119,10 +134,26 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 			} catch (IOException e1) {
 				e.addSuppressed(e1);
 			}
-			log.warn("problem in SpiNNaker-to-client part of {}/{}", name, id,
-					e);
+			log.warn("problem in SpiNNaker-to-client part of {}", name, e);
 		} finally {
-			log.info("shutting down listener {} for channel {}", name, id);
+			log.debug("shutting down listener {}", name);
+			me.setName(oldThreadName);
+		}
+	}
+
+	private void mainLoop() throws IOException {
+		while (!isClosed()) {
+			while (!isReadyToReceive(TIMEOUT)) {
+				if (!session.isOpen() || isClosed()) {
+					return;
+				}
+			}
+			Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
+			if (!msg.isPresent()) {
+				// Timeout; go round the loop again.
+				continue;
+			}
+			handleReceivedMessage(msg.get());
 		}
 	}
 
@@ -135,7 +166,7 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 *             If the message can't be sent.
 	 */
 	private void handleReceivedMessage(ByteBuffer msg) throws IOException {
-		log.debug("{}/{} received message {}", name, id, msg);
+		log.debug("{} received message {}", name, msg);
 		ByteBuffer outgoing = workingBuffer.duplicate();
 		outgoing.put(msg);
 		outgoing.flip();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -77,7 +77,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 	private ConnectionIDIssuer idIssuer = new ConnectionIDIssuer();
 
 	// TODO move to proper configuration bean
-	@Value("${spalloc.proxy.writeCounts:true}")
+	@Value("${spalloc.proxy.writeCounts:false}")
 	private boolean writeCounts;
 
 	public SpinWSHandler() {
@@ -209,7 +209,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 								"job not in state where proxying permitted"));
 		session.getAttributes().put(PROXY, proxy);
 		job.rememberProxy(proxy);
-		log.info("user {} has web socket {} connected for job {}",
+		log.debug("user {} has web socket {} connected for job {}",
 				session.getPrincipal(), session, job.getId());
 	}
 
@@ -229,7 +229,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 			proxy.close();
 			job.forgetProxy(proxy);
 		}
-		log.info("user {} has disconnected web socket {}",
+		log.debug("user {} has disconnected web socket {}",
 				session.getPrincipal(), session);
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -72,7 +72,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 	}
 
 	/** The path that we match in this handler. */
-	public static final String PATH = "proxy/{id:\\\\d+}";
+	public static final String PATH = "proxy/{id:\\d+}";
 
 	/** The {@link #PATH} as a template. */
 	private final UriTemplate template = new UriTemplate("/system/" + PATH);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -148,10 +148,14 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 		/**
 		 * Issue an ID.
 		 *
-		 * @return A new ID.
+		 * @return A new ID. Never zero.
 		 */
 		private synchronized int issueId() {
-			return ++id;
+			int thisId;
+			do {
+				thisId = ++id;
+			} while (thisId == 0);
+			return thisId;
 		}
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -21,6 +21,7 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.EOFException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -175,7 +176,10 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 	@Override
 	public void handleTransportError(WebSocketSession session,
 			Throwable exception) throws Exception {
-		log.warn("transport error for {}", session, exception);
+		if (!(exception instanceof EOFException)) {
+			// We don't log EOFException
+			log.warn("transport error for {}", session, exception);
+		}
 		// Don't need to close; afterConnectionClosed() will be called next
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -294,4 +294,10 @@ abstract class Utils {
 	static boolean positive(int n) {
 		return n > 0;
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(NotFound q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.alloc.proxy;
+
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.springframework.web.socket.CloseStatus.BAD_DATA;
+import static org.springframework.web.socket.CloseStatus.SERVER_ERROR;
+import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+
+import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
+import uk.ac.manchester.spinnaker.alloc.model.ConnectionInfo;
+import uk.ac.manchester.spinnaker.alloc.security.Permit;
+import uk.ac.manchester.spinnaker.connections.UDPConnection;
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
+
+@Component
+public class SpinWSHandler extends BinaryWebSocketHandler {
+	private Map<WebSocketSession, SpinProxy> map;
+
+	@Autowired
+	private SpallocAPI spallocCore;
+
+	private ThreadGroup threadGroup;
+
+	public SpinWSHandler() {
+		threadGroup = new ThreadGroup("WebSocket proxy handlers");
+	}
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) {
+		// Connection established, but need to check auth and session binding
+		String[] parts = session.getUri().getPath().split("/");
+		int jobId = Integer.parseInt(parts[parts.length - 1]);
+		spallocCore.getJob(new Permit(session), jobId)
+				.ifPresent(job -> job.getMachine().ifPresent(
+						machine -> map.put(session, new SpinProxy(session,
+								machine.getConnections(), threadGroup))));
+	}
+
+	@Override
+	public void afterConnectionClosed(WebSocketSession session,
+			CloseStatus status) {
+		SpinProxy p = map.remove(session);
+		if (p != null) {
+			p.close();
+		}
+	}
+
+	@Override
+	protected void handleBinaryMessage(WebSocketSession session,
+			BinaryMessage message) throws Exception {
+		SpinProxy p = map.get(session);
+		if (p != null) {
+			p.handleClientMessage(message.getPayload().order(LITTLE_ENDIAN));
+		}
+	}
+
+	@Override
+	public void handleTransportError(WebSocketSession session,
+			Throwable exception) throws Exception {
+		SpinProxy p = map.remove(session);
+		if (p != null) {
+			p.close();
+		}
+	}
+}
+
+enum ProxyOp {
+	/** Ask for a bidirectional connection to a board to be opened. */
+	OPEN,
+	/** Ask for a bidirectional connection to a board to be closed. */
+	CLOSE,
+	/** A message going to or from a board. Connection must be open already. */
+	MESSAGE
+}
+
+class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
+	private static final int TIMEOUT = 1000;
+
+	// Plenty of room; SpiNNaker messages are quite a bit smaller than this
+	private static final int WORKING_BUFFER_SIZE = 1024;
+
+	private final WebSocketSession session;
+
+	private final int id;
+
+	ProxyUDPConnection(WebSocketSession session, InetAddress remoteHost,
+			int remotePort, int id) throws IOException {
+		super(null, null, remoteHost, remotePort);
+		this.session = session;
+		this.id = id;
+	}
+
+	@Override
+	public Optional<ByteBuffer> receiveMessage(Integer timeout)
+			throws IOException {
+		try {
+			// Raw buffer, including header bytes
+			return Optional.of(receive(timeout));
+		} catch (SocketTimeoutException e) {
+			return Optional.empty();
+		}
+	}
+
+	void receiveLoop() {
+		ByteBuffer workingBuffer =
+				allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
+		// Fixed header from this particular connection
+		workingBuffer.putInt(ProxyOp.MESSAGE.ordinal());
+		workingBuffer.putInt(id);
+
+		try {
+			while (!isClosed()) {
+				Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
+				if (!session.isOpen()) {
+					break;
+				}
+				if (!msg.isPresent()) {
+					// Timeout; go round the loop again.
+					continue;
+				}
+				ByteBuffer outgoing = workingBuffer.duplicate();
+				outgoing.put(msg.get());
+				outgoing.flip();
+				session.sendMessage(new BinaryMessage(outgoing));
+			}
+		} catch (IOException e) {
+			try {
+				// TODO remove from connections?
+				close();
+			} catch (IOException e1) {
+				// TODO log this!
+			}
+		}
+	}
+}
+
+class SpinProxy {
+	private static final int MAX_PORT = 65535;
+
+	private final WebSocketSession session;
+
+	private final Map<ChipLocation, InetAddress> hosts = new HashMap<>();
+
+	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
+
+	private int count;
+
+	private final ThreadGroup threadGroup;
+
+	SpinProxy(WebSocketSession s, List<ConnectionInfo> connections,
+			ThreadGroup threadGroup) {
+		session = s;
+		this.threadGroup = threadGroup;
+		for (ConnectionInfo ci : connections) {
+			try {
+				hosts.put(ci.getChip(),
+						InetAddress.getByName(ci.getHostname()));
+			} catch (UnknownHostException e) {
+				// TODO log this
+			}
+		}
+	}
+
+	public void handleClientMessage(ByteBuffer message) throws IOException {
+		try {
+			ByteBuffer reply;
+			switch (ProxyOp.values()[message.getInt()]) {
+			case OPEN:
+				reply = openConnection(message);
+				break;
+			case CLOSE:
+				reply = closeConnection(message);
+				break;
+			case MESSAGE:
+				reply = sendMessage(message);
+				break;
+			default:
+				reply = null;
+			}
+			if (reply != null) {
+				reply.flip();
+				session.sendMessage(new BinaryMessage(reply));
+			}
+		} catch (IOException e) {
+			session.close(SERVER_ERROR);
+		} catch (IllegalArgumentException | BufferUnderflowException e) {
+			session.close(BAD_DATA);
+		}
+	}
+
+	private ByteBuffer openConnection(ByteBuffer message) throws IOException {
+		int x = message.getInt();
+		int y = message.getInt();
+		int port = message.getInt();
+		if (port < 1 || port > MAX_PORT) {
+			throw new IllegalArgumentException("bad port number");
+		}
+		InetAddress who = hosts.get(new ChipLocation(x, y));
+		if (who == null) {
+			throw new IllegalArgumentException("unrecognised ethernet chip");
+		}
+
+		int id = ++count;
+		ProxyUDPConnection conn =
+				new ProxyUDPConnection(session, who, port, id);
+		conns.put(id, conn);
+
+		// Start sending messages received from the board
+		Thread t = new Thread(threadGroup, conn::receiveLoop,
+				"WS handler for " + who);
+		t.setDaemon(true);
+		t.start();
+
+		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
+		msg.putInt(ProxyOp.OPEN.ordinal());
+		msg.putInt(id);
+		return msg;
+	}
+
+	private ByteBuffer closeConnection(ByteBuffer message) throws IOException {
+		Integer id = message.getInt();
+		ProxyUDPConnection conn = conns.remove(id);
+		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
+		msg.putInt(ProxyOp.CLOSE.ordinal());
+		if (conn != null && !conn.isClosed()) {
+			conn.close();
+			msg.putInt(id);
+		}
+		return msg;
+		// Thread will shut down now that the proxy is closed
+	}
+
+	private ByteBuffer sendMessage(ByteBuffer message) throws IOException {
+		Integer id = message.getInt();
+		ProxyUDPConnection conn = conns.get(id);
+		if (conn != null && !conn.isClosed()) {
+			conn.send(message.slice());
+		}
+		return null;
+	}
+
+	void close() {
+		// Take a copy immediately
+		for (ProxyUDPConnection conn : new ArrayList<>(conns.values())) {
+			if (conn != null && !conn.isClosed()) {
+				try {
+					conn.close();
+				} catch (IOException e) {
+					// Don't stop what we're doing; everything must go!
+					// TODO Auto-generated catch block
+				}
+			}
+		}
+	}
+
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -72,8 +72,10 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 	}
 
 	/** The path that we match in this handler. */
-	private final UriTemplate template =
-			new UriTemplate("/system/proxy/{id:\\d+}");
+	public static final String PATH = "proxy/{id:\\\\d+}";
+
+	/** The {@link #PATH} as a template. */
+	private final UriTemplate template = new UriTemplate("/system/" + PATH);
 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -16,43 +16,35 @@
  */
 package uk.ac.manchester.spinnaker.alloc.proxy;
 
-import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static org.springframework.web.socket.CloseStatus.BAD_DATA;
-import static org.springframework.web.socket.CloseStatus.SERVER_ERROR;
-import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
 
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
-import uk.ac.manchester.spinnaker.alloc.model.ConnectionInfo;
 import uk.ac.manchester.spinnaker.alloc.security.Permit;
-import uk.ac.manchester.spinnaker.connections.UDPConnection;
-import uk.ac.manchester.spinnaker.machine.ChipLocation;
 
+/**
+ * Initial handler for web sockets. Maps a particular websocket to a
+ * {@linkplain ProxyCore proxy handler} that processes messages received and
+ * sends messages the other way.
+ *
+ * @author Donal Fellows
+ */
 @Component
 public class SpinWSHandler extends BinaryWebSocketHandler {
-	private Map<WebSocketSession, SpinProxy> map;
-
 	@Autowired
 	private SpallocAPI spallocCore;
+
+	/** Maps a session to how we handle it locally. */
+	private Map<WebSocketSession, ProxyCore> map;
 
 	private ThreadGroup threadGroup;
 
@@ -60,21 +52,37 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 		threadGroup = new ThreadGroup("WebSocket proxy handlers");
 	}
 
+	private static final AntPathMatcher MATCHER = new AntPathMatcher();
+
+	/**
+	 * The path that we match in this handler.
+	 */
+	public static final String PATH = "/system/proxy/{id:\\d+}";
+
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) {
 		// Connection established, but need to check auth and session binding
-		String[] parts = session.getUri().getPath().split("/");
-		int jobId = Integer.parseInt(parts[parts.length - 1]);
+		int jobId = Integer.parseInt(MATCHER
+				.extractUriTemplateVariables(PATH, session.getUri().getPath())
+				.get("id"));
 		spallocCore.getJob(new Permit(session), jobId)
-				.ifPresent(job -> job.getMachine().ifPresent(
-						machine -> map.put(session, new SpinProxy(session,
-								machine.getConnections(), threadGroup))));
+				.ifPresent(job -> job.getMachine().ifPresent(machine -> {
+					ProxyCore p = new ProxyCore(session,
+							machine.getConnections(), threadGroup);
+					map.put(session, p);
+					/*
+					 * TODO remember the proxy in the spalloc core.
+					 *
+					 * This is so that things get destroyed when the job changes
+					 * state
+					 */
+				}));
 	}
 
 	@Override
 	public void afterConnectionClosed(WebSocketSession session,
 			CloseStatus status) {
-		SpinProxy p = map.remove(session);
+		ProxyCore p = map.remove(session);
 		if (p != null) {
 			p.close();
 		}
@@ -83,7 +91,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 	@Override
 	protected void handleBinaryMessage(WebSocketSession session,
 			BinaryMessage message) throws Exception {
-		SpinProxy p = map.get(session);
+		ProxyCore p = map.get(session);
 		if (p != null) {
 			p.handleClientMessage(message.getPayload().order(LITTLE_ENDIAN));
 		}
@@ -92,200 +100,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler {
 	@Override
 	public void handleTransportError(WebSocketSession session,
 			Throwable exception) throws Exception {
-		SpinProxy p = map.remove(session);
-		if (p != null) {
-			p.close();
-		}
+		// TODO log some sort of warning?
+		// Don't need to close; afterConnectionClosed() will be called next
 	}
-}
-
-enum ProxyOp {
-	/** Ask for a bidirectional connection to a board to be opened. */
-	OPEN,
-	/** Ask for a bidirectional connection to a board to be closed. */
-	CLOSE,
-	/** A message going to or from a board. Connection must be open already. */
-	MESSAGE
-}
-
-class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
-	private static final int TIMEOUT = 1000;
-
-	// Plenty of room; SpiNNaker messages are quite a bit smaller than this
-	private static final int WORKING_BUFFER_SIZE = 1024;
-
-	private final WebSocketSession session;
-
-	private final int id;
-
-	ProxyUDPConnection(WebSocketSession session, InetAddress remoteHost,
-			int remotePort, int id) throws IOException {
-		super(null, null, remoteHost, remotePort);
-		this.session = session;
-		this.id = id;
-	}
-
-	@Override
-	public Optional<ByteBuffer> receiveMessage(Integer timeout)
-			throws IOException {
-		try {
-			// Raw buffer, including header bytes
-			return Optional.of(receive(timeout));
-		} catch (SocketTimeoutException e) {
-			return Optional.empty();
-		}
-	}
-
-	void receiveLoop() {
-		ByteBuffer workingBuffer =
-				allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);
-		// Fixed header from this particular connection
-		workingBuffer.putInt(ProxyOp.MESSAGE.ordinal());
-		workingBuffer.putInt(id);
-
-		try {
-			while (!isClosed()) {
-				Optional<ByteBuffer> msg = receiveMessage(TIMEOUT);
-				if (!session.isOpen()) {
-					break;
-				}
-				if (!msg.isPresent()) {
-					// Timeout; go round the loop again.
-					continue;
-				}
-				ByteBuffer outgoing = workingBuffer.duplicate();
-				outgoing.put(msg.get());
-				outgoing.flip();
-				session.sendMessage(new BinaryMessage(outgoing));
-			}
-		} catch (IOException e) {
-			try {
-				// TODO remove from connections?
-				close();
-			} catch (IOException e1) {
-				// TODO log this!
-			}
-		}
-	}
-}
-
-class SpinProxy {
-	private static final int MAX_PORT = 65535;
-
-	private final WebSocketSession session;
-
-	private final Map<ChipLocation, InetAddress> hosts = new HashMap<>();
-
-	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
-
-	private int count;
-
-	private final ThreadGroup threadGroup;
-
-	SpinProxy(WebSocketSession s, List<ConnectionInfo> connections,
-			ThreadGroup threadGroup) {
-		session = s;
-		this.threadGroup = threadGroup;
-		for (ConnectionInfo ci : connections) {
-			try {
-				hosts.put(ci.getChip(),
-						InetAddress.getByName(ci.getHostname()));
-			} catch (UnknownHostException e) {
-				// TODO log this
-			}
-		}
-	}
-
-	public void handleClientMessage(ByteBuffer message) throws IOException {
-		try {
-			ByteBuffer reply;
-			switch (ProxyOp.values()[message.getInt()]) {
-			case OPEN:
-				reply = openConnection(message);
-				break;
-			case CLOSE:
-				reply = closeConnection(message);
-				break;
-			case MESSAGE:
-				reply = sendMessage(message);
-				break;
-			default:
-				reply = null;
-			}
-			if (reply != null) {
-				reply.flip();
-				session.sendMessage(new BinaryMessage(reply));
-			}
-		} catch (IOException e) {
-			session.close(SERVER_ERROR);
-		} catch (IllegalArgumentException | BufferUnderflowException e) {
-			session.close(BAD_DATA);
-		}
-	}
-
-	private ByteBuffer openConnection(ByteBuffer message) throws IOException {
-		int x = message.getInt();
-		int y = message.getInt();
-		int port = message.getInt();
-		if (port < 1 || port > MAX_PORT) {
-			throw new IllegalArgumentException("bad port number");
-		}
-		InetAddress who = hosts.get(new ChipLocation(x, y));
-		if (who == null) {
-			throw new IllegalArgumentException("unrecognised ethernet chip");
-		}
-
-		int id = ++count;
-		ProxyUDPConnection conn =
-				new ProxyUDPConnection(session, who, port, id);
-		conns.put(id, conn);
-
-		// Start sending messages received from the board
-		Thread t = new Thread(threadGroup, conn::receiveLoop,
-				"WS handler for " + who);
-		t.setDaemon(true);
-		t.start();
-
-		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
-		msg.putInt(ProxyOp.OPEN.ordinal());
-		msg.putInt(id);
-		return msg;
-	}
-
-	private ByteBuffer closeConnection(ByteBuffer message) throws IOException {
-		Integer id = message.getInt();
-		ProxyUDPConnection conn = conns.remove(id);
-		ByteBuffer msg = allocate(2 * WORD_SIZE).order(LITTLE_ENDIAN);
-		msg.putInt(ProxyOp.CLOSE.ordinal());
-		if (conn != null && !conn.isClosed()) {
-			conn.close();
-			msg.putInt(id);
-		}
-		return msg;
-		// Thread will shut down now that the proxy is closed
-	}
-
-	private ByteBuffer sendMessage(ByteBuffer message) throws IOException {
-		Integer id = message.getInt();
-		ProxyUDPConnection conn = conns.get(id);
-		if (conn != null && !conn.isClosed()) {
-			conn.send(message.slice());
-		}
-		return null;
-	}
-
-	void close() {
-		// Take a copy immediately
-		for (ProxyUDPConnection conn : new ArrayList<>(conns.values())) {
-			if (conn != null && !conn.isClosed()) {
-				try {
-					conn.close();
-				} catch (IOException e) {
-					// Don't stop what we're doing; everything must go!
-					// TODO Auto-generated catch block
-				}
-			}
-		}
-	}
-
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -82,8 +82,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 	public static final String PATH = "proxy/{id:\\d+}";
 
 	/** The {@link #PATH} as a template. */
-	// TODO is this right?
-	private final UriTemplate template = new UriTemplate("/system/" + PATH);
+	private final UriTemplate template = new UriTemplate(PATH);
 
 	@Override
 	public boolean beforeHandshake(ServerHttpRequest request,

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * SpiNNaker message proxying support code.
+ */
+package uk.ac.manchester.spinnaker.alloc.proxy;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/AccessDeniedExceptionMapper.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/AccessDeniedExceptionMapper.java
@@ -84,4 +84,10 @@ class AccessDeniedExceptionMapper
 		// But the user gets a bland response
 		return status(FORBIDDEN).entity(BLAND_AUTH_MSG).build();
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(PreAuthorize q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/AnyTypeMethodSecurityExpressionHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/AnyTypeMethodSecurityExpressionHandler.java
@@ -71,4 +71,10 @@ class AnyTypeMethodSecurityExpressionHandler
 		target.ifPresent(a::add);
 		return ((Stream<T>) super.filter(a.stream(), expr, ctx)).findFirst();
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(PostFilter q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/Permit.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/Permit.java
@@ -33,6 +33,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.socket.WebSocketSession;
 
 /**
  * Encodes what a user is permitted to do. Abstracts over several types of
@@ -97,6 +98,17 @@ public final class Permit {
 		USER.getGrants().forEach(authorities::add);
 		admin = false;
 		name = serviceUser;
+	}
+
+	/**
+	 * The permit used for web socket handling.
+	 *
+	 * @param session
+	 */
+	public Permit(WebSocketSession session) {
+		USER.getGrants().forEach(authorities::add);
+		admin = false;
+		name = session.getPrincipal().getName();
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/SecurityConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/SecurityConfig.java
@@ -285,4 +285,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		sclh.setInvalidateHttpSession(true);
 		return sclh;
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(PreAuthorize q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/Action.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/Action.java
@@ -34,3 +34,8 @@ public @interface Action {
 	/** @return The action we do in the annotated method. */
 	String value();
 }
+
+abstract class ActionUseOtherClassReferences {
+	private ActionUseOtherClassReferences(AdminControllerImpl q) {
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/BackgroundSupport.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/BackgroundSupport.java
@@ -127,4 +127,10 @@ public abstract class BackgroundSupport {
 					new RequestFailedException("unexpected server problem", e));
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(Response q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/ControllerUtils.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/ControllerUtils.java
@@ -131,4 +131,10 @@ public abstract class ControllerUtils {
 			return new ModelAndView(view, key, value);
 		}
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(MvcUriComponentsBuilder q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
@@ -17,7 +17,6 @@
 package uk.ac.manchester.spinnaker.alloc.web;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.alloc.model.JobState.DESTROYED;
 import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.JOB_BOARD_BY_CHIP;
 import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.JOB_KEEPALIVE;
@@ -32,7 +31,6 @@ import java.util.Optional;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.slf4j.Logger;
 import org.springframework.dao.DataAccessException;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -48,8 +46,6 @@ import uk.ac.manchester.spinnaker.alloc.proxy.SpinWSHandler;
  * @author Donal Fellows
  */
 public class JobStateResponse {
-	private static final Logger log = getLogger(JobStateResponse.class);
-
 	private JobState state;
 
 	private String owner;
@@ -147,8 +143,6 @@ public class JobStateResponse {
 		// Messy; needs to refer to the other half of the application
 		URI u = ui.getBaseUriBuilder().scheme("wss").replacePath(servletPath)
 				.path(SpinWSHandler.PATH).build(job.getId());
-		log.info("built {} from {} and {}", u, ui.getAbsolutePath(),
-				job.getId());
 		return u;
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 The University of Manchester
+ * Copyright (c) 2021-2022 The University of Manchester
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,7 +113,8 @@ public class JobStateResponse {
 		}
 	}
 
-	JobStateResponse(Job job, UriInfo ui, JsonMapper mapper) {
+	JobStateResponse(Job job, UriInfo ui, JsonMapper mapper,
+			String servletPath) {
 		state = job.getState();
 		startTime = job.getStartTime();
 		reason = job.getReason().orElse(null);
@@ -134,7 +135,7 @@ public class JobStateResponse {
 		switch (state) {
 		case POWER:
 		case READY:
-			proxyRef = makeProxyURI(job, ui);
+			proxyRef = makeProxyURI(job, ui, servletPath);
 			break;
 		default:
 			// Not telling the user the proxy URL if queued or destroyed
@@ -142,10 +143,10 @@ public class JobStateResponse {
 		}
 	}
 
-	private static URI makeProxyURI(Job job, UriInfo ui) {
-		// TODO is this path correct? I suspect not...
-		URI u = ui.getBaseUriBuilder().scheme("wss").path(SpinWSHandler.PATH)
-				.build(job.getId());
+	private static URI makeProxyURI(Job job, UriInfo ui, String servletPath) {
+		// Messy; needs to refer to the other half of the application
+		URI u = ui.getBaseUriBuilder().scheme("wss").replacePath(servletPath)
+				.path(SpinWSHandler.PATH).build(job.getId());
 		log.info("built {} from {} and {}", u, ui.getAbsolutePath(),
 				job.getId());
 		return u;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
@@ -131,8 +131,10 @@ public class JobStateResponse {
 		switch (state) {
 		case POWER:
 		case READY:
-			proxyRef = makeProxyURI(job, ui, servletPath);
-			break;
+			if (servletPath != null) {
+				proxyRef = makeProxyURI(job, ui, servletPath);
+				break;
+			}
 		default:
 			// Not telling the user the proxy URL if queued or destroyed
 			proxyRef = null;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.spinnaker.alloc.web;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.alloc.model.JobState.DESTROYED;
 import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.JOB_BOARD_BY_CHIP;
 import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.JOB_KEEPALIVE;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import org.slf4j.Logger;
 import org.springframework.dao.DataAccessException;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -46,6 +48,8 @@ import uk.ac.manchester.spinnaker.alloc.proxy.SpinWSHandler;
  * @author Donal Fellows
  */
 public class JobStateResponse {
+	private static final Logger log = getLogger(JobStateResponse.class);
+
 	private JobState state;
 
 	private String owner;
@@ -139,9 +143,12 @@ public class JobStateResponse {
 	}
 
 	private static URI makeProxyURI(Job job, UriInfo ui) {
-		// TODO is this correct?
-		return ui.getBaseUriBuilder().scheme("wss").path(SpinWSHandler.PATH)
+		// TODO is this path correct? I suspect not...
+		URI u = ui.getBaseUriBuilder().scheme("wss").path(SpinWSHandler.PATH)
 				.build(job.getId());
+		log.info("built {} from {} and {}", u, ui.getAbsolutePath(),
+				job.getId());
+		return u;
 	}
 
 	/** @return The formal state of the job */

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
@@ -18,12 +18,18 @@ package uk.ac.manchester.spinnaker.alloc.web;
 
 import static org.springframework.beans.factory.config.BeanDefinition.ROLE_SUPPORT;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+import uk.ac.manchester.spinnaker.alloc.proxy.SpinWSHandler;
 
 /**
  * Sets up the login page and static resource mappings. Note that paths in here
@@ -31,9 +37,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * program path matchers).
  */
 @EnableWebMvc
+@EnableWebSocket
 @Configuration
 @Role(ROLE_SUPPORT)
-public class MvcConfig implements WebMvcConfigurer {
+public class MvcConfig implements WebMvcConfigurer, WebSocketConfigurer {
 	// TODO check if we should use the url path maker bean
 
 	@Override
@@ -46,5 +53,13 @@ public class MvcConfig implements WebMvcConfigurer {
 		registry.addResourceHandler("/system/resources/**")
 				.addResourceLocations(
 						"classpath:/META-INF/public-web-resources/");
+	}
+
+	@Autowired
+	private SpinWSHandler wsHandler;
+
+	@Override
+	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+		registry.addHandler(wsHandler, "/system/proxy/*");
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
@@ -60,6 +60,8 @@ public class MvcConfig implements WebMvcConfigurer, WebSocketConfigurer {
 
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		registry.addHandler(wsHandler, "/proxy/*");
+		// It's its own interceptor!
+		registry.addHandler(wsHandler, "/proxy/*").addInterceptors(wsHandler)
+				.setAllowedOriginPatterns("*");
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
@@ -29,6 +29,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+import uk.ac.manchester.spinnaker.alloc.SpallocProperties;
 import uk.ac.manchester.spinnaker.alloc.proxy.SpinWSHandler;
 
 /**
@@ -58,10 +59,16 @@ public class MvcConfig implements WebMvcConfigurer, WebSocketConfigurer {
 	@Autowired
 	private SpinWSHandler wsHandler;
 
+	@Autowired
+	private SpallocProperties props;
+
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		// It's its own interceptor!
-		registry.addHandler(wsHandler, "/proxy/*").addInterceptors(wsHandler)
-				.setAllowedOriginPatterns("*");
+		if (props.getProxy().isEnable()) {
+			// It's its own interceptor!
+			registry.addHandler(wsHandler, "/proxy/*")
+					.addInterceptors(wsHandler)
+					.setAllowedOriginPatterns("*");
+		}
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
@@ -60,6 +60,6 @@ public class MvcConfig implements WebMvcConfigurer, WebSocketConfigurer {
 
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		registry.addHandler(wsHandler, "/srv/proxy/*");
+		registry.addHandler(wsHandler, "/proxy/*");
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/MvcConfig.java
@@ -60,6 +60,6 @@ public class MvcConfig implements WebMvcConfigurer, WebSocketConfigurer {
 
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		registry.addHandler(wsHandler, "/system/proxy/*");
+		registry.addHandler(wsHandler, "/srv/proxy/*");
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPIImplBuilder.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPIImplBuilder.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -75,6 +76,9 @@ class SpallocServiceAPIImplBuilder extends BackgroundSupport {
 
 	@Autowired
 	private SpallocProperties props;
+
+	@Value("${spring.mvc.servlet.path}")
+	private String servletPath;
 
 	/**
 	 * Make a machine access interface.
@@ -176,11 +180,12 @@ class SpallocServiceAPIImplBuilder extends BackgroundSupport {
 						// Refresh the handle
 						Job nj = core.getJob(permit, j.getId())
 								.orElseThrow(() -> new ItsGone("no such job"));
-						return new JobStateResponse(nj, ui, mapper);
+						return new JobStateResponse(nj, ui, mapper,
+								servletPath);
 					});
 				} else {
-					fgAction(response,
-							() -> new JobStateResponse(j, ui, mapper));
+					fgAction(response, () -> new JobStateResponse(j, ui, mapper,
+							servletPath));
 				}
 			}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPIImplBuilder.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPIImplBuilder.java
@@ -163,6 +163,7 @@ class SpallocServiceAPIImplBuilder extends BackgroundSupport {
 	@Prototype
 	@Role(ROLE_APPLICATION)
 	public JobAPI job(Job j, String caller, Permit permit, UriInfo ui) {
+		String sp = props.getProxy().isEnable() ? servletPath : null;
 		return new JobAPI() {
 			@Override
 			public String keepAlive(String reqBody) {
@@ -180,12 +181,11 @@ class SpallocServiceAPIImplBuilder extends BackgroundSupport {
 						// Refresh the handle
 						Job nj = core.getJob(permit, j.getId())
 								.orElseThrow(() -> new ItsGone("no such job"));
-						return new JobStateResponse(nj, ui, mapper,
-								servletPath);
+						return new JobStateResponse(nj, ui, mapper, sp);
 					});
 				} else {
 					fgAction(response, () -> new JobStateResponse(j, ui, mapper,
-							servletPath));
+							sp));
 				}
 			}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
@@ -140,3 +140,8 @@ public interface SystemController {
 	String performLogout(HttpServletRequest request,
 			HttpServletResponse response);
 }
+
+abstract class SystemControllerUseLogoutHandler {
+	private SystemControllerUseLogoutHandler(LogoutHandler q) {
+	}
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemControllerImpl.java
@@ -287,4 +287,10 @@ public class SystemControllerImpl implements SystemController {
 		mach.setMachineUrl(uri(self().getMachineInfo(mach.getMachine())));
 		return view(JOB_VIEW, ONE_JOB_OBJ, mach);
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(Valid q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DBTestingUtils.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DBTestingUtils.java
@@ -221,4 +221,10 @@ abstract class DBTestingUtils {
 	static void assumeWritable(Connection conn) {
 		assumeFalse(conn.isReadOnly(), "connection is read-only");
 	}
+
+	@SuppressWarnings("unused")
+	private abstract static class Use {
+		Use(SpallocAPI q) {
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
@@ -24,6 +24,7 @@ import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.BoardLocation;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.SubMachine;
 import uk.ac.manchester.spinnaker.alloc.model.JobState;
+import uk.ac.manchester.spinnaker.alloc.proxy.ProxyCore;
 import uk.ac.manchester.spinnaker.alloc.security.Permit;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 
@@ -33,7 +34,7 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
  *
  * @author Donal Fellows
  */
-public class StubJob implements SpallocAPI.Job {
+public abstract class StubJob implements SpallocAPI.Job {
 	@Override
 	public void waitForChange(Duration timeout) {
 		throw new UnsupportedOperationException();
@@ -126,6 +127,16 @@ public class StubJob implements SpallocAPI.Job {
 
 	@Override
 	public String reportIssue(IssueReportRequest reqBody, Permit permit) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void rememberProxy(ProxyCore proxy) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void forgetProxy(ProxyCore proxy) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
@@ -33,7 +33,7 @@ import uk.ac.manchester.spinnaker.messages.bmp.BMPCoords;
  *
  * @author Donal Fellows
  */
-public class StubMachine implements SpallocAPI.Machine {
+public abstract class StubMachine implements SpallocAPI.Machine {
 	@Override
 	public void waitForChange(Duration timeout) {
 		throw new UnsupportedOperationException();

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubUriInfo.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubUriInfo.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-class StubUriInfo implements UriInfo {
+abstract class StubUriInfo implements UriInfo {
 	@Override
 	public String getPath() {
 		throw new UnsupportedOperationException();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -75,7 +75,7 @@ public class DelegatingSCPConnection extends SCPConnection {
 	}
 
 	@Override
-	DatagramPacket doReceiveWithAddress(int timeout)
+	DatagramPacket doReceiveWithAddress(Integer timeout)
 			throws SocketTimeoutException, IOException {
 		return delegate.doReceiveWithAddress(timeout);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -75,7 +75,7 @@ public class DelegatingSCPConnection extends SCPConnection {
 	}
 
 	@Override
-	DatagramPacket doReceiveWithAddress(Integer timeout)
+	DatagramPacket doReceiveWithAddress(int timeout)
 			throws SocketTimeoutException, IOException {
 		return delegate.doReceiveWithAddress(timeout);
 	}


### PR DESCRIPTION
An integrated system for setting up proxies to SpiNNaker boards. Uses web sockets (will be the `wss:` basic protocol because we're using HTTPS to establish) to provide connection establishment and basic message framing.

fixes #441

Supported _binary_ protocol (within overall WebSocket framing)

<table border>
<tr>
<th>Name</th>
<th>Request Layout (words)</th>
<th>Response Layout (words)</th>
<th>Meaning</th>
</tr>
<tr>
<td>Open Conn.</td>
<td><table border>
<tr>
<td><code>0</code>
<td>CorID</td>
<td>X
<td>Y
<td>UDP<br>Port
</tr>
</table>
(5 words)
</td>
<td><table border>
<tr>
<td><code>0</code>
<td>CorID</td>
<td>ID
</tr>
</table>
(3 words)
</td>
<td>Establish a UDP socket that will talk to the given Ethernet chip within the allocation (i.e., these are job-local coordinates!) on the given port. The CorId is a correlation ID; it's an arbitrary value from the request that the server will pass back unchanged in the response (that enables matching up requests and responses by the client). Returns an ID (non-zero) that can be used to refer to that connection (only guaranteed unique within overall websocket). <p><p>Note that opening a socket declares that you are prepared to receive messages from SpiNNaker on it, but does not mean that SpiNNaker will send any messages that way. All sockets are bidirectional.</td>
</tr>
<tr>
<td>Close Conn.</td>
<td><table border>
<tr>
<td><code>1</code>
<td>CorID</td>
<td>ID
</tr>
</table>
(3 words)
</td>
<td><table border>
<tr>
<td><code>1</code>
<td>CorID</td>
<td>ID/<code>0</code>
</tr>
</table>
(3 words)
</td>
<td>Close an established UDP socket, given its ID. The CorId is a correlation ID; it's an arbitrary value from the request that the server will pass back unchanged in the response (that enables matching up requests and responses by the client). Returns the ID on success, and zero on failure (e.g., because the socket is already closed).</td>
</tr>
<tr>
<td>Send Msg.</td>
<td><table border>
<tr>
<td><code>2</code>
<td>ID
<td>Raw message bytes...
</tr>
</table>
(2 words plus payload bytes)
</td>
<td>N/A</td>
<td>Send a message to SpiNNaker on a particular established UDP configuration. The raw message bytes (<em>including</em> the half-word of ethernet frame padding) follow the header.<p><p>This is technically one-way, but messages come back in the same format (i.e., a 4 byte prefix to say that it is a message, and another 4 bytes to say what socket this is talking about).</td>
</tr>
</table>

Note that closing the websocket closes all UDP connections beneath it, and that they are _not_ intended to be robust across server restarts. Destroying the job _or_ powering down the boards should cause the websockets in that job to be closed (not yet implemented). 