### PR TITLE
Timeouts should never get multiplied by 1000

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
@@ -85,13 +85,12 @@ public class BMPConnection extends UDPConnection<SDPMessage>
 	}
 
 	@Override
-	public SCPResultMessage receiveSCPResponse(Integer timeout)
-			throws IOException {
+	public SCPResultMessage receiveSCPResponse(int timeout) throws IOException {
 		return new SCPResultMessage(receive(timeout));
 	}
 
 	@Override
-	public SDPMessage receiveMessage(Integer timeout) throws IOException {
+	public SDPMessage receiveMessage(int timeout) throws IOException {
 		return new SDPMessage(receive(timeout));
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
@@ -87,7 +87,7 @@ public class BootConnection extends UDPConnection<BootMessage>
 	}
 
 	@Override
-	public BootMessage receiveMessage(Integer timeout) throws IOException {
+	public BootMessage receiveMessage(int timeout) throws IOException {
 		return new BootMessage(receive(timeout));
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -75,7 +75,7 @@ public class DelegatingSCPConnection extends SCPConnection {
 	}
 
 	@Override
-	DatagramPacket doReceiveWithAddress(int timeout)
+	DatagramPacket doReceiveWithAddress(Integer timeout)
 			throws SocketTimeoutException, IOException {
 		return delegate.doReceiveWithAddress(timeout);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -69,13 +69,13 @@ public class DelegatingSCPConnection extends SCPConnection {
 	}
 
 	@Override
-	ByteBuffer doReceive(Integer timeout)
+	ByteBuffer doReceive(int timeout)
 			throws SocketTimeoutException, IOException {
 		return delegate.doReceive(timeout);
 	}
 
 	@Override
-	DatagramPacket doReceiveWithAddress(Integer timeout)
+	DatagramPacket doReceiveWithAddress(int timeout)
 			throws SocketTimeoutException, IOException {
 		return delegate.doReceiveWithAddress(timeout);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
@@ -188,7 +188,7 @@ public class EIEIOConnection
 	private static final int FLAG = 0x4000;
 
 	@Override
-	public EIEIOMessage<? extends EIEIOHeader> receiveMessage(Integer timeout)
+	public EIEIOMessage<? extends EIEIOHeader> receiveMessage(int timeout)
 			throws IOException {
 		ByteBuffer b = receive(timeout);
 		short header = b.getShort();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/IPAddressConnection.java
@@ -51,7 +51,7 @@ public class IPAddressConnection extends UDPConnection<InetAddress>
 	 */
 	@Override
 	public final InetAddress receiveMessage() {
-		return receiveMessage(null);
+		return receiveMessage(Integer.MAX_VALUE);
 	}
 
 	/**
@@ -60,7 +60,7 @@ public class IPAddressConnection extends UDPConnection<InetAddress>
 	 * @return The IP address, or {@code null} if none was forthcoming.
 	 */
 	@Override
-	public InetAddress receiveMessage(Integer timeout) {
+	public InetAddress receiveMessage(int timeout) {
 		try {
 			DatagramPacket packet = receiveWithAddress(timeout);
 			if (packet.getPort() == BOOTROM_SPINN_PORT) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -128,7 +128,7 @@ public class SCPConnection extends SDPConnection
 	}
 
 	@Override
-	public SCPResultMessage receiveSCPResponse(Integer timeout)
+	public SCPResultMessage receiveSCPResponse(int timeout)
 			throws IOException {
 		return new SCPResultMessage(receive(timeout));
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -81,7 +81,7 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 	}
 
 	@Override
-	public SDPMessage receiveMessage(Integer timeout)
+	public SDPMessage receiveMessage(int timeout)
 			throws IOException, InterruptedIOException {
 		ByteBuffer buffer = receive(timeout);
 		buffer.getShort(); // SKIP TWO PADDING BYTES

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -311,15 +311,26 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	 */
 	public final ByteBuffer receive(Integer timeout)
 			throws SocketTimeoutException, IOException {
+		return receive(convertTimeout(timeout));
+	}
+
+	/**
+	 * Receive data from the connection.
+	 *
+	 * @param timeout
+	 *            The timeout in milliseconds
+	 * @return The data received, in a little-endian buffer
+	 * @throws SocketTimeoutException
+	 *             If a timeout occurs before any data is received
+	 * @throws EOFException
+	 *             If the connection is closed
+	 * @throws IOException
+	 *             If an error occurs receiving the data
+	 */
+	public final ByteBuffer receive(int timeout)
+			throws SocketTimeoutException, IOException {
 		if (isClosed()) {
 			throw new EOFException();
-		}
-		if (timeout == null) {
-			/*
-			 * "Infinity" is nearly 25 days, which is a very long time to wait
-			 * for any message from SpiNNaker.
-			 */
-			timeout = Integer.MAX_VALUE;
 		}
 		return doReceive(timeout);
 	}
@@ -338,7 +349,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	 * @throws IOException
 	 *             If an error occurs receiving the data
 	 */
-	ByteBuffer doReceive(Integer timeout)
+	ByteBuffer doReceive(int timeout)
 			throws SocketTimeoutException, IOException {
 		if (!receivable && !isReadyToReceive(timeout)) {
 			log.debug("not ready to recieve");
@@ -371,15 +382,27 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	 */
 	public final DatagramPacket receiveWithAddress(Integer timeout)
 			throws SocketTimeoutException, IOException {
+		return receiveWithAddress(convertTimeout(timeout));
+	}
+
+	/**
+	 * Receive data from the connection along with the address where the data
+	 * was received from.
+	 *
+	 * @param timeout
+	 *            The timeout in milliseconds
+	 * @return The datagram packet received
+	 * @throws SocketTimeoutException
+	 *             If a timeout occurs before any data is received
+	 * @throws EOFException
+	 *             If the connection is closed
+	 * @throws IOException
+	 *             If an error occurs receiving the data
+	 */
+	public final DatagramPacket receiveWithAddress(int timeout)
+			throws SocketTimeoutException, IOException {
 		if (isClosed()) {
 			throw new EOFException();
-		}
-		if (timeout == null) {
-			/*
-			 * "Infinity" is nearly 25 days, which is a very long time to wait
-			 * for any message from SpiNNaker.
-			 */
-			timeout = Integer.MAX_VALUE;
 		}
 		return doReceiveWithAddress(timeout);
 	}
@@ -399,7 +422,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	 * @throws IOException
 	 *             If an error occurs receiving the data
 	 */
-	DatagramPacket doReceiveWithAddress(Integer timeout)
+	DatagramPacket doReceiveWithAddress(int timeout)
 			throws SocketTimeoutException, IOException {
 		if (!receivable && !isReadyToReceive(timeout)) {
 			throw new SocketTimeoutException();
@@ -649,13 +672,12 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 	}
 
 	@Override
-	public final boolean isReadyToReceive(Integer timeout) throws IOException {
+	public final boolean isReadyToReceive(int timeout) throws IOException {
 		if (isClosed()) {
 			log.debug("connection closed, so not ready to receive");
 			return false;
 		}
-		int t = (timeout == null ? 0 : timeout);
-		boolean r = readyToReceive(t);
+		boolean r = readyToReceive(timeout);
 		receivable = r;
 		return r;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
@@ -37,7 +37,7 @@ public interface Listenable<MessageType> extends MessageReceiver<MessageType> {
 	 * @see #isReadyToReceive(Integer)
 	 */
 	default boolean isReadyToReceive() throws IOException {
-		return isReadyToReceive(null);
+		return isReadyToReceive(0);
 	}
 
 	/**
@@ -45,12 +45,12 @@ public interface Listenable<MessageType> extends MessageReceiver<MessageType> {
 	 * blocking. <i>This method</i> may block until the timeout given.
 	 *
 	 * @param timeout
-	 *            How long to wait, in <em>milliseconds</em>; if zero or
-	 *            {@code null}, a non-blocking poll is performed.
+	 *            How long to wait, in <em>milliseconds</em>; if zero, a
+	 *            non-blocking poll is performed.
 	 * @return true when there is a message waiting to be received
 	 * @throws IOException
 	 *             If anything goes wrong, e.g., if the socket is closed under
 	 *             our feet.
 	 */
-	boolean isReadyToReceive(Integer timeout) throws IOException;
+	boolean isReadyToReceive(int timeout) throws IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/Listenable.java
@@ -16,8 +16,6 @@
  */
 package uk.ac.manchester.spinnaker.connections.model;
 
-import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
-
 import java.io.IOException;
 
 /**
@@ -36,24 +34,10 @@ public interface Listenable<MessageType> extends MessageReceiver<MessageType> {
 	 * @throws IOException
 	 *             If anything goes wrong, e.g., if the socket is closed under
 	 *             our feet.
+	 * @see #isReadyToReceive(Integer)
 	 */
 	default boolean isReadyToReceive() throws IOException {
 		return isReadyToReceive(null);
-	}
-
-	/**
-	 * Do a blocking poll of whether there is a message ready to be received
-	 * without blocking. <i>This method</i> may block until the timeout given.
-	 *
-	 * @param timeout
-	 *            How many seconds to wait for a message to be receivable.
-	 * @return true when there is a packet waiting to be received
-	 * @throws IOException
-	 *             If anything goes wrong, e.g., if the socket is closed under
-	 *             our feet.
-	 */
-	default boolean isReadyToReceive(double timeout) throws IOException {
-		return isReadyToReceive((int) (timeout * MSEC_PER_SEC));
 	}
 
 	/**
@@ -61,8 +45,8 @@ public interface Listenable<MessageType> extends MessageReceiver<MessageType> {
 	 * blocking. <i>This method</i> may block until the timeout given.
 	 *
 	 * @param timeout
-	 *            How long to wait, in milliseconds; if zero or {@code null}, a
-	 *            non-blocking poll is performed.
+	 *            How long to wait, in <em>milliseconds</em>; if zero or
+	 *            {@code null}, a non-blocking poll is performed.
 	 * @return true when there is a message waiting to be received
 	 * @throws IOException
 	 *             If anything goes wrong, e.g., if the socket is closed under

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
@@ -56,5 +56,22 @@ public interface MessageReceiver<MessageType> extends SocketHolder {
 	 * @throws IllegalArgumentException
 	 *             If one of the fields of the SpiNNaker message is invalid
 	 */
-	MessageType receiveMessage(Integer timeout) throws IOException;
+	default MessageType receiveMessage(Integer timeout) throws IOException {
+		return receiveMessage(convertTimeout(timeout));
+	}
+
+	/**
+	 * Receives a SpiNNaker message from this connection. Blocks until a message
+	 * has been received, or a timeout occurs.
+	 *
+	 * @param timeout
+	 *            The time in seconds to wait for the message to arrive, or
+	 *            until the connection is closed.
+	 * @return the received message
+	 * @throws IOException
+	 *             If there is an error receiving the message
+	 * @throws IllegalArgumentException
+	 *             If one of the fields of the SpiNNaker message is invalid
+	 */
+	MessageType receiveMessage(int timeout) throws IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
@@ -43,6 +43,26 @@ public interface SCPReceiver extends SocketHolder {
 	 * @throws SocketTimeoutException
 	 *             If there is a timeout before a message is received
 	 */
-	SCPResultMessage receiveSCPResponse(Integer timeout)
+	default SCPResultMessage receiveSCPResponse(Integer timeout)
+			throws SocketTimeoutException, IOException {
+		return receiveSCPResponse(convertTimeout(timeout));
+	}
+
+	/**
+	 * Receives an SCP response from this connection. Blocks until a message has
+	 * been received, or a timeout occurs.
+	 *
+	 * @param timeout
+	 *            The time in milliseconds to wait for the message to arrive, or
+	 *            until the connection is closed.
+	 * @return The SCP result, the sequence number, and the data of the
+	 *         response. The buffer pointer will be positioned at the point
+	 *         where the payload starts.
+	 * @throws IOException
+	 *             If there is an error receiving the message
+	 * @throws SocketTimeoutException
+	 *             If there is a timeout before a message is received
+	 */
+	SCPResultMessage receiveSCPResponse(int timeout)
 			throws SocketTimeoutException, IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SocketHolder.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SocketHolder.java
@@ -46,4 +46,23 @@ public interface SocketHolder extends AutoCloseable {
 	 * @return the remote (board) port of the socket.
 	 */
 	int getRemotePort();
+
+	/**
+	 * Convert a timeout into a primitive type.
+	 *
+	 * @param timeout
+	 *            The timeout in milliseconds, or {@code null} to wait
+	 *            "forever".
+	 * @return The primitive timeout.
+	 */
+	default int convertTimeout(Integer timeout) {
+		if (timeout == null) {
+			/*
+			 * "Infinity" is nearly 25 days, which is a very long time to wait
+			 * for any message from SpiNNaker.
+			 */
+			return Integer.MAX_VALUE;
+		}
+		return timeout.intValue();
+	}
 }


### PR DESCRIPTION
This was a hold-over from when the code was converted from Python, where we were trying to use the same type of timeout type as there. It didn't work out and wasn't necessary, but this held on and was a bit more reachable than expected.

Since we never _deliberately_ passed a `double` to that call as a timeout, just deleting the method is best.

A few other type and doc corrections/improvements too. And a little refactoring.
