### PR TITLE
Handle EIEIO proxying

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -40,6 +40,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.core.io.Resource;
 import org.springframework.validation.annotation.Validated;
 
+import uk.ac.manchester.spinnaker.alloc.model.IPAddress;
+
 /**
  * Spalloc service management properties. These are all intended to be set via
  * the configuration file.
@@ -236,6 +238,8 @@ public class SpallocProperties {
 	/**
 	 * @return Properties relating to the SDP proxying.
 	 */
+	@NotNull
+	@Valid
 	public ProxyProperties getProxy() {
 		return proxy;
 	}
@@ -719,7 +723,6 @@ public class SpallocProperties {
 		 */
 		private OpenIDProperties openid;
 
-		@SuppressWarnings("checkstyle:ParameterNumber")
 		public AuthProperties(//
 				@DefaultValue("true") boolean basic,
 				@DefaultValue("SpallocService") String realm,
@@ -936,7 +939,6 @@ public class SpallocProperties {
 		/** How to unlock the truststore. */
 		private String truststorePassword;
 
-		@SuppressWarnings("checkstyle:ParameterNumber")
 		public OpenIDProperties(@DefaultValue("false") boolean enable,
 				@DefaultValue("") String domain, //
 				Set<String> scopes, //
@@ -1762,10 +1764,19 @@ public class SpallocProperties {
 		 */
 		private boolean logWriteCounts;
 
+		/**
+		 * The address for local proxied sockets to listen on if they're not
+		 * being bound to a specific board. If empty, that type of socket will
+		 * be disabled.
+		 */
+		private String localHost;
+
 		public ProxyProperties(@DefaultValue("true") boolean enable,
-				@DefaultValue("false") boolean logWriteCounts) {
+				@DefaultValue("false") boolean logWriteCounts,
+				@DefaultValue("") String localHost) {
 			this.enable = enable;
 			this.logWriteCounts = logWriteCounts;
+			this.localHost = localHost;
 		}
 
 		/** @return Whether to enable the UDP proxy subsystem. */
@@ -1787,6 +1798,21 @@ public class SpallocProperties {
 
 		public void setLogWriteCounts(boolean logWriteCounts) {
 			this.logWriteCounts = logWriteCounts;
+		}
+
+		/**
+		 * @return The address for local proxied sockets to listen on if
+		 *         they're not being bound to a specific board. If empty, that
+		 *         type of socket will be disabled.
+		 */
+		@NotNull
+		@IPAddress(emptyOK = true)
+		public String getLocalHost() {
+			return localHost;
+		}
+
+		public void setLocalHost(String localHost) {
+			this.localHost = localHost;
 		}
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/IPAddress.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/IPAddress.java
@@ -22,7 +22,6 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -46,6 +45,13 @@ import javax.validation.Payload;
 })
 @Constraint(validatedBy = IPAddressValidator.class)
 public @interface IPAddress {
+	/**
+	 * Whether the empty string is allowed. It defaults to being disallowed.
+	 *
+	 * @return Whether to accept the empty string.
+	 */
+	boolean emptyOK() default false;
+
 	/**
 	 * Message on constraint violated.
 	 *
@@ -71,15 +77,24 @@ public @interface IPAddress {
 class IPAddressValidator implements ConstraintValidator<IPAddress, String> {
 	private Pattern pattern;
 
+	private boolean emptyOK;
+
 	@Override
 	public void initialize(IPAddress annotation) {
 		if (isNull(pattern)) {
 			pattern = Pattern.compile("^\\d+[.]\\d+[.]\\d+[.]\\d+$");
 		}
+		emptyOK = annotation.emptyOK();
 	}
 
 	@Override
 	public boolean isValid(String value, ConstraintValidatorContext context) {
-		return nonNull(value) && pattern.matcher(value).matches();
+		if (isNull(value)) {
+			return false;
+		}
+		if (emptyOK && value.isEmpty()) {
+			return true;
+		}
+		return pattern.matcher(value).matches();
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -130,7 +130,6 @@ import uk.ac.manchester.spinnaker.utils.ValueHolder;
  * <tr>
  * <td>{@link ProxyOp#OPEN_EIEIO 3}
  * <td>Correlation&nbsp;ID
- * <td>UDP&nbsp;Port on Chip
  * </tr>
  * </table>
  * </td>

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -173,6 +173,8 @@ public class ProxyCore implements AutoCloseable {
 
 	private final Map<Integer, ProxyUDPConnection> conns = new HashMap<>();
 
+	private final Set<InetAddress> recvFrom;
+
 	private final IntSupplier idIssuer;
 
 	private final Executor executor;
@@ -207,6 +209,7 @@ public class ProxyCore implements AutoCloseable {
 						ci.getHostname(), e);
 			}
 		}
+		recvFrom = new HashSet<>(hosts.values());
 	}
 
 	/**
@@ -310,7 +313,7 @@ public class ProxyCore implements AutoCloseable {
 		setConnection(id, conn);
 
 		// Start sending messages received from the board
-		executor.execute(conn::receiverTask);
+		executor.execute(conn::connectedReceiverTask);
 
 		log.info("opened proxy connection {}:{} to {}:{}", session, id, who,
 				port);
@@ -363,7 +366,6 @@ public class ProxyCore implements AutoCloseable {
 		setConnection(id, conn);
 		InetAddress who = conn.getLocalIPAddress();
 		int port = conn.getLocalPort();
-		Set<InetAddress> recvFrom = new HashSet<>(hosts.values());
 
 		// Start sending messages received from the board
 		executor.execute(() -> conn.eieioReceiverTask(recvFrom));

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyCore.java
@@ -494,7 +494,7 @@ public class ProxyCore implements AutoCloseable {
 
 	/**
 	 * Send a message to a particular destination on a connection. It's not an
-	 * error to send on a non-existant or closed connection. It is an error to
+	 * error to send on a non-existent or closed connection. It is an error to
 	 * use this operation on a channel that has a bound remote host address.
 	 *
 	 * @param message

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
@@ -23,33 +23,34 @@ package uk.ac.manchester.spinnaker.alloc.proxy;
  */
 public enum ProxyOp {
 	/**
-	 * Ask for a bidirectional connection to a board to be opened. Also the
+	 * Ask for a bidirectional channel to a board to be opened. Also the
 	 * response to such a request.
 	 */
 	OPEN,
 	/**
-	 * Ask for a bidirectional connection to a board to be closed. Also the
-	 * response to such a request.
+	 * Ask for a channel (created with {@link #OPEN} or
+	 * {@link #OPEN_UNCONNECTED}) to be closed. Also the response to such a
+	 * request.
 	 */
 	CLOSE,
 	/**
-	 * A message going to or from a board. Connection must be open already.
-	 * When going to a board, the connection must have been opened with
+	 * A message going to or from a board. Channel must be open already.
+	 * When going to a board, the channel must have been opened with
 	 * {@link #OPEN}, and thus be already bound.
 	 */
 	MESSAGE,
 	/**
-	 * Ask for a bidirectional connection from all boards to be opened. Also
+	 * Ask for a bidirectional channel from all boards to be opened. Also
 	 * the response to such a request. The difference is that this reports the
 	 * real listening IP address and port in the response message. (This is
 	 * closed with a {@link #CLOSE} message.) Sending is only possible on this
-	 * channel with {@link #MESSAGE_TO} (because no target address is bound by
+	 * channel with {@link #MESSAGE_TO} (because no target address is set by
 	 * default).
 	 */
-	OPEN_UNBOUND,
+	OPEN_UNCONNECTED,
 	/**
 	 * A message going to a board on a channel which does not have a SpiNNaker
-	 * board target address bound already ({@link #OPEN_UNBOUND}).
+	 * board target address set up already ({@link #OPEN_UNBOUND}).
 	 */
 	MESSAGE_TO
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
@@ -35,12 +35,13 @@ public enum ProxyOp {
 	/** A message going to or from a board. Connection must be open already. */
 	MESSAGE,
 	/**
-	 * Ask for a bidirectional connection to a board to be opened. Also the
-	 * response to such a request. The difference is that this reports the
+	 * Ask for a unidirectional connection from all boards to be opened. Also
+	 * the response to such a request. The difference is that this reports the
 	 * real listening IP address and port in the response message. (This is
-	 * closed with a {@link #CLOSE} message.)
+	 * closed with a {@link #CLOSE} message.) Sending is not possible on this
+	 * channel (because no target address is bound).
 	 * <p>
 	 * EIEIO is a very ugly protocol.
 	 */
-	OPEN_EIEIO
+	OPEN_EIEIO_LISTENER
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
@@ -32,16 +32,24 @@ public enum ProxyOp {
 	 * response to such a request.
 	 */
 	CLOSE,
-	/** A message going to or from a board. Connection must be open already. */
+	/**
+	 * A message going to or from a board. Connection must be open already.
+	 * When going to a board, the connection must have been opened with
+	 * {@link #OPEN}, and thus be already bound.
+	 */
 	MESSAGE,
 	/**
-	 * Ask for a unidirectional connection from all boards to be opened. Also
+	 * Ask for a bidirectional connection from all boards to be opened. Also
 	 * the response to such a request. The difference is that this reports the
 	 * real listening IP address and port in the response message. (This is
-	 * closed with a {@link #CLOSE} message.) Sending is not possible on this
-	 * channel (because no target address is bound).
-	 * <p>
-	 * EIEIO is a very ugly protocol.
+	 * closed with a {@link #CLOSE} message.) Sending is only possible on this
+	 * channel with {@link #MESSAGE_TO} (because no target address is bound by
+	 * default).
 	 */
-	OPEN_EIEIO_LISTENER
+	OPEN_UNBOUND,
+	/**
+	 * A message going to a board on a channel which does not have a SpiNNaker
+	 * board target address bound already ({@link #OPEN_UNBOUND}).
+	 */
+	MESSAGE_TO
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyOp.java
@@ -33,5 +33,14 @@ public enum ProxyOp {
 	 */
 	CLOSE,
 	/** A message going to or from a board. Connection must be open already. */
-	MESSAGE
+	MESSAGE,
+	/**
+	 * Ask for a bidirectional connection to a board to be opened. Also the
+	 * response to such a request. The difference is that this reports the
+	 * real listening IP address and port in the response message. (This is
+	 * closed with a {@link #CLOSE} message.)
+	 * <p>
+	 * EIEIO is a very ugly protocol.
+	 */
+	OPEN_EIEIO
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -115,6 +115,24 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 		sendCount++;
 	}
 
+	/**
+	 * Send a message on this connection.
+	 *
+	 * @param msg
+	 *            The message to send.
+	 * @param addr
+	 *            Where to send to.
+	 * @param port
+	 *            What port to send to.
+	 * @throws IOException
+	 *             If sending fails.
+	 */
+	public void sendMessage(ByteBuffer msg, InetAddress addr, int port)
+			throws IOException {
+		sendTo(msg, addr, port);
+		sendCount++;
+	}
+
 	protected void writeCountsToLog() {
 		log.info("{} message counts: sent {} received {}", name, sendCount,
 				receiveCount);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -65,9 +65,10 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	private long receiveCount;
 
 	ProxyUDPConnection(WebSocketSession session, InetAddress remoteHost,
-			int remotePort, int id, Runnable emergencyRemove)
+			int remotePort, int id, Runnable emergencyRemove,
+			InetAddress localHost)
 			throws IOException {
-		super(null, null, remoteHost, remotePort);
+		super(localHost, null, remoteHost, remotePort);
 		this.session = session;
 		this.emergencyRemove = emergencyRemove;
 		workingBuffer = allocate(WORKING_BUFFER_SIZE).order(LITTLE_ENDIAN);

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -81,6 +81,15 @@ spalloc:
   wait: 30s
   # Whether to pause ALL periodic callbacks; probably only useful for debugging
   pause: false
+  proxy:
+    # Whether to enable proxying
+    enable: true
+    # Whether to log the number of proxied packets when connections are clsoed
+    log-write-counts: false
+    # The local host IP address for listening for messages from multiple boards
+    # for EIEIO listeners. If the empty string (default) such listeners are
+    # disabled.
+    local-host: ""
   historical-data:
     # Where to we back up old jobs to?
     path: ${spalloc.working-directory}/spalloc-history.sqlite3


### PR DESCRIPTION
The live packet gatherer needs a totally different approach. Of course. It wants to use a single EIEIO connection and reprogram the tags on multiple ethernet chips to point to it. That in turn works in a totally different mode of operation of sockets to the way that the proxies are working. Ugh.

Needs two extra operations:
1. `OPEN_UNBOUND` &mdash; Open a socket without binding it. (Requires that we validate the addresses of messages passing by it, but allow messages from any board.)
2. `MESSAGE_TO` &mdash; Send a message on an unbound socket to a given board. We specify the board by X,Y; we could do it by IP address, but that seems wonky given that we don't really expose that elsewhere.