### PR TITLE
Style update: constructor parameter number increase

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DiagnosticFilter.java
@@ -94,7 +94,6 @@ public class DiagnosticFilter {
 	 *            Increment the counter if one or more of the given packet types
 	 *            match (or empty list to match all)
 	 */
-	@SuppressWarnings("checkstyle:ParameterNumber")
 	public DiagnosticFilter(boolean enableInterruptOnCounterEvent,
 			boolean matchEmergencyRoutingStatusToIncomingPacket,
 			Collection<Destination> destinations, Collection<Source> sources,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -173,7 +173,6 @@ import uk.ac.manchester.spinnaker.storage.StorageException;
  * <strong>always</strong> parallel-unsafe, other documentation in this class
  * notwithstanding.</em>
  */
-@SuppressWarnings("checkstyle:ParameterNumber")
 public class Transceiver extends UDPTransceiver
 		implements TransceiverInterface, RetryTracker {
 	private static final Logger log = getLogger(Transceiver.class);

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Chip.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Chip.java
@@ -111,7 +111,6 @@ public class Chip implements HasChipLocation {
 	 * @throws IllegalArgumentException
 	 *             Thrown if multiple chips share the same id.
 	 */
-	@SuppressWarnings("checkstyle:parameternumber")
 	public Chip(ChipLocation location, Iterable<Processor> processors,
 			Router router, int sdram, InetAddress ipAddress, boolean virtual,
 			List<Integer> tagIds, ChipLocation nearestEthernet) {

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineVersion.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MachineVersion.java
@@ -150,7 +150,6 @@ public enum MachineVersion {
 	 * @param isTriad
 	 *            Indicates if this board is made up of triads,
 	 */
-	@SuppressWarnings("checkstyle:ParameterNumber")
 	MachineVersion(Integer id, MachineDimensions dimensions, boolean isFourChip,
 			boolean isFourtyeightChip, boolean horizontalWrap,
 			boolean verticalWrap, boolean isTriad) {
@@ -197,7 +196,6 @@ public enum MachineVersion {
 	 * @param isTriad
 	 *            Indicates if this board is made up of triads.
 	 */
-	@SuppressWarnings("checkstyle:ParameterNumber")
 	MachineVersion(Integer id, int width, int height, boolean isFourChip,
 			boolean isFortyEightChip, boolean horizontalWrap,
 			boolean verticalWrap, boolean isTriad) {

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/tags/IPTag.java
@@ -178,7 +178,6 @@ public final class IPTag extends Tag {
 	 * @throws UnknownHostException
 	 *             If an IP address doesn't resolve.
 	 */
-	@SuppressWarnings("checkstyle:ParameterNumber")
 	public IPTag(
 			@JsonProperty(value = "boardAddress", required = true)
 			String boardAddress,

--- a/src/support/checkstyle/style.xml
+++ b/src/support/checkstyle/style.xml
@@ -93,6 +93,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		</module>
 		<module name="MethodLength" />
 		<module name="ParameterNumber">
+			<property name="tokens" value="METHOD_DEF" />
+			<property name="ignoreOverriddenMethods" value="true" />
+		</module>
+		<module name="ParameterNumber">
+			<property name="tokens" value="CTOR_DEF" />
+			<property name="max" value="15" />
 			<property name="ignoreOverriddenMethods" value="true" />
 		</module>
 		<module name="EmptyForIteratorPad" />


### PR DESCRIPTION
This is a minor style update that increases the number of parameters that may be passed _to a constructor only_. The aim is that, if you have an object that acts as a holder for a great many attributes (which we occasionally do as it is much nicer than passing them all individually), you can set them all in the constructor. It's a bit confusing, but nothing like as confusing as other approaches. Ordinary methods have the old standard limit.