### PR TITLE
Improve the handling of process exceptions

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/UnexpectedResponseCodeException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/UnexpectedResponseCodeException.java
@@ -28,6 +28,13 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPResult;
 public class UnexpectedResponseCodeException extends Exception {
 	private static final long serialVersionUID = 7864690081287752744L;
 
+	private static final String MSG_TEMPLATE =
+			"Unexpected response %s while performing operation %s "
+					+ "using command %s";
+
+	/** The response that cause this exception to be thrown, if known. */
+	public final SCPResult response;
+
 	/**
 	 * @param operation
 	 *            The operation being performed
@@ -38,8 +45,8 @@ public class UnexpectedResponseCodeException extends Exception {
 	 */
 	public UnexpectedResponseCodeException(String operation, String command,
 			String response) {
-		super(format("Unexpected response %s while performing operation %s "
-				+ "using command %s", response, operation, command));
+		super(format(MSG_TEMPLATE, response, operation, command));
+		this.response = null;
 	}
 
 	/**
@@ -52,6 +59,7 @@ public class UnexpectedResponseCodeException extends Exception {
 	 */
 	public UnexpectedResponseCodeException(String operation, SCPCommand command,
 			SCPResult response) {
-		this(operation, command.name(), response.name());
+		super(format(MSG_TEMPLATE, response.name(), operation, command.name()));
+		this.response = response;
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
@@ -23,6 +23,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.RETRY_DELAY_MS;
 import static uk.ac.manchester.spinnaker.messages.Constants.BMP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.scp.SequenceNumberSource.SEQUENCE_LENGTH;
+import static uk.ac.manchester.spinnaker.transceiver.ProcessException.makeInstance;
 import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
 
 import java.io.IOException;
@@ -131,7 +132,7 @@ class BMPCommandProcess<R extends BMPResponse> {
 		requestPipeline.sendRequest(request, holder::setValue);
 		requestPipeline.finish();
 		if (exception != null) {
-			throw new ProcessException(errorRequest.sdpHeader.getDestination(),
+			throw makeInstance(errorRequest.sdpHeader.getDestination(),
 					exception);
 		}
 		return holder.getValue();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Process.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Process.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.transceiver;
 
+import static uk.ac.manchester.spinnaker.transceiver.ProcessException.makeInstance;
+
 import java.io.IOException;
 import java.util.function.Consumer;
 
@@ -72,9 +74,7 @@ abstract class Process {
 			return;
 		}
 		SDPHeader hdr = errorRequest.sdpHeader;
-		ProcessException ex =
-				new ProcessException(hdr.getDestination(), exception);
-		throw ex;
+		throw makeInstance(hdr.getDestination(), exception);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 The University of Manchester
+ * Copyright (c) 2018-2022 The University of Manchester
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,7 +118,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_LEN}
 	 * message, indicating that the packet length was wrong.
 	 */
-	public static class BadPacketLength extends ProcessException {
+	public static final class BadPacketLength extends ProcessException {
 		private static final long serialVersionUID = 4329836896716525422L;
 
 		private BadPacketLength(HasCoreLocation core,
@@ -131,7 +131,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_SUM}
 	 * message, indicating that the checksum was wrong.
 	 */
-	public static class BadChecksum extends ProcessException {
+	public static final class BadChecksum extends ProcessException {
 		private static final long serialVersionUID = -5660270018252119601L;
 
 		private BadChecksum(HasCoreLocation core,
@@ -145,7 +145,7 @@ public class ProcessException extends SpinnmanException {
 	 * message, indicating that the command was not supported by the
 	 * destination.
 	 */
-	public static class BadCommand extends ProcessException {
+	public static final class BadCommand extends ProcessException {
 		private static final long serialVersionUID = 2446636059917726286L;
 
 		private BadCommand(HasCoreLocation core,
@@ -158,7 +158,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_ARG}
 	 * message, indicating that the arguments to the command are wrong.
 	 */
-	public static class InvalidArguments extends ProcessException {
+	public static final class InvalidArguments extends ProcessException {
 		private static final long serialVersionUID = 3907517289211998444L;
 
 		private InvalidArguments(HasCoreLocation core,
@@ -171,7 +171,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_PORT}
 	 * message, indicating that the SCP port was out of range.
 	 */
-	public static class BadSCPPort extends ProcessException {
+	public static final class BadSCPPort extends ProcessException {
 		private static final long serialVersionUID = -5171910962257032626L;
 
 		private BadSCPPort(HasCoreLocation core,
@@ -185,7 +185,7 @@ public class ProcessException extends SpinnmanException {
 	 * {@link SCPResult#RC_TIMEOUT} message, indicating that communications
 	 * timed out.
 	 */
-	public static class TimedOut extends ProcessException {
+	public static final class TimedOut extends ProcessException {
 		private static final long serialVersionUID = -298985937364034661L;
 
 		private TimedOut(HasCoreLocation core,
@@ -199,7 +199,7 @@ public class ProcessException extends SpinnmanException {
 	 * message, indicating that messages cannot be directed to that destination
 	 * for some reason.
 	 */
-	public static class NoP2PRoute extends ProcessException {
+	public static final class NoP2PRoute extends ProcessException {
 		private static final long serialVersionUID = -6132417061161625508L;
 
 		private NoP2PRoute(HasCoreLocation core,
@@ -212,7 +212,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_CPU}
 	 * message, indicating that the destination core number was out of range.
 	 */
-	public static class BadCPUNumber extends ProcessException {
+	public static final class BadCPUNumber extends ProcessException {
 		private static final long serialVersionUID = 6532417803149087690L;
 
 		private BadCPUNumber(HasCoreLocation core,
@@ -226,7 +226,7 @@ public class ProcessException extends SpinnmanException {
 	 * message, indicating that the destination core was not responding to
 	 * messages from SCAMP.
 	 */
-	public static class DeadDestination extends ProcessException {
+	public static final class DeadDestination extends ProcessException {
 		private static final long serialVersionUID = -3842030808096451015L;
 
 		private DeadDestination(HasCoreLocation core,
@@ -239,7 +239,7 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_BUF}
 	 * message, indicating that SCAMP had exhausted its supply of buffers.
 	 */
-	public static class NoBufferAvailable extends ProcessException {
+	public static final class NoBufferAvailable extends ProcessException {
 		private static final long serialVersionUID = 3647501054775981197L;
 
 		private NoBufferAvailable(HasCoreLocation core,
@@ -253,7 +253,7 @@ public class ProcessException extends SpinnmanException {
 	 * {@link SCPResult#RC_P2P_NOREPLY} message, indicating that the inter-SCAMP
 	 * messaging failed because the channel open failed.
 	 */
-	public static class P2PNoReply extends ProcessException {
+	public static final class P2PNoReply extends ProcessException {
 		private static final long serialVersionUID = 2196366740196153289L;
 
 		private P2PNoReply(HasCoreLocation core,
@@ -267,7 +267,7 @@ public class ProcessException extends SpinnmanException {
 	 * {@link SCPResult#RC_P2P_REJECT} message, indicating that the receiver in
 	 * the inter-SCAMP messaging rejected the message.
 	 */
-	public static class P2PReject extends ProcessException {
+	public static final class P2PReject extends ProcessException {
 		private static final long serialVersionUID = -2903670314989693747L;
 
 		private P2PReject(HasCoreLocation core,
@@ -281,7 +281,7 @@ public class ProcessException extends SpinnmanException {
 	 * {@link SCPResult#RC_P2P_BUSY} message, indicating that the receiver in
 	 * the inter-SCAMP messaging was busy.
 	 */
-	public static class P2PBusy extends ProcessException {
+	public static final class P2PBusy extends ProcessException {
 		private static final long serialVersionUID = 4445680981367158468L;
 
 		private P2PBusy(HasCoreLocation core,
@@ -295,7 +295,7 @@ public class ProcessException extends SpinnmanException {
 	 * {@link SCPResult#RC_P2P_TIMEOUT} message, indicating that the receiver in
 	 * the inter-SCAMP messaging did not respond.
 	 */
-	public static class P2PTimedOut extends ProcessException {
+	public static final class P2PTimedOut extends ProcessException {
 		private static final long serialVersionUID = -7686611958418374003L;
 
 		private P2PTimedOut(HasCoreLocation core,
@@ -308,7 +308,8 @@ public class ProcessException extends SpinnmanException {
 	 * A process exception cause by the receipt of a {@link SCPResult#RC_PKT_TX}
 	 * message, indicating that the packet transmission failed.
 	 */
-	public static class PacketTransmissionFailed extends ProcessException {
+	public static final class PacketTransmissionFailed
+			extends ProcessException {
 		private static final long serialVersionUID = 5119831821960433468L;
 
 		private PacketTransmissionFailed(HasCoreLocation core,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
@@ -17,20 +17,47 @@
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
+import uk.ac.manchester.spinnaker.messages.scp.SCPResult;
 
 /**
  * Encapsulates exceptions from processes which communicate with some core/chip.
  */
 public class ProcessException extends SpinnmanException {
-	private static final long serialVersionUID = 7759365416594564702L;
+	private static final long serialVersionUID = 5198868033333540659L;
 
 	private static final String S = "     "; // five spaces
 
+	private static final String MSG_TEMPLATE =
+			"when sending to %d:%d:%d, received exception: %s\n" + S
+					+ "with message: %s";
+
 	/** Where does the code believe this exception originated? */
 	public final CoreLocation core;
+
+	/**
+	 * The response that cause this exception to be thrown, if known. Never
+	 * {@link SCPResult#RC_OK RC_OK}; that doesn't cause exceptions! May be
+	 * {@code null} if the cause was not identified as an error from SpiNNaker.
+	 */
+	public final SCPResult responseCode;
+
+	private ProcessException(HasCoreLocation core, Throwable cause,
+			SCPResult responseCode) {
+		super(format(MSG_TEMPLATE, core.getX(), core.getY(), core.getP(),
+				cause.getClass().getName(), cause.getMessage()), cause);
+		this.core = core.asCoreLocation();
+		this.responseCode = responseCode;
+	}
+
+	private ProcessException(HasCoreLocation core,
+			UnexpectedResponseCodeException cause) {
+		this(core, cause, cause.response);
+	}
 
 	/**
 	 * Create an exception.
@@ -39,13 +66,254 @@ public class ProcessException extends SpinnmanException {
 	 *            What core were we talking to.
 	 * @param cause
 	 *            What exception caused problems.
+	 * @return A process exception, or a subclass of it.
 	 */
-	ProcessException(HasCoreLocation core, Throwable cause) {
-		super(format(
-				"when sending to %d:%d:%d, received exception: %s\n" + S
-						+ "with message: %s",
-				core.getX(), core.getY(), core.getP(),
-				cause.getClass().getName(), cause.getMessage()), cause);
-		this.core = core.asCoreLocation();
+	static ProcessException makeInstance(HasCoreLocation core,
+			Throwable cause) {
+		if (requireNonNull(cause) instanceof UnexpectedResponseCodeException) {
+			UnexpectedResponseCodeException urc =
+					(UnexpectedResponseCodeException) cause;
+			if (urc.response == null) {
+				return new ProcessException(core, cause, null);
+			}
+			switch (urc.response) {
+			case RC_LEN:
+				return new BadPacketLength(core, urc);
+			case RC_SUM:
+				return new BadChecksum(core, urc);
+			case RC_CMD:
+				return new BadCommand(core, urc);
+			case RC_ARG:
+				return new InvalidArguments(core, urc);
+			case RC_PORT:
+				return new BadSCPPort(core, urc);
+			case RC_TIMEOUT:
+				return new TimedOut(core, urc);
+			case RC_ROUTE:
+				return new NoP2PRoute(core, urc);
+			case RC_CPU:
+				return new BadCPUNumber(core, urc);
+			case RC_DEAD:
+				return new DeadDestination(core, urc);
+			case RC_BUF:
+				return new NoBufferAvailable(core, urc);
+			case RC_P2P_NOREPLY:
+				return new P2PNoReply(core, urc);
+			case RC_P2P_REJECT:
+				return new P2PReject(core, urc);
+			case RC_P2P_BUSY:
+				return new P2PBusy(core, urc);
+			case RC_P2P_TIMEOUT:
+				return new P2PTimedOut(core, urc);
+			case RC_PKT_TX:
+				return new PacketTransmissionFailed(core, urc);
+			default:
+				// Fall through
+			}
+		}
+		return new ProcessException(core, cause, null);
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_LEN}
+	 * message, indicating that the packet length was wrong.
+	 */
+	public static class BadPacketLength extends ProcessException {
+		private static final long serialVersionUID = 4329836896716525422L;
+
+		private BadPacketLength(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_SUM}
+	 * message, indicating that the checksum was wrong.
+	 */
+	public static class BadChecksum extends ProcessException {
+		private static final long serialVersionUID = -5660270018252119601L;
+
+		private BadChecksum(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_CMD}
+	 * message, indicating that the command was not supported by the
+	 * destination.
+	 */
+	public static class BadCommand extends ProcessException {
+		private static final long serialVersionUID = 2446636059917726286L;
+
+		private BadCommand(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_ARG}
+	 * message, indicating that the arguments to the command are wrong.
+	 */
+	public static class InvalidArguments extends ProcessException {
+		private static final long serialVersionUID = 3907517289211998444L;
+
+		private InvalidArguments(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_PORT}
+	 * message, indicating that the SCP port was out of range.
+	 */
+	public static class BadSCPPort extends ProcessException {
+		private static final long serialVersionUID = -5171910962257032626L;
+
+		private BadSCPPort(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a
+	 * {@link SCPResult#RC_TIMEOUT} message, indicating that communications
+	 * timed out.
+	 */
+	public static class TimedOut extends ProcessException {
+		private static final long serialVersionUID = -298985937364034661L;
+
+		private TimedOut(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_ROUTE}
+	 * message, indicating that messages cannot be directed to that destination
+	 * for some reason.
+	 */
+	public static class NoP2PRoute extends ProcessException {
+		private static final long serialVersionUID = -6132417061161625508L;
+
+		private NoP2PRoute(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_CPU}
+	 * message, indicating that the destination core number was out of range.
+	 */
+	public static class BadCPUNumber extends ProcessException {
+		private static final long serialVersionUID = 6532417803149087690L;
+
+		private BadCPUNumber(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_DEAD}
+	 * message, indicating that the destination core was not responding to
+	 * messages from SCAMP.
+	 */
+	public static class DeadDestination extends ProcessException {
+		private static final long serialVersionUID = -3842030808096451015L;
+
+		private DeadDestination(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_BUF}
+	 * message, indicating that SCAMP had exhausted its supply of buffers.
+	 */
+	public static class NoBufferAvailable extends ProcessException {
+		private static final long serialVersionUID = 3647501054775981197L;
+
+		private NoBufferAvailable(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a
+	 * {@link SCPResult#RC_P2P_NOREPLY} message, indicating that the inter-SCAMP
+	 * messaging failed because the channel open failed.
+	 */
+	public static class P2PNoReply extends ProcessException {
+		private static final long serialVersionUID = 2196366740196153289L;
+
+		private P2PNoReply(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a
+	 * {@link SCPResult#RC_P2P_REJECT} message, indicating that the receiver in
+	 * the inter-SCAMP messaging rejected the message.
+	 */
+	public static class P2PReject extends ProcessException {
+		private static final long serialVersionUID = -2903670314989693747L;
+
+		private P2PReject(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a
+	 * {@link SCPResult#RC_P2P_BUSY} message, indicating that the receiver in
+	 * the inter-SCAMP messaging was busy.
+	 */
+	public static class P2PBusy extends ProcessException {
+		private static final long serialVersionUID = 4445680981367158468L;
+
+		private P2PBusy(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a
+	 * {@link SCPResult#RC_P2P_TIMEOUT} message, indicating that the receiver in
+	 * the inter-SCAMP messaging did not respond.
+	 */
+	public static class P2PTimedOut extends ProcessException {
+		private static final long serialVersionUID = -7686611958418374003L;
+
+		private P2PTimedOut(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
+	}
+
+	/**
+	 * A process exception cause by the receipt of a {@link SCPResult#RC_PKT_TX}
+	 * message, indicating that the packet transmission failed.
+	 */
+	public static class PacketTransmissionFailed extends ProcessException {
+		private static final long serialVersionUID = 5119831821960433468L;
+
+		private PacketTransmissionFailed(HasCoreLocation core,
+				UnexpectedResponseCodeException cause) {
+			super(core, cause);
+		}
 	}
 }


### PR DESCRIPTION
This makes it possible for higher-level code to handle particular types of failure without needing to dig in so deeply into how exceptions are wrapped inside the comms library. Or they can just ignore that detail and work as before.

This will prove useful when trying to make code that needs to handle potentially absent hardware (see #474 and #502).