### PR TITLE
Remove timestamps from javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<packages>uk.ac.manchester.spinnaker.utils*:uk.ac.manchester.spinnaker.storage*</packages>
 							</group>
 						</groups>
+						<notimestamp>true</notimestamp>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
These changes were bloating the gh-pages branch a lot and are very low value.