### PR TITLE
Eliminate a warning with Java9+

### DIFF
--- a/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDefaultMap.java
+++ b/SpiNNaker-utils/src/test/java/uk/ac/manchester/spinnaker/utils/TestDefaultMap.java
@@ -86,12 +86,10 @@ public class TestDefaultMap {
     }
 
     public class Doubler implements DefaultMap.KeyAwareFactory<Integer, Integer> {
-
         @Override
         public Integer createValue(Integer key) {
-            return new Integer(key.intValue() * 2);
+            return Integer.valueOf(key.intValue() * 2);
         }
-
     }
 
 }


### PR DESCRIPTION
The visible boxing is left deliberately; there's another test that shows that it is unnecessary.