### PR TITLE
No P2PC command

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SCPCommand.java
@@ -55,9 +55,6 @@ public enum SCPCommand implements CommandCode {
 	CMD_AR(19),
 	/** Send a broadcast Nearest-Neighbour packet. */
 	CMD_NNP(20),
-	/** unsupported by current spinnaker tools? */
-	@Deprecated
-	CMD_P2PC(21),
 	/** Send a Signal. */
 	CMD_SIG(22),
 	/** Send Flood-Fill Data. */


### PR DESCRIPTION
The infrastructure to support `CMD_P2PC` was removed 6 years ago. Nuke the tooling that could try to reach it anyway.