### PR TITLE
Split the notification protocol out of the EIEIO protocol

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/NotificationConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/NotificationConnection.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018-2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.connections;
+
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.connections.model.NotificationReceiver;
+import uk.ac.manchester.spinnaker.connections.model.NotificationSender;
+import uk.ac.manchester.spinnaker.messages.notification.AbstractNotificationMessage;
+import uk.ac.manchester.spinnaker.messages.notification.NotificationMessage;
+
+/**
+ * A UDP connection for sending and receiving notification protocol messages.
+ */
+public class NotificationConnection
+		extends UDPConnection<NotificationMessage>
+		implements NotificationReceiver, NotificationSender {
+	private static final int NOTIFICATION_MESSAGE_BUFFER_SIZE = 65535;
+
+	/**
+	 * Create a notification protocol connection only available for listening,
+	 * using default local port.
+	 *
+	 * @param localHost
+	 *            The local IP address to bind to.
+	 * @throws IOException
+	 *             If there is an error setting up the communication channel
+	 */
+	public NotificationConnection(InetAddress localHost) throws IOException {
+		super(localHost, null, null, null);
+		setReceivePacketSize(NOTIFICATION_MESSAGE_BUFFER_SIZE);
+	}
+
+	/**
+	 * Create a notification protocol connection only available for listening.
+	 *
+	 * @param localHost
+	 *            The local IP address to bind to.
+	 * @param localPort
+	 *            The local port to bind to, 0 or between 1025 and 65535.
+	 * @throws IOException
+	 *             If there is an error setting up the communication channel
+	 */
+	public NotificationConnection(InetAddress localHost, Integer localPort)
+			throws IOException {
+		super(localHost, localPort, null, null);
+		setReceivePacketSize(NOTIFICATION_MESSAGE_BUFFER_SIZE);
+	}
+
+	/**
+	 * Create a notification protocol connection that is bound to a particular
+	 * remote location (where the toolchain should be running).
+	 *
+	 * @param localHost
+	 *            The local host to bind to. If not specified, it defaults to
+	 *            binding to all interfaces, unless {@code remoteHost} is
+	 *            specified, in which case binding is done to the IP address
+	 *            that will be used to send packets.
+	 * @param localPort
+	 *            The local port to bind to, 0 or between 1025 and 65535.
+	 * @param remoteHost
+	 *            The remote host to send packets to. If not specified, the
+	 *            socket will be available for listening only, and will throw
+	 *            and exception if used for sending.
+	 * @param remotePort
+	 *            The remote port to send packets to. If remoteHost is
+	 *            {@code null}, this is ignored. If remoteHost is specified,
+	 *            this must also be specified as non-zero for the connection to
+	 *            allow sending.
+	 * @throws IOException
+	 *             If there is an error setting up the communication channel
+	 */
+	public NotificationConnection(InetAddress localHost, Integer localPort,
+			InetAddress remoteHost, Integer remotePort) throws IOException {
+		super(localHost, localPort, remoteHost, remotePort);
+		setReceivePacketSize(NOTIFICATION_MESSAGE_BUFFER_SIZE);
+	}
+
+	/**
+	 * @return Get a new little-endian buffer sized suitably for notification
+	 *         messages.
+	 */
+	private static ByteBuffer newMessageBuffer() {
+		return allocate(NOTIFICATION_MESSAGE_BUFFER_SIZE).order(LITTLE_ENDIAN);
+	}
+
+	@Override
+	public void sendNotification(NotificationMessage notificationMessage)
+			throws IOException {
+		ByteBuffer b = newMessageBuffer();
+		notificationMessage.addToBuffer(b);
+		b.flip();
+		send(b);
+	}
+
+	@Override
+	public NotificationMessage receiveMessage(int timeout) throws IOException {
+		ByteBuffer b = receive(timeout);
+		return AbstractNotificationMessage.build(b);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -95,6 +95,8 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 
 	private final ThreadLocal<SelectionKey> selectionKeyFactory;
 
+	private int receivePacketSize = PACKET_MAX_SIZE;
+
 	/**
 	 * Main constructor, any argument of which could {@code null}.
 	 * <p>
@@ -132,6 +134,18 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		if (channel != null && log.isDebugEnabled()) {
 			logInitialCreation();
 		}
+	}
+
+	/**
+	 * Set the maximum size of packet that can be received. Packets larger than
+	 * this will be truncated. The default is large enough for any packet that
+	 * is sent by SCAMP.
+	 *
+	 * @param receivePacketSize
+	 *            The new maximum packet size.
+	 */
+	protected void setReceivePacketSize(int receivePacketSize) {
+		this.receivePacketSize = receivePacketSize;
 	}
 
 	/**
@@ -355,7 +369,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 			log.debug("not ready to recieve");
 			throw new SocketTimeoutException();
 		}
-		ByteBuffer buffer = allocate(PACKET_MAX_SIZE);
+		ByteBuffer buffer = allocate(receivePacketSize);
 		SocketAddress addr = channel.receive(buffer);
 		receivable = false;
 		if (addr == null) {
@@ -427,7 +441,7 @@ public abstract class UDPConnection<T> implements Connection, Listenable<T> {
 		if (!receivable && !isReadyToReceive(timeout)) {
 			throw new SocketTimeoutException();
 		}
-		ByteBuffer buffer = ByteBuffer.allocate(PACKET_MAX_SIZE);
+		ByteBuffer buffer = ByteBuffer.allocate(receivePacketSize);
 		SocketAddress addr = channel.receive(buffer);
 		receivable = false;
 		if (addr == null) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/NotificationReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/NotificationReceiver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.connections.model;
+
+import uk.ac.manchester.spinnaker.messages.notification.NotificationMessage;
+
+/**
+ * A receiver of notification messages.
+ */
+public interface NotificationReceiver extends Connection,
+		MessageReceiver<NotificationMessage> {
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/NotificationSender.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/NotificationSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,15 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.eieio;
+package uk.ac.manchester.spinnaker.connections.model;
 
-import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.STOP_PAUSE_NOTIFICATION;
+import java.io.IOException;
 
-/**
- * Packet which indicates that the toolchain has paused or stopped.
- */
-public class NotificationProtocolPauseStop extends EIEIOCommandMessage {
-	public NotificationProtocolPauseStop() {
-		super(STOP_PAUSE_NOTIFICATION);
-	}
+import uk.ac.manchester.spinnaker.messages.notification.NotificationMessage;
+
+/** A sender of notification protocol messages. */
+public interface NotificationSender extends Connection {
+	/**
+	 * Sends a notification message down this connection.
+	 *
+	 * @param notificationMessage
+	 *            The notification message to be sent
+	 * @throws IOException
+	 *             If there is an error sending the message
+	 */
+	void sendNotification(NotificationMessage notificationMessage)
+			throws IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOCommandID.java
@@ -23,8 +23,6 @@ import java.util.Map;
  * What SpiNNaker-specific EIEIO commands there are.
  */
 public enum EIEIOCommandID implements EIEIOCommand {
-	/** Database handshake with external program. */
-	DATABASE_CONFIRMATION(1),
 	/** Fill in buffer area with padding. */
 	EVENT_PADDING(2),
 	/** End of all buffers, stop execution. */
@@ -41,10 +39,6 @@ public enum EIEIOCommandID implements EIEIOCommand {
 	SPINNAKER_REQUEST_READ_DATA(8),
 	/** Host confirming data being read form SpiNNaker memory. */
 	HOST_DATA_READ(9),
-	/** Notify the external devices that the simulation has stopped. */
-	STOP_PAUSE_NOTIFICATION(10),
-	/** Notify the external devices that the simulation has started. */
-	START_RESUME_NOTIFICATION(11),
 	/** Host confirming request to read data received. */
 	HOST_DATA_READ_ACK(12);
 	private final int value;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessageFactory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/eieio/EIEIOMessageFactory.java
@@ -43,8 +43,6 @@ public abstract class EIEIOMessageFactory {
 			return new EIEIOCommandMessage(data);
 		}
 		switch ((EIEIOCommandID) command) {
-		case DATABASE_CONFIRMATION:
-			return new DatabaseConfirmation(data);
 		case EVENT_PADDING:
 			// Fill in buffer area with padding
 			return new PaddingRequest();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/AbstractNotificationMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/AbstractNotificationMessage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.notification;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An notification message.
+ *
+ * @author Donal Fellows
+ */
+public abstract class AbstractNotificationMessage
+		implements NotificationMessage {
+	// Must be power of 2 (minus 1)
+	private static final int MAX_COMMAND = 0x3FFF;
+
+	private static final int FLAG1_BIT = 15;
+
+	private static final int FLAG2_BIT = 14;
+
+	/** The command code of the message. */
+	private final NotificationMessageCode command;
+
+	protected AbstractNotificationMessage(ByteBuffer buffer) {
+		command = NotificationMessageCode.get(buffer.getShort() & MAX_COMMAND);
+	}
+
+	public AbstractNotificationMessage(NotificationMessageCode command) {
+		this.command = command;
+	}
+
+	@Override
+	public void addToBuffer(ByteBuffer buffer) {
+		short value = (short) (0 << FLAG1_BIT | 1 << FLAG2_BIT
+				| command.getValue());
+		buffer.putShort(value);
+	}
+
+	public static NotificationMessage build(ByteBuffer buffer) {
+		switch (NotificationMessageCode.get(buffer.getShort(0) & MAX_COMMAND)) {
+		case DATABASE_CONFIRMATION:
+			return new DatabaseConfirmation(buffer);
+		case START_RESUME_NOTIFICATION:
+			return new StartResume(buffer);
+		case STOP_PAUSE_NOTIFICATION:
+			return new PauseStop(buffer);
+		default:
+			// TODO Auto-generated method stub
+			return null;
+		}
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/DatabaseConfirmation.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/DatabaseConfirmation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 The University of Manchester
+ * Copyright (c) 2018-2022 The University of Manchester
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,11 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.eieio;
+package uk.ac.manchester.spinnaker.messages.notification;
 
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Objects.requireNonNull;
-import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.DATABASE_CONFIRMATION;
+import static uk.ac.manchester.spinnaker.messages.notification.NotificationMessageCode.DATABASE_CONFIRMATION;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -27,7 +27,7 @@ import java.nio.charset.Charset;
  * Packet which contains the path to the database created by the toolchain which
  * is to be used by any software which interfaces with SpiNNaker.
  */
-public class DatabaseConfirmation extends EIEIOCommandMessage {
+public class DatabaseConfirmation extends AbstractNotificationMessage {
 	/**
 	 * The path to the database. Note that there is a length limit; the overall
 	 * message must fit in a SpiNNaker UDP message.
@@ -67,7 +67,7 @@ public class DatabaseConfirmation extends EIEIOCommandMessage {
 	DatabaseConfirmation(ByteBuffer data) {
 		super(data);
 		if (data.remaining() > 0) {
-			if (data.hasArray()) {
+			if (data.hasArray() && !data.isReadOnly()) {
 				databasePath = new String(data.array(), data.position(),
 						data.remaining(), CHARSET);
 			} else {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/NotificationMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/NotificationMessage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.notification;
+
+import uk.ac.manchester.spinnaker.messages.SerializableMessage;
+
+/**
+ * A notification message.
+ */
+public interface NotificationMessage extends SerializableMessage {
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/NotificationMessageCode.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/NotificationMessageCode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018-2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.notification;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * What command codes are used in the notification protocol.
+ */
+public enum NotificationMessageCode {
+	/** Database handshake with external program. */
+	DATABASE_CONFIRMATION(1),
+	/** Notify the external devices that the simulation has stopped. */
+	STOP_PAUSE_NOTIFICATION(10),
+	/** Notify the external devices that the simulation has started. */
+	START_RESUME_NOTIFICATION(11);
+	private final int value;
+
+	private static final Map<Integer, NotificationMessageCode> MAP =
+			new HashMap<>();
+
+	static {
+		for (NotificationMessageCode commmand : values()) {
+			MAP.put(commmand.value, commmand);
+		}
+	}
+
+	NotificationMessageCode(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	/**
+	 * Get a command from an ID.
+	 *
+	 * @param command
+	 *            the encoded command
+	 * @return the ID, or {@code null} if the encoded form was unrecognised.
+	 */
+	public static NotificationMessageCode get(int command) {
+		return MAP.get(command);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/PauseStop.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/PauseStop.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.notification;
+
+import static uk.ac.manchester.spinnaker.messages.notification.NotificationMessageCode.STOP_PAUSE_NOTIFICATION;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Packet which indicates that the toolchain has paused or stopped.
+ */
+public class PauseStop extends AbstractNotificationMessage {
+	public PauseStop() {
+		super(STOP_PAUSE_NOTIFICATION);
+	}
+
+	public PauseStop(ByteBuffer buffer) {
+		super(buffer);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/StartResume.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/StartResume.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.notification;
+
+import static uk.ac.manchester.spinnaker.messages.notification.NotificationMessageCode.START_RESUME_NOTIFICATION;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Packet which indicates that the toolchain has started or resumed.
+ */
+public class StartResume extends AbstractNotificationMessage {
+	public StartResume() {
+		super(START_RESUME_NOTIFICATION);
+	}
+
+	public StartResume(ByteBuffer buffer) {
+		super(buffer);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/package-info.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/notification/package-info.java
@@ -14,15 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.eieio;
-
-import static uk.ac.manchester.spinnaker.messages.eieio.EIEIOCommandID.START_RESUME_NOTIFICATION;
-
 /**
- * Packet which indicates that the toolchain has started or resumed.
+ * The messages of the notification protocol.
  */
-public class NotificationProtocolStartResume extends EIEIOCommandMessage {
-	public NotificationProtocolStartResume() {
-		super(START_RESUME_NOTIFICATION);
-	}
-}
+package uk.ac.manchester.spinnaker.messages.notification;


### PR DESCRIPTION
They're not the same thing, as the notification protocol is not routed via SpiNNaker and so doesn't need the SpiNNaker header and can be much larger. They never should have been the same thing.

Nothing in the rest of the current Java code depends on this.