### PR TITLE
Make memory locations into their own type

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
@@ -299,7 +299,7 @@ public class FirmwareLoader {
 	public static class RegisterSet {
 		private final FPGA fpga;
 
-		private final int address;
+		private final MemoryLocation address;
 
 		private final int value;
 
@@ -502,7 +502,7 @@ public class FirmwareLoader {
 			throws ProcessException, IOException {
 		List<Integer> data = new ArrayList<>();
 		for (RegisterSet r : settings) {
-			data.add(r.address | r.fpga.value);
+			data.add(r.address.address | r.fpga.value);
 			data.add(r.value);
 		}
 		FlashDataSector sector =

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
@@ -45,6 +45,7 @@ import uk.ac.manchester.spinnaker.alloc.ServiceMasterControl;
 import uk.ac.manchester.spinnaker.alloc.SpallocProperties.TxrxProperties;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.Machine;
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPCoords;
 import uk.ac.manchester.spinnaker.messages.model.BMPConnectionData;
@@ -271,14 +272,14 @@ class DummyTransceiver extends UnimplementedTransceiver {
 	}
 
 	@Override
-	public int readFPGARegister(FPGA fpga, int register, BMPCoords bmp,
-			BMPBoard board) {
+	public int readFPGARegister(FPGA fpga, MemoryLocation register,
+			BMPCoords bmp, BMPBoard board) {
 		log.info("readFPGARegister({},{},{},{})", fpga, register, bmp, board);
 		return fpga.value;
 	}
 
 	@Override
-	public void writeFPGARegister(FPGA fpga, int register, int value,
+	public void writeFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPCoords bmp, BMPBoard board) {
 		log.info("writeFPGARegister({},{},{},{},{})", fpga, register, value,
 				bmp, board);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/UnimplementedTransceiver.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/UnimplementedTransceiver.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPCoords;
 import uk.ac.manchester.spinnaker.messages.model.ADCInfo;
@@ -111,79 +112,89 @@ class UnimplementedTransceiver implements BMPTransceiverInterface {
 
 	@Override
 	public ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board,
-			int baseAddress, int length) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws IOException, ProcessException {
+	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ByteBuffer readSerialFlash(BMPCoords bmp, BMPBoard board,
-			int baseAddress, int length) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int readSerialFlashCRC(BMPCoords bmp, BMPBoard board,
-			int baseAddress, int length) throws IOException, ProcessException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws ProcessException, IOException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws ProcessException, IOException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public int eraseBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size) throws IOException, ProcessException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void chunkBMPFlash(BMPCoords bmp, BMPBoard board, int address)
+			MemoryLocation baseAddress, int length)
 			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void copyBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size) throws IOException, ProcessException {
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws ProcessException, IOException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public int getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws ProcessException, IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public MemoryLocation eraseBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size)
 			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size, InputStream stream) throws ProcessException, IOException {
+	public void chunkBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation address) throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void writeBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress)
+	public void copyBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size)
 			throws IOException, ProcessException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public MemoryLocation getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
+			throws IOException, ProcessException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size, InputStream stream)
+			throws ProcessException, IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void writeBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress) throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/UnimplementedTransceiver.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/UnimplementedTransceiver.java
@@ -74,13 +74,14 @@ class UnimplementedTransceiver implements BMPTransceiverInterface {
 	}
 
 	@Override
-	public int readFPGARegister(FPGA fpga, int register, BMPCoords bmp,
-			BMPBoard board) throws IOException, ProcessException {
+	public int readFPGARegister(FPGA fpga, MemoryLocation register,
+			BMPCoords bmp, BMPBoard board)
+			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void writeFPGARegister(FPGA fpga, int register, int value,
+	public void writeFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPCoords bmp, BMPBoard board)
 			throws IOException, ProcessException {
 		throw new UnsupportedOperationException();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/AbstractIO.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.FillDataType;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.utils.Slice;
@@ -147,7 +148,7 @@ public interface AbstractIO extends AutoCloseable {
 	int tell() throws IOException, ProcessException;
 
 	/** @return the current absolute address within the region. */
-	int getAddress();
+	MemoryLocation getAddress();
 
 	/**
 	 * Read the rest of the data.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.spinnaker.io;
 import java.io.EOFException;
 import java.io.IOException;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.FillDataType;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.utils.Slice;
@@ -30,16 +31,16 @@ import uk.ac.manchester.spinnaker.utils.Slice;
  */
 abstract class BaseIO implements AbstractIO {
 	/** The start address of the region to write to. */
-	final int start;
+	final MemoryLocation start;
 
 	/** The end of the region to write to. */
-	final int end;
+	final MemoryLocation end;
 
 	/** The current pointer where read and writes are taking place. */
-	int current;
+	MemoryLocation current;
 
-	BaseIO(int start, int end) {
-		if (start >= end) {
+	BaseIO(MemoryLocation start, MemoryLocation end) {
+		if (!start.lessThan(end)) {
 			throw new IllegalArgumentException(
 					"start address must precede end address");
 		}
@@ -50,13 +51,13 @@ abstract class BaseIO implements AbstractIO {
 
 	@Override
 	public int size() {
-		return end - start;
+		return end.address - start.address;
 	}
 
 	@Override
 	public void seek(int numBytes) {
-		int position = start + numBytes;
-		if (position < start || position > end) {
+		MemoryLocation position = start.add(numBytes);
+		if (position.lessThan(start) || position.greaterThan(end)) {
 			throw new IllegalArgumentException(
 					"Attempt to seek to a position of " + position
 							+ " which is outside of the region");
@@ -66,11 +67,11 @@ abstract class BaseIO implements AbstractIO {
 
 	@Override
 	public int tell() {
-		return current - start;
+		return current.diff(start);
 	}
 
 	@Override
-	public int getAddress() {
+	public MemoryLocation getAddress() {
 		return current;
 	}
 
@@ -121,44 +122,47 @@ abstract class BaseIO implements AbstractIO {
 	abstract void doFill(int value, FillDataType type, int len)
 			throws IOException, ProcessException;
 
+	private void inRange(int delta) throws EOFException {
+		int newAddr = current.address + delta;
+		if (newAddr > end.address) {
+			throw new EOFException();
+		}
+	}
+
 	@Override
 	public byte[] read(Integer numBytes) throws IOException, ProcessException {
 		if (numBytes != null && numBytes == 0) {
 			return new byte[0];
 		}
-		int n = (numBytes == null || numBytes < 0) ? (end - current) : numBytes;
-		if (current + n > end) {
-			throw new EOFException();
-		}
+		int n = (numBytes == null || numBytes < 0)
+				? (end.address - current.address)
+				: numBytes;
+		inRange(n);
 		byte[] data = doRead(n);
-		current += n;
+		current = current.add(n);
 		return data;
 	}
 
 	@Override
 	public int write(byte[] data) throws IOException, ProcessException {
 		int n = data.length;
-		if (current + n > end) {
-			throw new EOFException();
-		}
+		inRange(n);
 		doWrite(data, 0, n);
-		current += n;
+		current = current.add(n);
 		return n;
 	}
 
 	@Override
 	public void fill(int value, Integer size, FillDataType type)
 			throws IOException, ProcessException {
-		int len = (size == null) ? (end - current) : size;
-		if (current + len > end) {
-			throw new EOFException();
-		}
+		int len = (size == null) ? (end.address - current.address) : size;
+		inRange(len);
 		if (len < 0 || len % type.size != 0) {
 			throw new IllegalArgumentException(
 					"length to fill must be multiple of fill unit size");
 		}
 		doFill(value, type, len);
-		current += len;
+		current = current.add(len);
 	}
 
 	/**
@@ -179,7 +183,7 @@ abstract class BaseIO implements AbstractIO {
 		 *            Where the slice ends. Greater than {@code from}.
 		 * @return The sliced object.
 		 */
-		V call(int from, int to);
+		V call(MemoryLocation from, MemoryLocation to);
 	}
 
 	/**
@@ -199,20 +203,20 @@ abstract class BaseIO implements AbstractIO {
 	 */
 	final <IO extends AbstractIO> IO get(Slice slice,
 			SliceFactory<IO> factory) {
-		int from = start;
-		int to = end;
+		MemoryLocation from = start;
+		MemoryLocation to = end;
 		if (slice.start != null) {
 			if (slice.start < 0) {
-				from = end + slice.start;
+				from = end.add(slice.start);
 			} else {
-				from += slice.start;
+				from = from.add(slice.start);
 			}
 		}
 		if (slice.stop != null) {
 			if (slice.stop < 0) {
-				to = end + slice.stop;
+				to = end.add(slice.stop);
 			} else {
-				to += slice.stop;
+				to = to.add(slice.stop);
 			}
 		}
 		/*
@@ -221,13 +225,13 @@ abstract class BaseIO implements AbstractIO {
 		 *
 		 * An equivalent argument holds for slice.stop.
 		 */
-		if (from < start || from > end) {
+		if (from.lessThan(start) || from.greaterThan(end)) {
 			throw new ArrayIndexOutOfBoundsException(slice.start);
 		}
-		if (to < start || to > end) {
+		if (to.lessThan(start) || to.greaterThan(end)) {
 			throw new ArrayIndexOutOfBoundsException(slice.stop);
 		}
-		if (from == to) {
+		if (from.equals(to)) {
 			throw new ArrayIndexOutOfBoundsException(
 					"zero-sized regions are not supported");
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
@@ -51,7 +51,7 @@ abstract class BaseIO implements AbstractIO {
 
 	@Override
 	public int size() {
-		return end.address - start.address;
+		return end.diff(start);
 	}
 
 	@Override
@@ -123,8 +123,8 @@ abstract class BaseIO implements AbstractIO {
 			throws IOException, ProcessException;
 
 	private void inRange(int delta) throws EOFException {
-		int newAddr = current.address + delta;
-		if (newAddr > end.address) {
+		MemoryLocation newAddr = current.add(delta);
+		if (!newAddr.lessThan(end)) {
 			throw new EOFException();
 		}
 	}
@@ -134,8 +134,7 @@ abstract class BaseIO implements AbstractIO {
 		if (numBytes != null && numBytes == 0) {
 			return new byte[0];
 		}
-		int n = (numBytes == null || numBytes < 0)
-				? (end.address - current.address)
+		int n = (numBytes == null || numBytes < 0) ? end.diff(current)
 				: numBytes;
 		inRange(n);
 		byte[] data = doRead(n);
@@ -155,7 +154,7 @@ abstract class BaseIO implements AbstractIO {
 	@Override
 	public void fill(int value, Integer size, FillDataType type)
 			throws IOException, ProcessException {
-		int len = (size == null) ? (end.address - current.address) : size;
+		int len = (size == null) ? end.diff(current) : size;
 		inRange(len);
 		if (len < 0 || len % type.size != 0) {
 			throw new IllegalArgumentException(

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
@@ -20,6 +20,7 @@ import static java.lang.Math.min;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.UNBUFFERED_SDRAM_START;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -39,21 +40,6 @@ import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 
 /** A file-like object for the memory of a chip. */
 final class ChipMemoryIO {
-	/**
-	 * Start of unbuffered access to SDRAM. Writes will block until they have
-	 * completed.
-	 * <p>
-	 * <blockquote> Buffered SDRAM means that writes go through a write buffer.
-	 * Unbuffered means that they go directly to SDRAM. Reads are unaffected in
-	 * general. If you are writing lots of data, it is unlikely to matter much
-	 * since the write buffer is limited in size. Here you probably want to use
-	 * Unbuffered anyway, as it will then block until the write is definitely
-	 * done. Using Buffered writing means that the write may or may not have
-	 * happened at the time of the response. </blockquote>
-	 */
-	private static final MemoryLocation UNBUFFERED_SDRAM_START =
-			new MemoryLocation(0x60000000);
-
 	/**
 	 * A set of ChipMemoryIO objects that have been created, indexed by
 	 * transceiver, x and y (thus two transceivers might not see the same

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/FileIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/FileIO.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.FillDataType;
 import uk.ac.manchester.spinnaker.utils.Slice;
 
@@ -42,8 +43,8 @@ public class FileIO extends BaseIO {
 	 * @throws IOException
 	 *             If anything goes wrong opening the file.
 	 */
-	public FileIO(File file, int startOffset, int endOffset)
-			throws IOException {
+	public FileIO(File file, MemoryLocation startOffset,
+			MemoryLocation endOffset) throws IOException {
 		this(new RandomAccessFile(file, "rw"), startOffset, endOffset);
 	}
 
@@ -55,7 +56,8 @@ public class FileIO extends BaseIO {
 	 * @param endOffset
 	 *            The end offset from the start of the file
 	 */
-	private FileIO(RandomAccessFile file, int startOffset, int endOffset) {
+	private FileIO(RandomAccessFile file, MemoryLocation startOffset,
+			MemoryLocation endOffset) {
 		super(startOffset, endOffset);
 		this.file = file;
 	}
@@ -70,7 +72,7 @@ public class FileIO extends BaseIO {
 		if (slice < 0 || slice >= size()) {
 			throw new ArrayIndexOutOfBoundsException(slice);
 		}
-		return new FileIO(file, start + slice, start + slice + 1);
+		return new FileIO(file, start.add(slice), start.add(slice + 1));
 	}
 
 	@Override
@@ -92,7 +94,7 @@ public class FileIO extends BaseIO {
 	byte[] doRead(int numBytes) throws IOException {
 		byte[] data = new byte[numBytes];
 		synchronized (file) {
-			file.seek(current);
+			file.seek(current.address);
 			file.readFully(data, 0, numBytes);
 		}
 		return data;
@@ -101,7 +103,7 @@ public class FileIO extends BaseIO {
 	@Override
 	void doWrite(byte[] data, int from, int len) throws IOException {
 		synchronized (file) {
-			file.seek(current);
+			file.seek(current.address);
 			file.write(data, from, len);
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.spinnaker.io;
 import java.io.IOException;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.FillDataType;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
@@ -41,12 +42,13 @@ public class MemoryIO extends BaseIO {
 	 *            address just outside the region
 	 */
 	public MemoryIO(Transceiver transceiver, HasChipLocation chip,
-			int startAddress, int endAddress) {
+			MemoryLocation startAddress, MemoryLocation endAddress) {
 		super(startAddress, endAddress);
 		io = ChipMemoryIO.getInstance(transceiver, chip);
 	}
 
-	private MemoryIO(ChipMemoryIO io, int startAddress, int endAddress) {
+	private MemoryIO(ChipMemoryIO io, MemoryLocation startAddress,
+			MemoryLocation endAddress) {
 		super(startAddress, endAddress);
 		this.io = io;
 	}
@@ -63,7 +65,7 @@ public class MemoryIO extends BaseIO {
 		if (slice < 0 || slice >= size()) {
 			throw new ArrayIndexOutOfBoundsException(slice);
 		}
-		return new MemoryIO(io, start + slice, start + slice + 1);
+		return new MemoryIO(io, start.add(slice), start.add(slice + 1));
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
@@ -23,6 +23,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTran
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /** An SCP request to read a region of memory from a BMP. */
@@ -43,8 +44,8 @@ public class BMPReadMemory extends BMPRequest<BMPReadMemory.Response> {
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public BMPReadMemory(BMPBoard board, int address, int size) {
-		super(board, CMD_READ, address, validate(size),
+	public BMPReadMemory(BMPBoard board, MemoryLocation address, int size) {
+		super(board, CMD_READ, address.address, validate(size),
 				efficientTransferUnit(address, size).value);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadSerialFlash.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadSerialFlash.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_BMP_SF;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /** An SCP request to read a region of serial flash from a BMP. */
@@ -43,8 +44,9 @@ public class BMPReadSerialFlash
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public BMPReadSerialFlash(BMPBoard board, int address, int size) {
-		super(board, CMD_BMP_SF, address, validate(size), 0);
+	public BMPReadSerialFlash(BMPBoard board, MemoryLocation address,
+			int size) {
+		super(board, CMD_BMP_SF, address.address, validate(size), 0);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPWriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPWriteMemory.java
@@ -21,6 +21,8 @@ import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTran
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** A request to write memory on a BMP. */
 public class BMPWriteMemory extends BMPRequest<BMPRequest.BMPResponse> {
 	/**
@@ -33,8 +35,9 @@ public class BMPWriteMemory extends BMPRequest<BMPRequest.BMPResponse> {
 	 *            buffer must be the point where the data starts, and the data
 	 *            must extend up to the <i>limit</i>.
 	 */
-	public BMPWriteMemory(BMPBoard board, int baseAddress, ByteBuffer data) {
-		super(board, CMD_WRITE, baseAddress, data.remaining(),
+	public BMPWriteMemory(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer data) {
+		super(board, CMD_WRITE, baseAddress.address, data.remaining(),
 				efficientTransferUnit(baseAddress, data.remaining()).value,
 				data);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
@@ -21,6 +21,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LINK_READ;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.FPGA;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
@@ -41,8 +42,10 @@ public class ReadFPGARegister extends BMPRequest<ReadFPGARegister.Response> {
 	 * @throws IllegalArgumentException
 	 *             If {@link FPGA#FPGA_ALL} is used.
 	 */
-	public ReadFPGARegister(FPGA fpga, int register, BMPBoard board) {
-		super(board, CMD_LINK_READ, register & ~MASK, WORD_SIZE, fpga.value);
+	public ReadFPGARegister(FPGA fpga, MemoryLocation register,
+			BMPBoard board) {
+		super(board, CMD_LINK_READ, register.address & ~MASK, WORD_SIZE,
+				fpga.value);
 		if (!fpga.isSingleFPGA()) {
 			throw new IllegalArgumentException(
 					"cannot read multiple FPGAs at once with this message");

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
@@ -29,23 +29,24 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * Requests the data from a FPGA's register.
  */
 public class ReadFPGARegister extends BMPRequest<ReadFPGARegister.Response> {
-	private static final int MASK = 0b00000011;
-
 	/**
 	 * @param fpga
 	 *            FPGA (0, 1 or 2 on SpiNN-5 board) to communicate with.
 	 * @param register
-	 *            Register address to read to (will be rounded down to the
-	 *            nearest 32-bit word boundary).
+	 *            Register address to read to. Must be aligned
 	 * @param board
 	 *            which board to request the ADC register from
 	 * @throws IllegalArgumentException
-	 *             If {@link FPGA#FPGA_ALL} is used.
+	 *             If {@link FPGA#FPGA_ALL} is used or the register address is
+	 *             not aligned.
 	 */
 	public ReadFPGARegister(FPGA fpga, MemoryLocation register,
 			BMPBoard board) {
-		super(board, CMD_LINK_READ, register.address & ~MASK, WORD_SIZE,
-				fpga.value);
+		super(board, CMD_LINK_READ, register.address, WORD_SIZE, fpga.value);
+		if (!register.isAligned()) {
+			throw new IllegalArgumentException(
+					"FPGA register addresses must be aligned");
+		}
 		if (!fpga.isSingleFPGA()) {
 			throw new IllegalArgumentException(
 					"cannot read multiple FPGAs at once with this message");

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlashCRC.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlashCRC.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_BMP_SF;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /** An SCP request to get the CRC of serial flash memory from a BMP. */
@@ -30,13 +31,14 @@ public class ReadSerialFlashCRC
 	/**
 	 * @param board
 	 *            which board's BMP's serial flash should be checked
-	 * @param address
+	 * @param baseAddress
 	 *            The positive base address to start the check from
 	 * @param size
 	 *            The number of bytes to check
 	 */
-	public ReadSerialFlashCRC(BMPBoard board, int address, int size) {
-		super(board, CMD_BMP_SF, address, size, CRC.value);
+	public ReadSerialFlashCRC(BMPBoard board, MemoryLocation baseAddress,
+			int size) {
+		super(board, CMD_BMP_SF, baseAddress.address, size, CRC.value);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/UpdateFlash.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/UpdateFlash.java
@@ -20,6 +20,8 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FLASH_COPY;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * A request to update flash memory on a BMP. Must have already been prepared
  * with {@link EraseFlash} and {@link WriteFlashBuffer}.
@@ -35,8 +37,9 @@ public final class UpdateFlash extends BMPRequest<BMPRequest.BMPResponse> {
 	 * @param size
 	 *            The number of bytes to copy
 	 */
-	public UpdateFlash(BMPBoard board, int baseAddress, int size) {
-		super(board, CMD_FLASH_COPY, REAL_FLASH_ADDRESS, baseAddress, size);
+	public UpdateFlash(BMPBoard board, MemoryLocation baseAddress, int size) {
+		super(board, CMD_FLASH_COPY, REAL_FLASH_ADDRESS, baseAddress.address,
+				size);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
@@ -36,25 +36,27 @@ import uk.ac.manchester.spinnaker.messages.model.FPGA;
  *      on GitHub</a>
  */
 public class WriteFPGARegister extends BMPRequest<BMPRequest.BMPResponse> {
-	private static final int MASK = 0b00000011;
-
 	/**
 	 * @param fpga
 	 *            FPGA (0, 1 or 2 on SpiNN-5 board) to communicate with.
 	 * @param register
-	 *            Register address to read to (will be rounded down to the
-	 *            nearest 32-bit word boundary).
+	 *            Register address to read to. Must be aligned.
 	 * @param value
 	 *            A 32-bit value to write to the register.
 	 * @param board
 	 *            which board to write the ADC register on
 	 * @throws IllegalArgumentException
-	 *             If {@link FPGA#FPGA_ALL} is used.
+	 *             If {@link FPGA#FPGA_ALL} is used or the register address is
+	 *             not aligned.
 	 */
 	public WriteFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPBoard board) {
-		super(board, CMD_LINK_WRITE, register.address & ~MASK, WORD_SIZE,
-				fpga.value, data(value));
+		super(board, CMD_LINK_WRITE, register.address, WORD_SIZE, fpga.value,
+				data(value));
+		if (!register.isAligned()) {
+			throw new IllegalArgumentException(
+					"FPGA register addresses must be aligned");
+		}
 		if (!fpga.isSingleFPGA()) {
 			throw new IllegalArgumentException(
 					"cannot write multiple FPGAs at once with this message");

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFPGARegister.java
@@ -23,6 +23,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_LINK_WRITE;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.FPGA;
 
 /**
@@ -50,10 +51,10 @@ public class WriteFPGARegister extends BMPRequest<BMPRequest.BMPResponse> {
 	 * @throws IllegalArgumentException
 	 *             If {@link FPGA#FPGA_ALL} is used.
 	 */
-	public WriteFPGARegister(FPGA fpga, int register, int value,
+	public WriteFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPBoard board) {
-		super(board, CMD_LINK_WRITE, register & ~MASK, WORD_SIZE, fpga.value,
-				data(value));
+		super(board, CMD_LINK_WRITE, register.address & ~MASK, WORD_SIZE,
+				fpga.value, data(value));
 		if (!fpga.isSingleFPGA()) {
 			throw new IllegalArgumentException(
 					"cannot write multiple FPGAs at once with this message");

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFlashBuffer.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteFlashBuffer.java
@@ -20,6 +20,8 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FLASH_WRITE
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * A request to write memory to flash on a BMP. Must have already been prepared
  * with {@link EraseFlash}.
@@ -36,8 +38,9 @@ public class WriteFlashBuffer extends BMPRequest<BMPRequest.BMPResponse> {
 	 * @param erase
 	 *            Whether to erase first
 	 */
-	public WriteFlashBuffer(BMPBoard board, int baseAddress, boolean erase) {
-		super(board, CMD_FLASH_WRITE, baseAddress, FLASH_CHUNK_SIZE,
+	public WriteFlashBuffer(BMPBoard board, MemoryLocation baseAddress,
+			boolean erase) {
+		super(board, CMD_FLASH_WRITE, baseAddress.address, FLASH_CHUNK_SIZE,
 				erase ? 1 : 0);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteSerialFlash.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/WriteSerialFlash.java
@@ -21,6 +21,8 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_BMP_SF;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * A request to write to serial flash on a BMP.
  */
@@ -37,9 +39,10 @@ public class WriteSerialFlash extends BMPRequest<BMPRequest.BMPResponse> {
 	 *            The data to transfer; up to {@link #FLASH_CHUNK_SIZE} bytes.
 	 *            This does <em>not</em> update the buffer position.
 	 */
-	public WriteSerialFlash(BMPBoard board, int baseAddress, ByteBuffer data) {
-		super(board, CMD_BMP_SF, baseAddress, FLASH_CHUNK_SIZE, WRITE.value,
-				condition(data));
+	public WriteSerialFlash(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer data) {
+		super(board, CMD_BMP_SF, baseAddress.address, FLASH_CHUNK_SIZE,
+				WRITE.value, condition(data));
 	}
 
 	private static ByteBuffer condition(ByteBuffer data) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/SystemVariableBootValues.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/boot/SystemVariableBootValues.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import uk.ac.manchester.spinnaker.machine.MachineVersion;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.SerializableMessage;
 import uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition;
 
@@ -88,6 +89,11 @@ public class SystemVariableBootValues implements SerializableMessage {
 			if (newbytes.length != defbytes.length) {
 				throw new IllegalArgumentException(
 						"byte array length must be " + defbytes.length);
+			}
+			break;
+		case ADDRESS:
+			if (!(value instanceof MemoryLocation)) {
+				throw new IllegalArgumentException("need a memory location");
 			}
 			break;
 		default:

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/ChipInfo.java
@@ -21,6 +21,7 @@ import static java.net.InetAddress.getByAddress;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
+import static uk.ac.manchester.spinnaker.messages.model.DataType.ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE_ARRAY;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.LONG;
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.allocated_tag_table_address;
@@ -112,6 +113,7 @@ import java.util.List;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.MachineDimensions;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * Represents the system variables for a chip, received from the chip SDRAM.
@@ -194,6 +196,7 @@ public class ChipInfo implements HasChipLocation {
 			return systemData.getShort(systemData.position() + var.offset);
 		case BYTE_ARRAY:
 		case LONG:
+		case ADDRESS:
 		default:
 			throw new IllegalArgumentException();
 		}
@@ -215,6 +218,14 @@ public class ChipInfo implements HasChipLocation {
 		byte[] bytes = (byte[]) var.getDefault();
 		b.get(bytes);
 		return bytes;
+	}
+
+	private MemoryLocation readPtr(SystemVariableDefinition var) {
+		if (var.type != ADDRESS) {
+			throw new IllegalArgumentException();
+		}
+		return new MemoryLocation(
+				systemData.getInt(systemData.position() + var.offset));
 	}
 
 	@Override
@@ -382,13 +393,13 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return The base address of the system SDRAM heap. */
-	public int getSystemRAMHeapAddress() {
-		return read(system_ram_heap_address);
+	public MemoryLocation getSystemRAMHeapAddress() {
+		return readPtr(system_ram_heap_address);
 	}
 
 	/** @return The base address of the user SDRAM heap. */
-	public int getSDRAMHeapAddress() {
-		return read(sdram_heap_address);
+	public MemoryLocation getSDRAMHeapAddress() {
+		return readPtr(sdram_heap_address);
 	}
 
 	/** @return The size of the iobuf buffer in bytes. */
@@ -412,8 +423,8 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return The memory pointer for nearest neighbour global operations. */
-	public int getNearestNeighbourMemoryAddress() {
-		return read(nearest_neighbour_memory_pointer);
+	public MemoryLocation getNearestNeighbourMemoryAddress() {
+		return readPtr(nearest_neighbour_memory_pointer);
 	}
 
 	/** @return The lock. (??) */
@@ -437,8 +448,8 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return Pointer to the first free shared message buffer. */
-	public int getSharedMessageFirstFreeAddress() {
-		return read(shared_message_first_free_address);
+	public MemoryLocation getSharedMessageFirstFreeAddress() {
+		return readPtr(shared_message_first_free_address);
 	}
 
 	/** @return The number of shared message buffers in use. */
@@ -508,43 +519,43 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return The base address of SDRAM. */
-	public int getSDRAMBaseAddress() {
-		return read(sdram_base_address);
+	public MemoryLocation getSDRAMBaseAddress() {
+		return readPtr(sdram_base_address);
 	}
 
 	/** @return The base address of System RAM. */
-	public int getSystemRAMBaseAddress() {
-		return read(system_ram_base_address);
+	public MemoryLocation getSystemRAMBaseAddress() {
+		return readPtr(system_ram_base_address);
 	}
 
 	/** @return The base address of System SDRAM. */
-	public int getSystemSDRAMBaseAddress() {
-		return read(system_sdram_base_address);
+	public MemoryLocation getSystemSDRAMBaseAddress() {
+		return readPtr(system_sdram_base_address);
 	}
 
 	/** @return The base address of the CPU information blocks. */
-	public int getCPUInformationBaseAddress() {
-		return read(cpu_information_base_address);
+	public MemoryLocation getCPUInformationBaseAddress() {
+		return readPtr(cpu_information_base_address);
 	}
 
 	/** @return The base address of the system SDRAM heap. */
-	public int getSystemSDRAMHeapAddress() {
-		return read(system_sdram_heap_address);
+	public MemoryLocation getSystemSDRAMHeapAddress() {
+		return readPtr(system_sdram_heap_address);
 	}
 
 	/** @return The address of the copy of the routing tables. */
-	public int getRouterTableCopyAddress() {
-		return read(router_table_copy_address);
+	public MemoryLocation getRouterTableCopyAddress() {
+		return readPtr(router_table_copy_address);
 	}
 
 	/** @return The address of the peer-to-peer hop tables. */
-	public int getP2PHopTableAddress() {
-		return read(peer_to_peer_hop_table_address);
+	public MemoryLocation getP2PHopTableAddress() {
+		return readPtr(peer_to_peer_hop_table_address);
 	}
 
 	/** @return The address of the allocated tag table. */
-	public int getAllocatedTagTableAddress() {
-		return read(allocated_tag_table_address);
+	public MemoryLocation getAllocatedTagTableAddress() {
+		return readPtr(allocated_tag_table_address);
 	}
 
 	/** @return The ID of the first free router entry. */
@@ -558,13 +569,13 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return The address of the application data table. */
-	public int getAppDataTableAddress() {
-		return read(app_data_table_address);
+	public MemoryLocation getAppDataTableAddress() {
+		return readPtr(app_data_table_address);
 	}
 
 	/** @return The address of the shared message buffers. */
-	public int getSharedMessageBufferAddress() {
-		return read(shared_message_buffer_address);
+	public MemoryLocation getSharedMessageBufferAddress() {
+		return readPtr(shared_message_buffer_address);
 	}
 
 	/** @return The monitor incoming mailbox flags. */
@@ -583,7 +594,7 @@ public class ChipInfo implements HasChipLocation {
 	}
 
 	/** @return A pointer to the board information structure. */
-	public int getBoardInfoAddress() {
-		return read(board_info);
+	public MemoryLocation getBoardInfoAddress() {
+		return readPtr(board_info);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
@@ -29,7 +29,9 @@ public enum DataType {
 	/** The value is eight bytes long. */
 	LONG(8),
 	/** The value is an array of bytes. */
-	BYTE_ARRAY(16);
+	BYTE_ARRAY(16),
+	/** The value is four bytes, representing a memory location. */
+	ADDRESS(4);
 
 	/** The SCAMP data type descriptor code. */
 	public final int value;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/DataType.java
@@ -16,21 +16,28 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
-import java.nio.ByteBuffer;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
-/** Enum for data types of system variables. */
+/**
+ * Enum for data types of system variables.
+ *
+ * @see SystemVariableDefinition
+ */
 public enum DataType {
-	/** The value is one byte long. */
+	/** The value is one byte long, a {@code byte}. */
 	BYTE(1),
-	/** The value is two bytes long. */
+	/** The value is two bytes long, a {@code short}. */
 	SHORT(2),
-	/** The value is four bytes long. */
+	/** The value is four bytes long, an {@code int}. */
 	INT(4),
-	/** The value is eight bytes long. */
+	/** The value is eight bytes long, a {@code long}. */
 	LONG(8),
-	/** The value is an array of bytes. */
+	/** The value is an array of bytes, a {@code byte[]}. */
 	BYTE_ARRAY(16),
-	/** The value is four bytes, representing a memory location. */
+	/**
+	 * The value is four bytes, representing a {@linkplain MemoryLocation memory
+	 * location}.
+	 */
 	ADDRESS(4);
 
 	/** The SCAMP data type descriptor code. */
@@ -40,41 +47,7 @@ public enum DataType {
 		this.value = value;
 	}
 
-	/**
-	 * Writes an object described by this data type into the given buffer at the
-	 * <i>position</i> as a contiguous range of bytes. This assumes that the
-	 * buffer has been configured to be
-	 * {@linkplain java.nio.ByteOrder#LITTLE_ENDIAN little-endian} and that its
-	 * <i>position</i> is at the point where this method should begin writing.
-	 * Once it has finished, the <i>position</i> should be immediately after the
-	 * last byte written by this method.
-	 *
-	 * @param value
-	 *            The value to write.
-	 * @param buffer
-	 *            The buffer to write into.
-	 */
-	void addToBuffer(Object value, ByteBuffer buffer) {
-		switch (this) {
-		case BYTE:
-			buffer.put(((Number) value).byteValue());
-			return;
-		case SHORT:
-			buffer.putShort(((Number) value).shortValue());
-			return;
-		case INT:
-			buffer.putInt(((Number) value).intValue());
-			return;
-		case LONG:
-			buffer.putLong(((Number) value).longValue());
-			return;
-		case BYTE_ARRAY:
-			buffer.put((byte[]) value);
-			return;
-		default:
-			// CHECKSTYLE:OFF
-			throw new Error("unreachable?");
-			// CHECKSTYLE:ON
-		}
+	static {
+		MemoryLocation.class.getClass();
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGALinkRegisters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGALinkRegisters.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * FPGA registers within a register bank.
  *
@@ -106,11 +108,12 @@ public enum FPGALinkRegisters {
 	 * @throws IllegalArgumentException
 	 *             If a bad register bank is given.
 	 */
-	public int address(int registerBank) {
+	public MemoryLocation address(int registerBank) {
 		if (registerBank < 0 || registerBank > 2) {
 			throw new IllegalArgumentException(
 					"registerBank must be 0, 1, or 2");
 		}
-		return BANK_OFFSET_MULTIPLIER * registerBank + offset;
+		return new MemoryLocation(
+				BANK_OFFSET_MULTIPLIER * registerBank + offset);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGAMainRegisters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGAMainRegisters.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * Main FPGA registers.
  *
@@ -118,7 +120,8 @@ public enum FPGAMainRegisters {
 	/**
 	 * Base address of the main registers. Fixed.
 	 */
-	public static final int BASE_ADDRESS = 0x00040000;
+	public static final MemoryLocation BASE_ADDRESS =
+			new MemoryLocation(0x00040000);
 
 	/** The offset of the register within the bank of registers. */
 	public final int offset;
@@ -142,7 +145,7 @@ public enum FPGAMainRegisters {
 	/**
 	 * @return The address of the register in the FPGA's address space.
 	 */
-	public int getAddress() {
-		return BASE_ADDRESS + offset;
+	public MemoryLocation getAddress() {
+		return BASE_ADDRESS.add(offset);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGARecevingLinkCounters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGARecevingLinkCounters.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * FPGA link receive counters. Counters are always read-only.
  *
@@ -35,7 +37,8 @@ public enum FPGARecevingLinkCounters {
 	/** Glitches detected on link. */
 	GLTE(48);
 
-	private static final int BASE_ADDRESS = 0x00060000;
+	private static final MemoryLocation BASE_ADDRESS =
+			new MemoryLocation(0x00060000);
 
 	private static final int COUNTER_SIZE = 4;
 
@@ -54,10 +57,10 @@ public enum FPGARecevingLinkCounters {
 	 * @throws IllegalArgumentException
 	 *             if a bad link number is given.
 	 */
-	public int address(int linkNumber) {
+	public MemoryLocation address(int linkNumber) {
 		if (linkNumber < 0 || linkNumber > 2) {
 			throw new IllegalArgumentException("linkNumber must be 0, 1, or 2");
 		}
-		return BASE_ADDRESS + offset + linkNumber * COUNTER_SIZE;
+		return BASE_ADDRESS.add(offset + linkNumber * COUNTER_SIZE);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGASendingLinkCounters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGASendingLinkCounters.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * FPGA link send counters. Counters are always read-only.
  *
@@ -33,7 +35,8 @@ public enum FPGASendingLinkCounters {
 	/** Timeouts on link. */
 	TMOE(32);
 
-	private static final int BASE_ADDRESS = 0x00050000;
+	private static final MemoryLocation BASE_ADDRESS =
+			new MemoryLocation(0x00050000);
 
 	private static final int COUNTER_SIZE = 4;
 
@@ -52,10 +55,10 @@ public enum FPGASendingLinkCounters {
 	 * @throws IllegalArgumentException
 	 *             if a bad link number is given.
 	 */
-	public int address(int linkNumber) {
+	public MemoryLocation address(int linkNumber) {
 		if (linkNumber < 0 || linkNumber > 2) {
 			throw new IllegalArgumentException("linkNumber must be 0, 1, or 2");
 		}
-		return BASE_ADDRESS + offset + linkNumber * COUNTER_SIZE;
+		return BASE_ADDRESS.add(offset + linkNumber * COUNTER_SIZE);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FirmwareDescriptors.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FirmwareDescriptors.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** Basic information about firmware. */
 public enum FirmwareDescriptors {
 	/** The main firmware copy. */
@@ -26,7 +28,7 @@ public enum FirmwareDescriptors {
 	Boot(0, 32, 6, 5);
 
 	/** The location of the firmware descriptor in BMP memory. */
-	public final int address;
+	public final MemoryLocation address;
 
 	/**
 	 * The amount of data to read to understand the firmware. The size of the
@@ -42,7 +44,7 @@ public enum FirmwareDescriptors {
 
 	FirmwareDescriptors(int address, int blockSize, int versionIndex,
 			int timestampIndex) {
-		this.address = address;
+		this.address = new MemoryLocation(address);
 		this.blockSize = blockSize;
 		this.versionIndex = versionIndex;
 		this.timestampIndex = timestampIndex;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/HeapElement.java
@@ -16,15 +16,17 @@
  */
 package uk.ac.manchester.spinnaker.messages.model;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** An element of one of the heaps on SpiNNaker. */
 @SARKStruct("block")
 public class HeapElement {
 	/** The address of the block. */
-	public final int blockAddress;
+	public final MemoryLocation blockAddress;
 
 	/** A pointer to the next block, or 0 if none. */
 	@SARKField("next")
-	public final int nextAddress;
+	public final MemoryLocation nextAddress;
 
 	/** The usable size of this block (not including the header). */
 	public final int size;
@@ -62,7 +64,8 @@ public class HeapElement {
 	 * @param free
 	 *            The "free" element of the block as read from the heap
 	 */
-	public HeapElement(int blockAddress, int nextAddress, int free) {
+	public HeapElement(MemoryLocation blockAddress, MemoryLocation nextAddress,
+			int free) {
 		this.blockAddress = blockAddress;
 		this.nextAddress = nextAddress;
 		this.isFree = (free & FREE_MASK) != FREE_MASK;
@@ -73,29 +76,7 @@ public class HeapElement {
 			tag = free & BYTE_MASK;
 			appID = new AppID((free >>> BYTE1_SHIFT) & BYTE_MASK);
 		}
-		size = nextAddress - blockAddress - BLOCK_HEADER_SIZE;
-	}
-
-	/**
-	 * @param blockAddress
-	 *            The address of this element on the heap
-	 * @param nextAddress
-	 *            The address of the next element on the heap
-	 * @param free
-	 *            The "free" element of the block as read from the heap
-	 */
-	public HeapElement(long blockAddress, int nextAddress, int free) {
-		this.blockAddress = (int) blockAddress;
-		this.nextAddress = nextAddress;
-		this.isFree = (free & FREE_MASK) != FREE_MASK;
-		if (isFree) {
-			tag = null;
-			appID = null;
-		} else {
-			tag = free & BYTE_MASK;
-			appID = new AppID((free >>> BYTE1_SHIFT) & BYTE_MASK);
-		}
-		size = (int) (nextAddress - blockAddress) - BLOCK_HEADER_SIZE;
+		size = nextAddress.diff(blockAddress) - BLOCK_HEADER_SIZE;
 	}
 
 	/**
@@ -104,7 +85,7 @@ public class HeapElement {
 	 * @return The address of the data ({@link #size} bytes long) that
 	 *         immediately follows the heap element header.
 	 */
-	public final int getDataAddress() {
-		return blockAddress + BLOCK_HEADER_SIZE;
+	public final MemoryLocation getDataAddress() {
+		return blockAddress.add(BLOCK_HEADER_SIZE);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
@@ -20,6 +20,7 @@ import static java.lang.Integer.compare;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.sort;
 import static java.util.Collections.unmodifiableList;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE_ARRAY;
@@ -227,30 +228,49 @@ public enum SystemVariableDefinition {
 	 */
 	private final Object def;
 
+	private final boolean hasDefinedDefault;
+
 	SystemVariableDefinition(DataType type, int offset) {
 		this.type = type;
 		this.offset = offset;
-		this.def = 0;
+		hasDefinedDefault = false;
+		if (type == ADDRESS) {
+			this.def = NULL;
+		} else {
+			this.def = 0;
+		}
 	}
 
 	SystemVariableDefinition(DataType type, int offset, Object def) {
 		this.type = type;
 		this.offset = offset;
-		this.def = def;
+		hasDefinedDefault = true;
+		if (type == ADDRESS) {
+			this.def = new MemoryLocation(((Number) def).intValue());
+		} else {
+			this.def = def;
+		}
 	}
 
 	/**
 	 * The default value assigned to the variable if not overridden; this can be
-	 * an integer or a byte array.
+	 * an integer, a byte array or a memory location.
 	 *
 	 * @return The default value, or a copy of it if the type of the value is an
 	 *         array.
 	 */
 	public Object getDefault() {
-		if (type == BYTE_ARRAY) {
+		switch (type) {
+		case BYTE_ARRAY:
 			return ((byte[]) def).clone();
+		default:
+			return def;
 		}
-		return def;
+	}
+
+	/** @return Whether this is a variable with a usefully-defined default. */
+	public boolean isDefaultSpecified() {
+		return hasDefinedDefault;
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
@@ -20,6 +20,7 @@ import static java.lang.Integer.compare;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.sort;
 import static java.util.Collections.unmodifiableList;
+import static uk.ac.manchester.spinnaker.messages.model.DataType.ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.BYTE_ARRAY;
 import static uk.ac.manchester.spinnaker.messages.model.DataType.INT;
@@ -125,9 +126,9 @@ public enum SystemVariableDefinition {
 	@Deprecated
 	padding_2(INT, 0x44),
 	/** The base address of the system SDRAM heap. */
-	system_ram_heap_address(INT, 0x48, 1024),
+	system_ram_heap_address(ADDRESS, 0x48, 1024),
 	/** The base address of the user SDRAM heap. */
-	sdram_heap_address(INT, 0x4c, 0),
+	sdram_heap_address(ADDRESS, 0x4c, 0),
 	/** The size of the iobuf buffer in bytes. */
 	iobuf_size(INT, 0x50, 16384),
 	/** The size of the system SDRAM in bytes. */
@@ -137,7 +138,7 @@ public enum SystemVariableDefinition {
 	/** The boot signature. */
 	boot_signature(INT, 0x5c),
 	/** The memory pointer for nearest neighbour global operations. */
-	nearest_neighbour_memory_pointer(INT, 0x60),
+	nearest_neighbour_memory_pointer(ADDRESS, 0x60),
 	/** The lock. */
 	lock(BYTE, 0x64),
 	/** Bit mask (6 bits) of links enabled. */
@@ -147,7 +148,7 @@ public enum SystemVariableDefinition {
 	/** Board testing flags. */
 	board_test_flags(BYTE, 0x67),
 	/** Pointer to the first free shared message buffer. */
-	shared_message_first_free_address(INT, 0x68),
+	shared_message_first_free_address(ADDRESS, 0x68),
 	/** The number of shared message buffers in use. */
 	shared_message_count_in_use(SHORT, 0x6c),
 	/** The maximum number of shared message buffers used. */
@@ -174,29 +175,29 @@ public enum SystemVariableDefinition {
 	@Deprecated
 	padding_3(SHORT, 0xbe),
 	/** The base address of SDRAM. */
-	sdram_base_address(INT, 0xc0),
+	sdram_base_address(ADDRESS, 0xc0),
 	/** The base address of System RAM. */
-	system_ram_base_address(INT, 0xc4),
+	system_ram_base_address(ADDRESS, 0xc4),
 	/** The base address of System SDRAM. */
-	system_sdram_base_address(INT, 0xc8),
+	system_sdram_base_address(ADDRESS, 0xc8),
 	/** The base address of the CPU information blocks. */
-	cpu_information_base_address(INT, 0xcc),
+	cpu_information_base_address(ADDRESS, 0xcc),
 	/** The base address of the system SDRAM heap. */
-	system_sdram_heap_address(INT, 0xd0),
+	system_sdram_heap_address(ADDRESS, 0xd0),
 	/** The address of the copy of the routing tables. */
-	router_table_copy_address(INT, 0xd4),
+	router_table_copy_address(ADDRESS, 0xd4),
 	/** The address of the peer-to-peer hop tables. */
-	peer_to_peer_hop_table_address(INT, 0xd8),
+	peer_to_peer_hop_table_address(ADDRESS, 0xd8),
 	/** The address of the allocated tag table. */
-	allocated_tag_table_address(INT, 0xdc),
+	allocated_tag_table_address(ADDRESS, 0xdc),
 	/** The ID of the first free router entry. */
 	first_free_router_entry(SHORT, 0xe0),
 	/** The number of active peer-to-peer addresses. */
 	n_active_peer_to_peer_addresses(SHORT, 0xe2),
 	/** The address of the application data table. */
-	app_data_table_address(INT, 0xe4),
+	app_data_table_address(ADDRESS, 0xe4),
 	/** The address of the shared message buffers. */
-	shared_message_buffer_address(INT, 0xe8),
+	shared_message_buffer_address(ADDRESS, 0xe8),
 	/** The monitor incoming mailbox flags. */
 	monitor_mailbox_flags(INT, 0xec),
 	/** The IP address of the chip. */

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/SystemVariableDefinition.java
@@ -32,6 +32,8 @@ import static uk.ac.manchester.spinnaker.messages.model.SVDConstants.PER_CORE_WI
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** Defines the system variables available. */
 public enum SystemVariableDefinition {
 	/** The y-coordinate of the chip. */
@@ -205,7 +207,7 @@ public enum SystemVariableDefinition {
 	/** A (virtual) copy of the router FR register. */
 	fixed_route_copy(INT, 0xf4),
 	/** A pointer to the board information structure. */
-	board_info(INT, 0xf8),
+	board_info(ADDRESS, 0xf8),
 	/** A word of padding. */
 	@Deprecated
 	padding_4(INT, 0xfc);
@@ -266,7 +268,30 @@ public enum SystemVariableDefinition {
 	 *            The buffer to write into.
 	 */
 	public void addToBuffer(Object value, ByteBuffer buffer) {
-		type.addToBuffer(value, buffer);
+		switch (type) {
+		case BYTE:
+			buffer.put(((Number) value).byteValue());
+			return;
+		case SHORT:
+			buffer.putShort(((Number) value).shortValue());
+			return;
+		case INT:
+			buffer.putInt(((Number) value).intValue());
+			return;
+		case LONG:
+			buffer.putLong(((Number) value).longValue());
+			return;
+		case BYTE_ARRAY:
+			buffer.put((byte[]) value);
+			return;
+		case ADDRESS:
+			buffer.putInt(((MemoryLocation) value).address);
+			return;
+		default:
+			// CHECKSTYLE:OFF
+			throw new Error("unreachable?");
+			// CHECKSTYLE:ON
+		}
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
@@ -21,6 +21,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FILL;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /** An SCP request to fill a region of memory on a chip with repeated data. */
 public final class FillRequest extends SCPRequest<CheckOKResponse> {
@@ -34,9 +35,9 @@ public final class FillRequest extends SCPRequest<CheckOKResponse> {
 	 * @param size
 	 *            The number of bytes to fill in
 	 */
-	public FillRequest(HasChipLocation chip, int baseAddress, int data,
-			int size) {
-		super(chip.getScampCore(), CMD_FILL, baseAddress, data, size);
+	public FillRequest(HasChipLocation chip, MemoryLocation baseAddress,
+			int data, int size) {
+		super(chip.getScampCore(), CMD_FILL, baseAddress.address, data, size);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
@@ -26,6 +26,8 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FFD;
 
 import java.nio.ByteBuffer;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** A request to start a flood fill of data. */
 public class FloodFillData extends SCPRequest<CheckOKResponse> {
 	private static final int MAGIC1 = 0x3f;
@@ -47,7 +49,7 @@ public class FloodFillData extends SCPRequest<CheckOKResponse> {
 	 *            divisible by 4.
 	 */
 	public FloodFillData(byte nearestNeighbourID, int blockNumber,
-			int baseAddress, byte[] data) {
+			MemoryLocation baseAddress, byte[] data) {
 		this(nearestNeighbourID, blockNumber, baseAddress, data, 0,
 				data.length);
 	}
@@ -68,9 +70,9 @@ public class FloodFillData extends SCPRequest<CheckOKResponse> {
 	 *            The length of the data; must be divisible by 4.
 	 */
 	public FloodFillData(byte nearestNeighbourID, int blockNumber,
-			int baseAddress, byte[] data, int offset, int length) {
+			MemoryLocation baseAddress, byte[] data, int offset, int length) {
 		super(BOOT_MONITOR_CORE, CMD_FFD, argument1(nearestNeighbourID),
-				argument2(blockNumber, length), baseAddress,
+				argument2(blockNumber, length), baseAddress.address,
 				wrap(data, offset, length));
 	}
 
@@ -87,9 +89,10 @@ public class FloodFillData extends SCPRequest<CheckOKResponse> {
 	 *            must be divisible by 4
 	 */
 	public FloodFillData(byte nearestNeighbourID, int blockNumber,
-			int baseAddress, ByteBuffer data) {
+			MemoryLocation baseAddress, ByteBuffer data) {
 		super(BOOT_MONITOR_CORE, CMD_FFD, argument1(nearestNeighbourID),
-				argument2(blockNumber, data.remaining()), baseAddress, data);
+				argument2(blockNumber, data.remaining()), baseAddress.address,
+				data);
 	}
 
 	private static int argument1(byte nearestNeighbourID) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /** An SCP request to read a region of memory via a link on a chip. */
@@ -47,9 +48,10 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public ReadLink(HasCoreLocation core, Direction link, int baseAddress,
-			int size) {
-		super(core, CMD_LINK_READ, baseAddress, validate(size), link.id);
+	public ReadLink(HasCoreLocation core, Direction link,
+			MemoryLocation baseAddress, int size) {
+		super(core, CMD_LINK_READ, baseAddress.address, validate(size),
+				link.id);
 	}
 
 	/**
@@ -62,10 +64,10 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public ReadLink(HasChipLocation chip, Direction link, int baseAddress,
-			int size) {
-		super(chip.getScampCore(), CMD_LINK_READ, baseAddress, validate(size),
-				link.id);
+	public ReadLink(HasChipLocation chip, Direction link,
+			MemoryLocation baseAddress, int size) {
+		super(chip.getScampCore(), CMD_LINK_READ, baseAddress.address,
+				validate(size), link.id);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /** An SCP request to read a region of memory. */
@@ -45,8 +46,8 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public ReadMemory(HasCoreLocation core, int address, int size) {
-		super(core, CMD_READ, address, validate(size),
+	public ReadMemory(HasCoreLocation core, MemoryLocation address, int size) {
+		super(core, CMD_READ, address.address, validate(size),
 				efficientTransferUnit(address, size).value);
 	}
 
@@ -58,8 +59,8 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	 * @param size
 	 *            The number of bytes to read, between 1 and 256
 	 */
-	public ReadMemory(HasChipLocation chip, int address, int size) {
-		super(chip.getScampCore(), CMD_READ, address, validate(size),
+	public ReadMemory(HasChipLocation chip, MemoryLocation address, int size) {
+		super(chip.getScampCore(), CMD_READ, address.address, validate(size),
 				efficientTransferUnit(address, size).value);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
@@ -57,13 +57,13 @@ public class RouterAlloc extends SCPRequest<RouterAlloc.Response> {
 
 	/** An SCP response to a request to allocate router entries. */
 	public static class Response extends CheckOKResponse {
-		/** The base address allocated, or 0 if none. */
-		public final int baseAddress;
+		/** The base entry index allocated within the router, or 0 if none. */
+		public final int baseIndex;
 
 		Response(int size, ByteBuffer buffer) throws Exception {
 			super("Router Allocation", CMD_ALLOC, buffer);
-			baseAddress = buffer.getInt();
-			if (baseAddress == 0) {
+			baseIndex = buffer.getInt();
+			if (baseIndex == 0) {
 				throw new MemoryAllocationFailedException(
 						format("Could not allocate %d router entries", size));
 			}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
@@ -24,6 +24,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 
 /** A request to initialise the router on a chip. */
@@ -37,23 +38,26 @@ public class RouterInit extends SCPRequest<CheckOKResponse> {
 	 * @param numEntries
 	 *            The number of entries in the table (more than 0)
 	 * @param tableAddress
-	 *            The allocated table address
-	 * @param baseAddress
-	 *            The base address containing the entries
+	 *            The allocated address containing the data to init the router
+	 *            from.
+	 * @param baseIndex
+	 *            The base index in the router table where the entries are to be
+	 *            placed.
 	 * @param appID
 	 *            The ID of the application with which to associate the routes.
 	 * @throws IllegalArgumentException
 	 *             If a bad address or entry count is given
 	 */
-	public RouterInit(HasChipLocation chip, int numEntries, int tableAddress,
-			int baseAddress, AppID appID) {
+	public RouterInit(HasChipLocation chip, int numEntries,
+			MemoryLocation tableAddress, int baseIndex,
+			AppID appID) {
 		super(chip.getScampCore(), CMD_RTR, argument1(numEntries, appID),
-				tableAddress, baseAddress);
-		if (baseAddress < 0) {
+				tableAddress.address, baseIndex);
+		if (baseIndex < 0) {
 			throw new IllegalArgumentException(
 					"baseAddress must not be negative");
 		}
-		if (tableAddress < 0) {
+		if (tableAddress.address < 0) {
 			throw new IllegalArgumentException(
 					"tableAddress must not be negative");
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
@@ -55,11 +55,7 @@ public class RouterInit extends SCPRequest<CheckOKResponse> {
 				tableAddress.address, baseIndex);
 		if (baseIndex < 0) {
 			throw new IllegalArgumentException(
-					"baseAddress must not be negative");
-		}
-		if (tableAddress.address < 0) {
-			throw new IllegalArgumentException(
-					"tableAddress must not be negative");
+					"baseIndex must not be negative");
 		}
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
@@ -26,6 +26,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_ALLOC;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.MemoryAllocationFailedException;
 
@@ -86,12 +87,12 @@ public class SDRAMAlloc extends SCPRequest<SDRAMAlloc.Response> {
 	/** An SCP response to a request to allocate space in SDRAM. */
 	public static class Response extends CheckOKResponse {
 		/** The base address allocated. */
-		public final int baseAddress;
+		public final MemoryLocation baseAddress;
 
 		Response(int size, ByteBuffer buffer) throws Exception {
 			super("SDRAM Allocation", CMD_ALLOC, buffer);
-			baseAddress = buffer.getInt();
-			if (baseAddress == 0) {
+			baseAddress = new MemoryLocation(buffer.getInt());
+			if (baseAddress.isNull()) {
 				throw new MemoryAllocationFailedException(
 						format("Could not allocate %d bytes of SDRAM", size));
 			}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
@@ -25,6 +25,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_ALLOC;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.MemoryAllocationFailedException;
 
@@ -54,9 +55,9 @@ public class SDRAMDeAlloc extends SCPRequest<SDRAMDeAlloc.Response> {
 	 *            The start address in SDRAM to which the block needs to be
 	 *            deallocated
 	 */
-	public SDRAMDeAlloc(HasChipLocation chip, int baseAddress) {
+	public SDRAMDeAlloc(HasChipLocation chip, MemoryLocation baseAddress) {
 		super(chip.getScampCore(), CMD_ALLOC, (int) FREE_SDRAM_BY_POINTER.value,
-				baseAddress);
+				baseAddress.address);
 		readNumFreedBlocks = false;
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
@@ -61,7 +61,7 @@ public enum TransferUnit {
 	 */
 	public static TransferUnit efficientTransferUnit(MemoryLocation address,
 			int size) {
-		if (address.address % WORD_SIZE == 0 && size % WORD_SIZE == 0) {
+		if (address.isAligned() && size % WORD_SIZE == 0) {
 			return WORD;
 		} else if (odd(address.address) || odd(size)) {
 			return BYTE;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TransferUnit.java
@@ -18,6 +18,8 @@ package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /** What to move data in units of. */
 public enum TransferUnit {
 	/** A byte. */
@@ -57,10 +59,11 @@ public enum TransferUnit {
 	 *            The data size.
 	 * @return The preferred transfer unit.
 	 */
-	public static TransferUnit efficientTransferUnit(int address, int size) {
-		if (address % WORD_SIZE == 0 && size % WORD_SIZE == 0) {
+	public static TransferUnit efficientTransferUnit(MemoryLocation address,
+			int size) {
+		if (address.address % WORD_SIZE == 0 && size % WORD_SIZE == 0) {
 			return WORD;
-		} else if (odd(address) || odd(size)) {
+		} else if (odd(address.address) || odd(size)) {
 			return BYTE;
 		} else {
 			return HALF_WORD;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /** A request to write memory on a neighbouring chip. */
 public class WriteLink extends SCPRequest<CheckOKResponse> {
@@ -36,10 +37,10 @@ public class WriteLink extends SCPRequest<CheckOKResponse> {
 	 *            The data to write (up to 256 bytes); the <i>position</i> of
 	 *            the buffer must be the point where the data starts.
 	 */
-	public WriteLink(HasCoreLocation core, Direction link, int baseAddress,
-			ByteBuffer data) {
-		super(core, CMD_LINK_WRITE, baseAddress, data.remaining(), link.id,
-				data);
+	public WriteLink(HasCoreLocation core, Direction link,
+			MemoryLocation baseAddress, ByteBuffer data) {
+		super(core, CMD_LINK_WRITE, baseAddress.address, data.remaining(),
+				link.id, data);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /** A request to write memory on a chip. */
 public class WriteMemory extends SCPRequest<CheckOKResponse> {
@@ -35,8 +36,9 @@ public class WriteMemory extends SCPRequest<CheckOKResponse> {
 	 *            Between 1 and 256 bytes to write; the <i>position</i> of the
 	 *            buffer must be the point where the data starts.
 	 */
-	public WriteMemory(HasCoreLocation core, int baseAddress, ByteBuffer data) {
-		super(core, CMD_WRITE, baseAddress, data.remaining(),
+	public WriteMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			ByteBuffer data) {
+		super(core, CMD_WRITE, baseAddress.address, data.remaining(),
 				efficientTransferUnit(baseAddress, data.remaining()).value,
 				data);
 	}
@@ -50,8 +52,10 @@ public class WriteMemory extends SCPRequest<CheckOKResponse> {
 	 *            Between 1 and 256 bytes to write; the <i>position</i> of the
 	 *            buffer must be the point where the data starts.
 	 */
-	public WriteMemory(HasChipLocation chip, int baseAddress, ByteBuffer data) {
-		super(chip.getScampCore(), CMD_WRITE, baseAddress, data.remaining(),
+	public WriteMemory(HasChipLocation chip, MemoryLocation baseAddress,
+			ByteBuffer data) {
+		super(chip.getScampCore(), CMD_WRITE, baseAddress.address,
+				data.remaining(),
 				efficientTransferUnit(baseAddress, data.remaining()).value,
 				data);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadMemoryProcess.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPReadMemory;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
@@ -66,12 +67,12 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	private <T> T read(BMPBoard board, int address, int size,
+	private <T> T read(BMPBoard board, MemoryLocation address, int size,
 			Accumulator<T> accum) throws ProcessException, IOException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			accum.add(offset, execute(
-					new BMPReadMemory(board, address + offset, chunk)).data);
+					new BMPReadMemory(board, address.add(offset), chunk)).data);
 		}
 		return accum.finish();
 	}
@@ -91,8 +92,8 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, ByteBuffer receivingBuffer)
-			throws IOException, ProcessException {
+	void read(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer receivingBuffer) throws IOException, ProcessException {
 		read(board, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 		// Ignore the result; caller already knows it
@@ -113,7 +114,7 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	ByteBuffer read(BMPBoard board, int baseAddress, int size)
+	ByteBuffer read(BMPBoard board, MemoryLocation baseAddress, int size)
 			throws IOException, ProcessException {
 		return read(board, baseAddress, size, new BufferAccumulator(size));
 	}
@@ -136,7 +137,7 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, int size,
+	void read(BMPBoard board, MemoryLocation baseAddress, int size,
 			RandomAccessFile dataFile) throws IOException, ProcessException {
 		read(board, baseAddress, size, new FileAccumulator(dataFile));
 	}
@@ -158,8 +159,8 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, int size, File dataFile)
-			throws IOException, ProcessException {
+	void read(BMPBoard board, MemoryLocation baseAddress, int size,
+			File dataFile) throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			read(board, baseAddress, size, new FileAccumulator(s));
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadSerialFlashProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadSerialFlashProcess.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPReadSerialFlash;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
@@ -67,12 +68,12 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	private <T> T read(BMPBoard board, int address, int size,
+	private <T> T read(BMPBoard board, MemoryLocation address, int size,
 			Accumulator<T> accum) throws ProcessException, IOException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			accum.add(offset, execute(new BMPReadSerialFlash(board,
-					address + offset, chunk)).data);
+					address.add(offset), chunk)).data);
 		}
 		return accum.finish();
 	}
@@ -92,8 +93,8 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, ByteBuffer receivingBuffer)
-			throws IOException, ProcessException {
+	void read(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer receivingBuffer) throws IOException, ProcessException {
 		read(board, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 		// Ignore the result; caller already knows it
@@ -114,7 +115,7 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	ByteBuffer read(BMPBoard board, int baseAddress, int size)
+	ByteBuffer read(BMPBoard board, MemoryLocation baseAddress, int size)
 			throws IOException, ProcessException {
 		return read(board, baseAddress, size, new BufferAccumulator(size));
 	}
@@ -137,7 +138,7 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, int size,
+	void read(BMPBoard board, MemoryLocation baseAddress, int size,
 			RandomAccessFile dataFile) throws IOException, ProcessException {
 		read(board, baseAddress, size, new FileAccumulator(dataFile));
 	}
@@ -159,8 +160,8 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void read(BMPBoard board, int baseAddress, int size, File dataFile)
-			throws IOException, ProcessException {
+	void read(BMPBoard board, MemoryLocation baseAddress, int size,
+			File dataFile) throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			read(board, baseAddress, size, new FileAccumulator(s));
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPCoords;
 import uk.ac.manchester.spinnaker.messages.bmp.WriteFlashBuffer;
@@ -888,7 +889,7 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default int getSerialFlashBuffer(BMPBoard board)
+	default MemoryLocation getSerialFlashBuffer(BMPBoard board)
 			throws IOException, ProcessException {
 		return getSerialFlashBuffer(getBoundBMP(), board);
 	}
@@ -907,7 +908,7 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	int getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
+	MemoryLocation getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
 			throws IOException, ProcessException;
 
 	/** The type of reset to perform. */
@@ -975,7 +976,7 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default ByteBuffer readBMPMemory(BMPBoard board, int baseAddress,
+	default ByteBuffer readBMPMemory(BMPBoard board, MemoryLocation baseAddress,
 			int length) throws IOException, ProcessException {
 		return readBMPMemory(getBoundBMP(), board, baseAddress, length);
 	}
@@ -1000,8 +1001,9 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int length) throws IOException, ProcessException;
+	ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException;
 
 	/**
 	 * Read BMP memory.
@@ -1018,7 +1020,7 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default int readBMPMemoryWord(BMPBoard board, int address)
+	default int readBMPMemoryWord(BMPBoard board, MemoryLocation address)
 			throws IOException, ProcessException {
 		return readBMPMemoryWord(getBoundBMP(), board, address);
 	}
@@ -1040,8 +1042,8 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default int readBMPMemoryWord(BMPCoords bmp, BMPBoard board, int address)
-			throws IOException, ProcessException {
+	default int readBMPMemoryWord(BMPCoords bmp, BMPBoard board,
+			MemoryLocation address) throws IOException, ProcessException {
 		ByteBuffer b = readBMPMemory(bmp, board, address, WORD_SIZE);
 		return b.getInt(0);
 	}
@@ -1063,7 +1065,7 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeBMPMemory(BMPBoard board, int baseAddress,
+	default void writeBMPMemory(BMPBoard board, MemoryLocation baseAddress,
 			ByteBuffer data) throws IOException, ProcessException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, data);
 	}
@@ -1087,8 +1089,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws IOException, ProcessException;
+	void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws IOException, ProcessException;
 
 	/**
 	 * Write BMP memory.
@@ -1105,8 +1108,8 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeBMPMemory(BMPBoard board, int baseAddress, int dataWord)
-			throws IOException, ProcessException {
+	default void writeBMPMemory(BMPBoard board, MemoryLocation baseAddress,
+			int dataWord) throws IOException, ProcessException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, dataWord);
 	}
 
@@ -1127,8 +1130,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int dataWord) throws IOException, ProcessException {
+	default void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int dataWord)
+			throws IOException, ProcessException {
 		ByteBuffer data = ByteBuffer.allocate(WORD_SIZE);
 		data.order(LITTLE_ENDIAN);
 		data.putInt(dataWord);
@@ -1151,7 +1155,7 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeBMPMemory(BMPBoard board, int baseAddress,
+	default void writeBMPMemory(BMPBoard board, MemoryLocation baseAddress,
 			File file) throws IOException, ProcessException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, file);
 	}
@@ -1173,8 +1177,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws IOException, ProcessException;
+	void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws IOException, ProcessException;
 
 	/**
 	 * Read BMP serial flash memory.
@@ -1194,8 +1199,9 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default ByteBuffer readSerialFlash(BMPBoard board, int baseAddress,
-			int length) throws IOException, ProcessException {
+	default ByteBuffer readSerialFlash(BMPBoard board,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return readSerialFlash(getBoundBMP(), board, baseAddress, length);
 	}
 
@@ -1219,8 +1225,9 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	ByteBuffer readSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int length) throws IOException, ProcessException;
+	ByteBuffer readSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException;
 
 	/**
 	 * Read the CRC32 checksum of BMP serial flash memory.
@@ -1239,7 +1246,7 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default int readSerialFlashCRC(BMPBoard board, int baseAddress,
+	default int readSerialFlashCRC(BMPBoard board, MemoryLocation baseAddress,
 			int length) throws IOException, ProcessException {
 		return readSerialFlashCRC(getBoundBMP(), board, baseAddress, length);
 	}
@@ -1263,8 +1270,9 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	int readSerialFlashCRC(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int length) throws IOException, ProcessException;
+	int readSerialFlashCRC(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException;
 
 	/**
 	 * Write BMP serial flash memory from a file.
@@ -1281,7 +1289,7 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeSerialFlash(BMPBoard board, int baseAddress,
+	default void writeSerialFlash(BMPBoard board, MemoryLocation baseAddress,
 			File file) throws ProcessException, IOException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, file);
 	}
@@ -1303,8 +1311,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws ProcessException, IOException;
+	void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws ProcessException, IOException;
 
 	/**
 	 * Write BMP serial flash memory from a stream.
@@ -1323,8 +1332,8 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeSerialFlash(BMPBoard board, int baseAddress, int size,
-			InputStream stream) throws ProcessException, IOException {
+	default void writeSerialFlash(BMPBoard board, MemoryLocation baseAddress,
+			int size, InputStream stream) throws ProcessException, IOException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, size, stream);
 	}
 
@@ -1347,8 +1356,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size, InputStream stream) throws ProcessException, IOException;
+	void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size, InputStream stream)
+			throws ProcessException, IOException;
 
 	/**
 	 * Write BMP serial flash memory.
@@ -1365,7 +1375,7 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeSerialFlash(BMPBoard board, int baseAddress,
+	default void writeSerialFlash(BMPBoard board, MemoryLocation baseAddress,
 			ByteBuffer data) throws ProcessException, IOException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, data);
 	}
@@ -1387,8 +1397,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws ProcessException, IOException;
+	void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws ProcessException, IOException;
 
 	/**
 	 * Prepare a transfer area for writing to the flash memory of a BMP.
@@ -1403,14 +1414,15 @@ public interface BMPTransceiverInterface {
 	 *            How much data will we write.
 	 * @return The location of the working buffer on the BMP
 	 * @deprecated This operation should not be used directly.
-	 * @see #writeFlash(BMPCoords,BMPBoard,int,ByteBuffer,boolean)
+	 * @see #writeFlash(BMPCoords,BMPBoard,MemoryLocation,ByteBuffer,boolean)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	@Deprecated
-	int eraseBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress, int size)
+	MemoryLocation eraseBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size)
 			throws IOException, ProcessException;
 
 	/**
@@ -1424,15 +1436,15 @@ public interface BMPTransceiverInterface {
 	 * @param address
 	 *            Where in the working buffer will we copy to?
 	 * @deprecated This operation should not be used directly.
-	 * @see #writeFlash(BMPCoords,BMPBoard,int,ByteBuffer,boolean)
-	 * @see #eraseBMPFlash(BMPCoords,BMPBoard,int,int)
+	 * @see #writeFlash(BMPCoords,BMPBoard,MemoryLocation,ByteBuffer,boolean)
+	 * @see #eraseBMPFlash(BMPCoords,BMPBoard,MemoryLocation,int)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	@Deprecated
-	void chunkBMPFlash(BMPCoords bmp, BMPBoard board, int address)
+	void chunkBMPFlash(BMPCoords bmp, BMPBoard board, MemoryLocation address)
 			throws IOException, ProcessException;
 
 	/**
@@ -1447,15 +1459,15 @@ public interface BMPTransceiverInterface {
 	 * @param size
 	 *            How much data will we write.
 	 * @deprecated This operation should not be used directly.
-	 * @see #writeFlash(BMPCoords,BMPBoard,int,ByteBuffer,boolean)
+	 * @see #writeFlash(BMPCoords,BMPBoard,MemoryLocation,ByteBuffer,boolean)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
 	@Deprecated
-	void copyBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress, int size)
-			throws IOException, ProcessException;
+	void copyBMPFlash(BMPCoords bmp, BMPBoard board, MemoryLocation baseAddress,
+			int size) throws IOException, ProcessException;
 
 	/**
 	 * Write a {@linkplain WriteFlashBuffer#FLASH_CHUNK_SIZE fixed size} chunk
@@ -1466,13 +1478,13 @@ public interface BMPTransceiverInterface {
 	 *            Which board's BMP are we writing to?
 	 * @param baseAddress
 	 *            Where in flash will we write?
-	 * @see #writeFlash(BMPCoords,BMPBoard,int,ByteBuffer,boolean)
+	 * @see #writeFlash(BMPCoords,BMPBoard,MemoryLocation,ByteBuffer,boolean)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeBMPFlash(BMPBoard board, int baseAddress)
+	default void writeBMPFlash(BMPBoard board, MemoryLocation baseAddress)
 			throws IOException, ProcessException {
 		writeBMPFlash(getBoundBMP(), board, baseAddress);
 	}
@@ -1488,14 +1500,14 @@ public interface BMPTransceiverInterface {
 	 *            Which board's BMP are we writing to?
 	 * @param baseAddress
 	 *            Where in flash will we write?
-	 * @see #writeFlash(BMPCoords,BMPBoard,int,ByteBuffer,boolean)
+	 * @see #writeFlash(BMPCoords,BMPBoard,MemoryLocation,ByteBuffer,boolean)
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress)
-			throws IOException, ProcessException;
+	void writeBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress) throws IOException, ProcessException;
 
 	/**
 	 * Write a buffer to flash memory on the BMP. This is a composite operation.
@@ -1513,8 +1525,9 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeFlash(BMPBoard board, int baseAddress, ByteBuffer data,
-			boolean update) throws ProcessException, IOException {
+	default void writeFlash(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer data, boolean update)
+			throws ProcessException, IOException {
 		writeFlash(getBoundBMP(), board, baseAddress, data, update);
 	}
 
@@ -1536,11 +1549,12 @@ public interface BMPTransceiverInterface {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	default void writeFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data, boolean update)
+	default void writeFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data, boolean update)
 			throws ProcessException, IOException {
 		int size = data.remaining();
-		int bufferBase = eraseBMPFlash(bmp, board, baseAddress, size);
+		MemoryLocation bufferBase =
+				eraseBMPFlash(bmp, board, baseAddress, size);
 		int offset = 0;
 
 		while (true) {
@@ -1557,10 +1571,11 @@ public interface BMPTransceiverInterface {
 			if (length < FLASH_CHUNK_SIZE) {
 				break;
 			}
-			baseAddress += FLASH_CHUNK_SIZE;
+			baseAddress = baseAddress.add(FLASH_CHUNK_SIZE);
 			offset += FLASH_CHUNK_SIZE;
 		}
 		if (update) {
+			// FIXME should this be the original address?
 			copyBMPFlash(bmp, board, baseAddress, size);
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
@@ -512,8 +512,8 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default int readFPGARegister(FPGA fpga, int register, BMPBoard board)
-			throws IOException, ProcessException {
+	default int readFPGARegister(FPGA fpga, MemoryLocation register,
+			BMPBoard board) throws IOException, ProcessException {
 		return readFPGARegister(fpga, register, getBoundBMP(), board);
 	}
 
@@ -537,8 +537,8 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	int readFPGARegister(FPGA fpga, int register, BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException;
+	int readFPGARegister(FPGA fpga, MemoryLocation register, BMPCoords bmp,
+			BMPBoard board) throws IOException, ProcessException;
 
 	/**
 	 * Write a register on a FPGA of a board, assuming the standard FPGA
@@ -664,8 +664,8 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeFPGARegister(FPGA fpga, int register, int value,
-			BMPBoard board) throws IOException, ProcessException {
+	default void writeFPGARegister(FPGA fpga, MemoryLocation register,
+			int value, BMPBoard board) throws IOException, ProcessException {
 		writeFPGARegister(fpga, register, value, getBoundBMP(), board);
 	}
 
@@ -690,8 +690,8 @@ public interface BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	void writeFPGARegister(FPGA fpga, int register, int value, BMPCoords bmp,
-			BMPBoard board) throws IOException, ProcessException;
+	void writeFPGARegister(FPGA fpga, MemoryLocation register, int value,
+			BMPCoords bmp, BMPBoard board) throws IOException, ProcessException;
 
 	/**
 	 * Read the ADC data.

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteMemoryProcess.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.Constants;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
@@ -69,8 +70,8 @@ class BMPWriteMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(BMPBoard board, int baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+	void writeMemory(BMPBoard board, MemoryLocation baseAddress,
+			ByteBuffer data) throws IOException, ProcessException {
 		execute(new BMPWriteIterator(board, baseAddress, data.remaining()) {
 			private int offset = data.position();
 
@@ -101,8 +102,9 @@ class BMPWriteMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(BMPBoard board, int baseAddress, InputStream data,
-			int bytesToWrite) throws IOException, ProcessException {
+	void writeMemory(BMPBoard board, MemoryLocation baseAddress,
+			InputStream data, int bytesToWrite)
+			throws IOException, ProcessException {
 		ValueHolder<IOException> exn = new ValueHolder<IOException>();
 		execute(new BMPWriteIterator(board, baseAddress, bytesToWrite) {
 			private ByteBuffer workingBuffer =
@@ -147,7 +149,7 @@ abstract class BMPWriteIterator
 
 	private int sizeRemaining;
 
-	private int address;
+	private MemoryLocation address;
 
 	private ByteBuffer sendBuffer;
 
@@ -159,7 +161,7 @@ abstract class BMPWriteIterator
 	 * @param size
 	 *            What size of memory will be written.
 	 */
-	BMPWriteIterator(BMPBoard board, int address, int size) {
+	BMPWriteIterator(BMPBoard board, MemoryLocation address, int size) {
 		this.board = board;
 		this.address = address;
 		this.sizeRemaining = size;
@@ -193,7 +195,7 @@ abstract class BMPWriteIterator
 		try {
 			return new BMPWriteMemory(board, address, sendBuffer);
 		} finally {
-			address += chunkSize;
+			address = address.add(chunkSize);
 			sizeRemaining -= chunkSize;
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteSerialFlashProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteSerialFlashProcess.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import uk.ac.manchester.spinnaker.connections.BMPConnection;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.Constants;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.bmp.BMPRequest.BMPResponse;
@@ -70,7 +71,7 @@ class BMPWriteSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void write(BMPBoard board, int baseAddress, ByteBuffer data)
+	void write(BMPBoard board, MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException {
 		execute(new BMPWriteSFIterator(board, baseAddress, data.remaining()) {
 			private int offset = data.position();
@@ -102,7 +103,7 @@ class BMPWriteSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void write(BMPBoard board, int baseAddress, InputStream data,
+	void write(BMPBoard board, MemoryLocation baseAddress, InputStream data,
 			int bytesToWrite) throws IOException, ProcessException {
 		ValueHolder<IOException> exn = new ValueHolder<IOException>();
 		execute(new BMPWriteSFIterator(board, baseAddress, bytesToWrite) {
@@ -148,7 +149,7 @@ abstract class BMPWriteSFIterator
 
 	private int sizeRemaining;
 
-	private int address;
+	private MemoryLocation address;
 
 	private ByteBuffer sendBuffer;
 
@@ -160,7 +161,7 @@ abstract class BMPWriteSFIterator
 	 * @param size
 	 *            What size of memory will be written.
 	 */
-	BMPWriteSFIterator(BMPBoard board, int address, int size) {
+	BMPWriteSFIterator(BMPBoard board, MemoryLocation address, int size) {
 		this.board = board;
 		this.address = address;
 		this.sizeRemaining = size;
@@ -194,7 +195,7 @@ abstract class BMPWriteSFIterator
 		try {
 			return new WriteSerialFlash(board, address, sendBuffer);
 		} finally {
-			address += chunkSize;
+			address = address.add(chunkSize);
 			sizeRemaining -= chunkSize;
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/CommonMemoryLocations.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/CommonMemoryLocations.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.transceiver;
+
+import static uk.ac.manchester.spinnaker.messages.Constants.CPU_INFO_OFFSET;
+import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_REGISTER_P2P_ADDRESS;
+import static uk.ac.manchester.spinnaker.messages.Constants.SYSTEM_VARIABLE_BASE_ADDRESS;
+
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
+/**
+ * Common memory locations. Note that many locations really come in both
+ * buffered and unbuffered varieties, but this class doesn't hold all standard
+ * locations and versions:
+ * <p>
+ * <blockquote> Buffered SDRAM means that writes go through a write buffer.
+ * Unbuffered means that they go directly to SDRAM. Reads are unaffected in
+ * general. If you are writing lots of data, it is unlikely to matter much since
+ * the write buffer is limited in size. Here you probably want to use Unbuffered
+ * anyway, as it will then block until the write is definitely done. Using
+ * Buffered writing means that the write may or may not have happened at the
+ * time of the response. </blockquote>
+ *
+ * @author Donal Fellows
+ */
+public abstract class CommonMemoryLocations {
+	private CommonMemoryLocations() {
+	}
+
+	/**
+	 * Start of unbuffered access to SDRAM. Writes will block until they have
+	 * completed.
+	 */
+	public static final MemoryLocation UNBUFFERED_SDRAM_START =
+			new MemoryLocation(0x60000000);
+
+	/** Location of routing table data in transit. Reserved by SCAMP. */
+	public static final MemoryLocation ROUTING_TABLE_DATA =
+			new MemoryLocation(0x67800000);
+
+	/**
+	 * Where executables are written to prior to launching them. Reserved by
+	 * SCAMP.
+	 */
+	public static final MemoryLocation EXECUTABLE_ADDRESS =
+			new MemoryLocation(0x67800000);
+
+	/**
+	 * Start of buffered access to SDRAM. Writes will finish rapidly, but data
+	 * may take some cycles to appear in memory.
+	 * <p>
+	 * It doesn't matter too much when working from host; the time to do the
+	 * network communications is rather longer than the normal buffering time
+	 * for SDRAM.
+	 */
+	public static final MemoryLocation BUFFERED_SDRAM_START =
+			new MemoryLocation(0x70000000);
+
+	/** Location of the bank of memory-mapped router registers. Buffered. */
+	public static final MemoryLocation ROUTER_BASE =
+			new MemoryLocation(0xe1000000);
+
+	/** Location of the memory-mapped router control register (r0). */
+	public static final MemoryLocation ROUTER_CONTROL =
+			new MemoryLocation(0xe1000000);
+
+	/** Location of the memory-mapped router error register (r5). */
+	public static final MemoryLocation ROUTER_ERROR =
+			new MemoryLocation(0xe1000014);
+
+	/**
+	 * Where to write router diagnostic counters control data to (r11).
+	 * Unbuffered.
+	 */
+	public static final MemoryLocation ROUTER_DIAGNOSTIC_COUNTER =
+			new MemoryLocation(0xf100002c);
+
+	/** Location of the memory-mapped router filtering registers (rFN). */
+	public static final MemoryLocation ROUTER_FILTERS =
+			new MemoryLocation(0xe1000200);
+
+	/** Location of the memory-mapped router diagnostics registers (rCN). */
+	public static final MemoryLocation ROUTER_DIAGNOSTICS =
+			new MemoryLocation(0xe1000300);
+
+	/** The base address of a router's P2P routing table, 3 bits per route. */
+	public static final MemoryLocation ROUTER_P2P =
+			new MemoryLocation(ROUTER_REGISTER_P2P_ADDRESS);
+
+	/** Where the CPU information structure is located. Buffered system RAM. */
+	public static final MemoryLocation CPU_INFO =
+			new MemoryLocation(CPU_INFO_OFFSET);
+
+	/** Where the system variables are located. Unbuffered system RAM. */
+	public static final MemoryLocation SYS_VARS =
+			new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS);
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.FillRequest;
 import uk.ac.manchester.spinnaker.messages.scp.WriteMemory;
 
@@ -76,8 +77,9 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws IllegalArgumentException
 	 *             If the size doesn't match the alignment of the data type.
 	 */
-	void fillMemory(HasChipLocation chip, int baseAddress, int data, int size,
-			FillDataType dataType) throws ProcessException, IOException {
+	void fillMemory(HasChipLocation chip, MemoryLocation baseAddress, int data,
+			int size, FillDataType dataType)
+			throws ProcessException, IOException {
 		// Don't do anything if there is nothing to do!
 		if (size == 0) {
 			return;
@@ -90,7 +92,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 							+ "size of the data of %d bytes",
 					size, dataType.size));
 		}
-		if (baseAddress % ALIGNMENT != 0) {
+		if (baseAddress.address % ALIGNMENT != 0) {
 			log.warn("Unaligned fill starting at {}; please use aligned fills",
 					baseAddress);
 		}
@@ -112,15 +114,16 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 		checkForError();
 	}
 
-	private void generateWriteMessages(HasChipLocation chip, int base, int size,
-			ByteBuffer buffer) throws IOException {
+	private void generateWriteMessages(HasChipLocation chip,
+			MemoryLocation base, int size, ByteBuffer buffer)
+			throws IOException {
 		int toWrite = size;
-		int address = base;
+		MemoryLocation address = base;
 
 		/*
 		 * Send the pre-data to make the memory aligned, up to the first word.
 		 */
-		int extraBytes = (ALIGNMENT - base % ALIGNMENT) % ALIGNMENT;
+		int extraBytes = (ALIGNMENT - base.address % ALIGNMENT) % ALIGNMENT;
 		if (extraBytes != 0) {
 			ByteBuffer preBytes = buffer.duplicate();
 			preBytes.limit(extraBytes);
@@ -129,7 +132,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 				sendRequest(new WriteMemory(chip, base, preBytes));
 			}
 			toWrite -= extraBytes;
-			address += extraBytes;
+			address = address.add(extraBytes);
 		}
 
 		// Fill as much as possible using the bulk operation, FillRequest
@@ -138,7 +141,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 			sendRequest(new FillRequest(chip, address,
 					buffer.getInt(extraBytes), bulkBytes));
 			toWrite -= bulkBytes;
-			address += bulkBytes;
+			address.add(bulkBytes);
 		}
 
 		/*
@@ -146,7 +149,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 		 * aligned word; send them if required. This uses a WriteMemory
 		 */
 		if (toWrite != 0) {
-			buffer.position(buffer.limit() - base % ALIGNMENT);
+			buffer.position(buffer.limit() - base.address % ALIGNMENT);
 			buffer.limit(buffer.position() + toWrite);
 			if (buffer.hasRemaining()) {
 				sendRequest(new WriteMemory(chip, address, buffer));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
@@ -92,7 +92,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 							+ "size of the data of %d bytes",
 					size, dataType.size));
 		}
-		if (baseAddress.address % ALIGNMENT != 0) {
+		if (!baseAddress.isAligned()) {
 			log.warn("Unaligned fill starting at {}; please use aligned fills",
 					baseAddress);
 		}
@@ -120,10 +120,8 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 		int toWrite = size;
 		MemoryLocation address = base;
 
-		/*
-		 * Send the pre-data to make the memory aligned, up to the first word.
-		 */
-		int extraBytes = (ALIGNMENT - base.address % ALIGNMENT) % ALIGNMENT;
+		// Send the pre-data to make the memory aligned, up to the first word.
+		int extraBytes = (ALIGNMENT - base.subWordAlignment()) % ALIGNMENT;
 		if (extraBytes != 0) {
 			ByteBuffer preBytes = buffer.duplicate();
 			preBytes.limit(extraBytes);
@@ -149,7 +147,7 @@ class FillProcess extends MultiConnectionProcess<SCPConnection> {
 		 * aligned word; send them if required. This uses a WriteMemory
 		 */
 		if (toWrite != 0) {
-			buffer.position(buffer.limit() - base.address % ALIGNMENT);
+			buffer.position(buffer.limit() - base.subWordAlignment());
 			buffer.limit(buffer.position() + toWrite);
 			if (buffer.hasRemaining()) {
 				sendRequest(new WriteMemory(chip, address, buffer));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
@@ -17,7 +17,7 @@
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.util.Collections.unmodifiableList;
-import static uk.ac.manchester.spinnaker.messages.Constants.SYSTEM_VARIABLE_BASE_ADDRESS;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.SYS_VARS;
 
 import java.io.IOException;
 import java.nio.IntBuffer;
@@ -145,11 +145,9 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 			SystemVariableDefinition heap)
 			throws IOException, ProcessException {
 		MemoryLocation heapBase = new MemoryLocation(readFromAddress(chip,
-				new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS + heap.offset),
-				heap.type.value).get());
-		HeapHeader header = new HeapHeader(
+				SYS_VARS.add(heap.offset), heap.type.value).get());
+		return new HeapHeader(
 				readFromAddress(chip, heapBase, HEAP_HEADER_SIZE));
-		return header;
 	}
 
 	private BlockHeader getBlockHeader(HasChipLocation chip,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
@@ -16,7 +16,6 @@
  */
 package uk.ac.manchester.spinnaker.transceiver;
 
-import static java.lang.Integer.toUnsignedLong;
 import static java.util.Collections.unmodifiableList;
 import static uk.ac.manchester.spinnaker.messages.Constants.SYSTEM_VARIABLE_BASE_ADDRESS;
 
@@ -28,6 +27,7 @@ import java.util.List;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.HeapElement;
 import uk.ac.manchester.spinnaker.messages.model.SARKField;
 import uk.ac.manchester.spinnaker.messages.model.SARKStruct;
@@ -72,16 +72,17 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 			SystemVariableDefinition heap)
 			throws IOException, ProcessException {
 		HeapHeader header = getHeapHeader(chip, heap);
-		long nextBlock = header.first;
+		MemoryLocation nextBlock = header.first;
 
 		List<HeapElement> blocks = new ArrayList<>();
 
-		while (nextBlock != 0) {
+		while (!nextBlock.isNull()) {
 			BlockHeader block = getBlockHeader(chip, nextBlock);
-			if (block.next != 0) {
-				blocks.add(new HeapElement(nextBlock, block.next, block.free));
+			if (!block.next.isNull()) {
+				blocks.add(new HeapElement(nextBlock, block.next,
+						block.free.address));
 			}
-			nextBlock = toUnsignedLong(block.next);
+			nextBlock = block.next;
 		}
 
 		return unmodifiableList(blocks);
@@ -90,7 +91,7 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 	/**
 	 * Get the free heap block descriptors.
 	 * <p>
-	 * <em>WARNING: This is untested code!</em>
+	 * <em><strong>WARNING:</strong> This is untested code!</em>
 	 *
 	 * @param chip
 	 *            The chip to ask.
@@ -106,16 +107,17 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 			SystemVariableDefinition heap)
 			throws IOException, ProcessException {
 		HeapHeader header = getHeapHeader(chip, heap);
-		long nextBlock = header.free;
+		MemoryLocation nextBlock = header.free;
 
 		List<HeapElement> blocks = new ArrayList<>();
 
-		while (nextBlock != 0 && nextBlock != header.last) {
+		while (!nextBlock.isNull() && !nextBlock.equals(header.last)) {
 			BlockHeader block = getBlockHeader(chip, nextBlock);
-			if (block.next != 0) {
-				blocks.add(new HeapElement(nextBlock, block.next, block.free));
+			if (!block.next.isNull()) {
+				blocks.add(new HeapElement(nextBlock, block.next,
+						block.free.address));
 			}
-			nextBlock = toUnsignedLong(block.free);
+			nextBlock = block.free;
 		}
 
 		return unmodifiableList(blocks);
@@ -142,46 +144,47 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 	private HeapHeader getHeapHeader(HasChipLocation chip,
 			SystemVariableDefinition heap)
 			throws IOException, ProcessException {
-		int heapBase = readFromAddress(chip,
-				SYSTEM_VARIABLE_BASE_ADDRESS + heap.offset, heap.type.value)
-						.get();
+		MemoryLocation heapBase = new MemoryLocation(readFromAddress(chip,
+				new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS + heap.offset),
+				heap.type.value).get());
 		HeapHeader header = new HeapHeader(
 				readFromAddress(chip, heapBase, HEAP_HEADER_SIZE));
 		return header;
 	}
 
-	private BlockHeader getBlockHeader(HasChipLocation chip, long address)
-			throws IOException, ProcessException {
+	private BlockHeader getBlockHeader(HasChipLocation chip,
+			MemoryLocation address) throws IOException, ProcessException {
 		return new BlockHeader(
 				readFromAddress(chip, address, HEAP_BLOCK_HEADER_SIZE));
 	}
 
 	// NB: assumes that size is small
-	private IntBuffer readFromAddress(HasChipLocation chip, long address,
-			long size) throws IOException, ProcessException {
+	private IntBuffer readFromAddress(HasChipLocation chip,
+			MemoryLocation address, long size)
+			throws IOException, ProcessException {
 		return synchronousCall(
-				new ReadMemory(chip, (int) address, (int) size)).data
+				new ReadMemory(chip, address, (int) size)).data
 						.asIntBuffer();
 	}
 
 	@SARKStruct("heap_t")
 	private static class HeapHeader {
 		@SARKField("free")
-		final long free;
+		final MemoryLocation free;
 
 		@SARKField("first")
-		final long first;
+		final MemoryLocation first;
 
 		@SARKField("last")
-		final long last;
+		final MemoryLocation last;
 
 		@SARKField("free_bytes")
 		final int freeBytes;
 
 		HeapHeader(IntBuffer data) {
-			free = toUnsignedLong(data.get());
-			first = toUnsignedLong(data.get());
-			last = toUnsignedLong(data.get());
+			free = new MemoryLocation(data.get());
+			first = new MemoryLocation(data.get());
+			last = new MemoryLocation(data.get());
 			freeBytes = data.get();
 			// Note that we don't read or look at the 'buffer' field
 		}
@@ -190,14 +193,14 @@ class GetHeapProcess extends MultiConnectionProcess<SCPConnection> {
 	@SARKStruct("block_t")
 	private static class BlockHeader {
 		@SARKField("next")
-		final int next;
+		final MemoryLocation next;
 
 		@SARKField("free")
-		final int free;
+		final MemoryLocation free;
 
 		BlockHeader(IntBuffer data) {
-			next = data.get();
-			free = data.get();
+			next = new MemoryLocation(data.get());
+			free = new MemoryLocation(data.get());
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetMachineProcess.java
@@ -23,10 +23,10 @@ import static java.util.Collections.unmodifiableMap;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_RETRIES;
 import static uk.ac.manchester.spinnaker.connections.SCPRequestPipeline.SCP_TIMEOUT;
-import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_REGISTER_P2P_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.CPUState.IDLE;
 import static uk.ac.manchester.spinnaker.messages.model.P2PTable.getColumnOffset;
 import static uk.ac.manchester.spinnaker.messages.model.P2PTable.getNumColumnBytes;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_P2P;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -47,7 +47,6 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.Link;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.MachineDimensions;
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.Processor;
 import uk.ac.manchester.spinnaker.machine.Router;
 import uk.ac.manchester.spinnaker.messages.model.ChipSummaryInfo;
@@ -119,9 +118,6 @@ class GetMachineProcess extends MultiConnectionProcess<SCPConnection> {
 		this.maxSDRAMSize = maxSDRAMSize;
 		this.chipInfo = new HashMap<>();
 	}
-
-	private static final MemoryLocation ROUTER_P2P =
-			new MemoryLocation(ROUTER_REGISTER_P2P_ADDRESS);
 
 	/**
 	 * Get a full, booted machine, populated with information directly from the

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
@@ -22,6 +22,7 @@ import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.machine.MachineDefaults.ROUTER_AVAILABLE_ENTRIES;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTING_TABLE_DATA;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -66,10 +67,6 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 * for SpiNNaker 1 chips.
 	 */
 	private static final int MAX_ROUTER_ENTRIES = 1023;
-
-	/** Location of routing table data. Reserved by SCAMP. */
-	private static final MemoryLocation ROUTING_TABLE_DATA =
-			new MemoryLocation(0x67800000);
 
 	/**
 	 * @param connectionSelector

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.MulticastRoutingEntry;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
@@ -66,7 +67,9 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 */
 	private static final int MAX_ROUTER_ENTRIES = 1023;
 
-	private static final int ROUTING_TABLE_ADDRESS = 0x67800000;
+	/** Location of routing table data. Reserved by SCAMP. */
+	private static final MemoryLocation ROUTING_TABLE_DATA =
+			new MemoryLocation(0x67800000);
 
 	/**
 	 * @param connectionSelector
@@ -154,19 +157,15 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 		ByteBuffer routingData = serializeRoutingData(routes);
 
 		// Upload the data
-		writeMemory(chip.getScampCore(), ROUTING_TABLE_ADDRESS, routingData);
+		writeMemory(chip.getScampCore(), ROUTING_TABLE_DATA, routingData);
 
 		// Allocate space in the router table
-		int baseAddress = synchronousCall(
-				new RouterAlloc(chip, appID, routes.size())).baseAddress;
-		if (baseAddress == 0) {
-			throw new RuntimeException("Not enough space to allocate "
-					+ routes.size() + " entries");
-		}
+		int baseIndex = synchronousCall(
+				new RouterAlloc(chip, appID, routes.size())).baseIndex;
 
 		// Load the entries
 		synchronousCall(new RouterInit(chip, routes.size(),
-				ROUTING_TABLE_ADDRESS, baseAddress, appID));
+				ROUTING_TABLE_DATA, baseIndex, appID));
 	}
 
 	/**
@@ -185,13 +184,15 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	List<MulticastRoutingEntry> getRoutes(HasChipLocation chip, int baseAddress,
-			AppID appID) throws IOException, ProcessException {
+	List<MulticastRoutingEntry> getRoutes(HasChipLocation chip,
+			MemoryLocation baseAddress, AppID appID)
+			throws IOException, ProcessException {
 		Map<Integer, MulticastRoutingEntry> routes = new TreeMap<>();
 		for (int i = 0; i < NUM_READS; i++) {
 			int offset = i * ENTRIES_PER_READ;
 			sendRequest(
-					new ReadMemory(chip, baseAddress + offset * BYTES_PER_ENTRY,
+					new ReadMemory(chip,
+							baseAddress.add(offset * BYTES_PER_ENTRY),
 							UDP_MESSAGE_MAX_SIZE),
 					response -> addRoutes(response.data, offset, routes,
 							appID));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.ReadLink;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
@@ -69,12 +70,12 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	private <T> T readMemory(HasChipLocation chip, int baseAddress, int size,
-			Accumulator<T> a) throws IOException, ProcessException {
+	private <T> T readMemory(HasChipLocation chip, MemoryLocation baseAddress,
+			int size, Accumulator<T> a) throws IOException, ProcessException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			final int thisOffset = offset;
-			sendRequest(new ReadMemory(chip, baseAddress + offset, chunk),
+			sendRequest(new ReadMemory(chip, baseAddress.add(offset), chunk),
 					response -> a.add(thisOffset, response.data));
 		}
 		finish();
@@ -104,13 +105,13 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	private <T> T readLink(HasChipLocation chip, Direction linkDirection,
-			int baseAddress, int size, Accumulator<T> a)
+			MemoryLocation baseAddress, int size, Accumulator<T> a)
 			throws IOException, ProcessException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			int thisOffset = offset;
 			sendRequest(
-					new ReadLink(chip, linkDirection, baseAddress + offset,
+					new ReadLink(chip, linkDirection, baseAddress.add(offset),
 							chunk),
 					response -> a.add(thisOffset, response.data));
 		}
@@ -137,7 +138,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
-			int baseAddress, ByteBuffer receivingBuffer)
+			MemoryLocation baseAddress, ByteBuffer receivingBuffer)
 			throws IOException, ProcessException {
 		readLink(chip, linkDirection, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
@@ -158,7 +159,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void readMemory(HasChipLocation chip, int baseAddress,
+	void readMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			ByteBuffer receivingBuffer) throws IOException, ProcessException {
 		readMemory(chip, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
@@ -182,7 +183,8 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	ByteBuffer readLink(HasChipLocation chip, Direction linkDirection,
-			int baseAddress, int size) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int size)
+			throws IOException, ProcessException {
 		return readLink(chip, linkDirection, baseAddress, size,
 				new BufferAccumulator(size));
 	}
@@ -202,8 +204,8 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	ByteBuffer readMemory(HasChipLocation chip, int baseAddress, int size)
-			throws IOException, ProcessException {
+	ByteBuffer readMemory(HasChipLocation chip, MemoryLocation baseAddress,
+			int size) throws IOException, ProcessException {
 		return readMemory(chip, baseAddress, size, new BufferAccumulator(size));
 	}
 
@@ -228,7 +230,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
-			int baseAddress, int size, RandomAccessFile dataFile)
+			MemoryLocation baseAddress, int size, RandomAccessFile dataFile)
 			throws IOException, ProcessException {
 		readLink(chip, linkDirection, baseAddress, size,
 				new FileAccumulator(dataFile));
@@ -252,7 +254,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void readMemory(HasChipLocation chip, int baseAddress, int size,
+	void readMemory(HasChipLocation chip, MemoryLocation baseAddress, int size,
 			RandomAccessFile dataFile) throws IOException, ProcessException {
 		readMemory(chip, baseAddress, size, new FileAccumulator(dataFile));
 	}
@@ -277,7 +279,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
-			int baseAddress, int size, File dataFile)
+			MemoryLocation baseAddress, int size, File dataFile)
 			throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			readLink(chip, linkDirection, baseAddress, size,
@@ -302,7 +304,7 @@ class ReadMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void readMemory(HasChipLocation chip, int baseAddress, int size,
+	void readMemory(HasChipLocation chip, MemoryLocation baseAddress, int size,
 			File dataFile) throws IOException, ProcessException {
 		try (RandomAccessFile s = new RandomAccessFile(dataFile, "rw")) {
 			readMemory(chip, baseAddress, size, s);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
@@ -17,6 +17,9 @@
 package uk.ac.manchester.spinnaker.transceiver;
 
 import static java.util.Collections.unmodifiableMap;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_CONTROL;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_DIAGNOSTICS;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_ERROR;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,7 +30,6 @@ import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.CoreSubsets;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.ReinjectionStatus;
 import uk.ac.manchester.spinnaker.messages.model.RouterDiagnostics;
 import uk.ac.manchester.spinnaker.messages.scp.ClearReinjectionQueue;
@@ -50,12 +52,6 @@ class RouterControlProcess extends MultiConnectionProcess<SCPConnection> {
 	private static final int REGISTER = 4;
 
 	private static final int NUM_REGISTERS = 16;
-
-	private static final int ROUTER_CONTROL_REGISTER = 0xe1000000;
-
-	private static final int ROUTER_ERROR_STATUS = 0xe1000014;
-
-	private static final int ROUTER_REGISTERS = 0xe1000300;
 
 	/**
 	 * @param connectionSelector
@@ -429,15 +425,6 @@ class RouterControlProcess extends MultiConnectionProcess<SCPConnection> {
 		return unmodifiableMap(status);
 	}
 
-	private static final MemoryLocation CONTROL =
-			new MemoryLocation(ROUTER_CONTROL_REGISTER);
-
-	private static final MemoryLocation ERROR =
-			new MemoryLocation(ROUTER_ERROR_STATUS);
-
-	private static final MemoryLocation REGISTER_BANK =
-			new MemoryLocation(ROUTER_REGISTERS);
-
 	/**
 	 * Get a chip's router's diagnostics.
 	 *
@@ -456,13 +443,14 @@ class RouterControlProcess extends MultiConnectionProcess<SCPConnection> {
 		int[] reg = new int[NUM_REGISTERS];
 
 		sendRequest(
-				new ReadMemory(chip, CONTROL, REGISTER),
+				new ReadMemory(chip, ROUTER_CONTROL, REGISTER),
 				response -> cr.setValue(response.data.getInt()));
 		sendRequest(
-				new ReadMemory(chip, ERROR, REGISTER),
+				new ReadMemory(chip, ROUTER_ERROR, REGISTER),
 				response -> es.setValue(response.data.getInt()));
 		sendRequest(
-				new ReadMemory(chip, REGISTER_BANK, NUM_REGISTERS * REGISTER),
+				new ReadMemory(chip, ROUTER_DIAGNOSTICS,
+						NUM_REGISTERS * REGISTER),
 				response -> response.data.asIntBuffer().get(reg));
 
 		finish();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
@@ -27,6 +27,7 @@ import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.CoreSubsets;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.ReinjectionStatus;
 import uk.ac.manchester.spinnaker.messages.model.RouterDiagnostics;
 import uk.ac.manchester.spinnaker.messages.scp.ClearReinjectionQueue;
@@ -428,6 +429,15 @@ class RouterControlProcess extends MultiConnectionProcess<SCPConnection> {
 		return unmodifiableMap(status);
 	}
 
+	private static final MemoryLocation CONTROL =
+			new MemoryLocation(ROUTER_CONTROL_REGISTER);
+
+	private static final MemoryLocation ERROR =
+			new MemoryLocation(ROUTER_ERROR_STATUS);
+
+	private static final MemoryLocation REGISTER_BANK =
+			new MemoryLocation(ROUTER_REGISTERS);
+
 	/**
 	 * Get a chip's router's diagnostics.
 	 *
@@ -445,13 +455,14 @@ class RouterControlProcess extends MultiConnectionProcess<SCPConnection> {
 		ValueHolder<Integer> es = new ValueHolder<>();
 		int[] reg = new int[NUM_REGISTERS];
 
-		sendRequest(new ReadMemory(chip, ROUTER_CONTROL_REGISTER, REGISTER),
+		sendRequest(
+				new ReadMemory(chip, CONTROL, REGISTER),
 				response -> cr.setValue(response.data.getInt()));
-		sendRequest(new ReadMemory(chip, ROUTER_ERROR_STATUS, REGISTER),
+		sendRequest(
+				new ReadMemory(chip, ERROR, REGISTER),
 				response -> es.setValue(response.data.getInt()));
 		sendRequest(
-				new ReadMemory(chip, ROUTER_REGISTERS,
-						NUM_REGISTERS * REGISTER),
+				new ReadMemory(chip, REGISTER_BANK, NUM_REGISTERS * REGISTER),
 				response -> response.data.asIntBuffer().get(reg));
 
 		finish();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
@@ -36,12 +36,13 @@ import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.CoreSubsets;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.IOBuffer;
 import uk.ac.manchester.spinnaker.messages.scp.ClearIOBUF;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
-import uk.ac.manchester.spinnaker.messages.scp.UpdateRuntime;
 import uk.ac.manchester.spinnaker.messages.scp.ReadMemory.Response;
 import uk.ac.manchester.spinnaker.messages.scp.UpdateProvenanceAndExit;
+import uk.ac.manchester.spinnaker.messages.scp.UpdateRuntime;
 import uk.ac.manchester.spinnaker.utils.DefaultMap;
 import uk.ac.manchester.spinnaker.utils.MappableIterable;
 
@@ -179,9 +180,9 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 		for (CoreLocation core : requireNonNull(cores,
 				"must have actual core subset to iterate over")) {
 			sendRequest(new ReadMemory(core.getScampCore(),
-					CPU_IOBUF_ADDRESS_OFFSET + getVcpuAddress(core), WORD),
+					getVcpuAddress(core).add(CPU_IOBUF_ADDRESS_OFFSET), WORD),
 					response -> issueReadForIOBufHead(core, 0,
-							response.data.getInt(),
+							new MemoryLocation(response.data.getInt()),
 							chunk(size + BUF_HEADER_BYTES)));
 		}
 		finish();
@@ -199,7 +200,8 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 				NextRead read = nextReads.remove();
 				sendRequest(read.message(), response -> {
 					// Unpack the IOBuf header
-					int nextAddress = response.data.getInt();
+					MemoryLocation nextAddress =
+							new MemoryLocation(response.data.getInt());
 					response.data.getLong(); // Ignore 8 bytes
 					int bytesToRead = response.data.getInt();
 
@@ -209,7 +211,7 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 
 					// Ask for the rest of the IOBuf buffer to be copied over
 					issueReadsForIOBufTail(read, bytesToRead,
-							read.base + packetBytes + BLOCK_HEADER_BYTES,
+							read.base.add(packetBytes + BLOCK_HEADER_BYTES),
 							packetBytes);
 
 					// If there is another IOBuf buffer, read this next
@@ -239,9 +241,9 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 		};
 	}
 
-	private void issueReadForIOBufHead(CoreLocation core, int blockID, int next,
-			int size) {
-		if (next != 0) {
+	private void issueReadForIOBufHead(CoreLocation core, int blockID,
+			MemoryLocation next, int size) {
+		if (!next.isNull()) {
 			nextReads.add(new NextRead(core, blockID, next, size));
 		}
 	}
@@ -261,14 +263,14 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 	}
 
 	private void issueReadsForIOBufTail(NextRead read, int bytesToRead,
-			int baseAddress, int readOffset) {
+			MemoryLocation baseAddress, int readOffset) {
 		bytesToRead -= readOffset;
 		// While more reads need to be done to read the data
 		while (bytesToRead > 0) {
 			// Read the next bit of memory making up the buffer
 			int next = chunk(bytesToRead);
 			extraReads.add(new ExtraRead(read, baseAddress, next, readOffset));
-			baseAddress += next;
+			baseAddress = baseAddress.add(next);
 			readOffset += next;
 			bytesToRead -= next;
 		}
@@ -287,11 +289,12 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 
 		final int blockID;
 
-		final int base;
+		final MemoryLocation base;
 
 		final int size;
 
-		NextRead(CoreLocation core, int blockID, int base, int size) {
+		NextRead(CoreLocation core, int blockID, MemoryLocation base,
+				int size) {
 			this.core = core;
 			this.blockID = blockID;
 			this.base = base;
@@ -311,13 +314,13 @@ class RuntimeControlProcess extends MultiConnectionProcess<SCPConnection> {
 
 		final int blockID;
 
-		final int base;
+		final MemoryLocation base;
 
 		final int size;
 
 		final int offset;
 
-		ExtraRead(NextRead head, int base, int size, int offset) {
+		ExtraRead(NextRead head, MemoryLocation base, int size, int offset) {
 			this.core = head.core;
 			this.blockID = head.blockID;
 			this.base = base;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -39,10 +39,7 @@ import static uk.ac.manchester.spinnaker.messages.Constants.BMP_TIMEOUT;
 import static uk.ac.manchester.spinnaker.messages.Constants.NO_ROUTER_DIAGNOSTIC_FILTERS;
 import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_DEFAULT_FILTERS_MAX_POSITION;
 import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_DIAGNOSTIC_FILTER_SIZE;
-import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_FILTER_CONTROLS_OFFSET;
-import static uk.ac.manchester.spinnaker.messages.Constants.ROUTER_REGISTER_BASE_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
-import static uk.ac.manchester.spinnaker.messages.Constants.SYSTEM_VARIABLE_BASE_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_BOOT_CONNECTION_DEFAULT_PORT;
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime.TIMEOUT_2560_ms;
@@ -55,6 +52,10 @@ import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.y_size;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPRequest.BOOT_CHIP;
 import static uk.ac.manchester.spinnaker.transceiver.BMPCommandProcess.BMP_RETRIES;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.EXECUTABLE_ADDRESS;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_DIAGNOSTIC_COUNTER;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.ROUTER_FILTERS;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.SYS_VARS;
 import static uk.ac.manchester.spinnaker.transceiver.Utils.defaultBMPforMachine;
 import static uk.ac.manchester.spinnaker.utils.UnitConstants.MSEC_PER_SEC;
 
@@ -223,27 +224,6 @@ public class Transceiver extends UDPTransceiver
 	private static final int POST_POWER_ON_DELAY = 2000;
 
 	private static final int ENABLE_SHIFT = 16;
-
-	/**
-	 * Where to read router diagnostic counters from.
-	 */
-	private static final int ROUTER_DIAGNOSTIC_COUNTER_ADDR = 0xf100002c;
-
-	/** Where executables are written to prior to launching them. */
-	private static final MemoryLocation EXECUTABLE_ADDRESS =
-			new MemoryLocation(0x67800000);
-
-	/** Where the system variables are located. */
-	private static final MemoryLocation SYS_VARS =
-			new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS);
-
-	/** Where the router's registers are located. */
-	private static final MemoryLocation ROUTER_BASE =
-			new MemoryLocation(ROUTER_REGISTER_BASE_ADDRESS);
-
-	/** Where to read router diagnostic counters from. */
-	private static final MemoryLocation ROUTER_DIAGNOSTICS =
-			new MemoryLocation(ROUTER_DIAGNOSTIC_COUNTER_ADDR);
 
 	/**
 	 * How much data to pile into SCAMP before reducing the number of messages
@@ -2309,8 +2289,8 @@ public class Transceiver extends UDPTransceiver
 					+ "the end user knows what they are doing.");
 		}
 
-		MemoryLocation address = ROUTER_BASE.add(ROUTER_FILTER_CONTROLS_OFFSET
-				+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
+		MemoryLocation address =
+				ROUTER_FILTERS.add(position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
 		writeMemory(chip, address, diagnosticFilter.getFilterWord());
 	}
 
@@ -2323,8 +2303,8 @@ public class Transceiver extends UDPTransceiver
 					"router filter positions must be between 0 and "
 							+ NO_ROUTER_DIAGNOSTIC_FILTERS);
 		}
-		MemoryLocation address = ROUTER_BASE.add(ROUTER_FILTER_CONTROLS_OFFSET
-				+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
+		MemoryLocation address =
+				ROUTER_FILTERS.add(position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
 		Response response = simpleProcess()
 				.execute(new ReadMemory(chip, address, WORD_SIZE));
 		return new DiagnosticFilter(response.data.getInt());
@@ -2348,7 +2328,7 @@ public class Transceiver extends UDPTransceiver
 				clearData |= 1 << counterID + ENABLE_SHIFT;
 			}
 		}
-		writeMemory(chip, ROUTER_DIAGNOSTICS, clearData);
+		writeMemory(chip, ROUTER_DIAGNOSTIC_COUNTER, clearData);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -1674,15 +1674,16 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelUnsafe
-	public int readFPGARegister(FPGA fpga, int register, BMPCoords bmp,
-			BMPBoard board) throws IOException, ProcessException {
+	public int readFPGARegister(FPGA fpga, MemoryLocation register,
+			BMPCoords bmp, BMPBoard board)
+			throws IOException, ProcessException {
 		return bmpCall(bmp,
 				new ReadFPGARegister(fpga, register, board)).fpgaRegister;
 	}
 
 	@Override
 	@ParallelUnsafe
-	public void writeFPGARegister(FPGA fpga, int register, int value,
+	public void writeFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPCoords bmp, BMPBoard board)
 			throws IOException, ProcessException {
 		bmpCall(bmp, new WriteFPGARegister(fpga, register, value, board));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -105,6 +105,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.MachineDimensions;
 import uk.ac.manchester.spinnaker.machine.MachineVersion;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.MulticastRoutingEntry;
 import uk.ac.manchester.spinnaker.machine.Processor;
 import uk.ac.manchester.spinnaker.machine.RoutingEntry;
@@ -191,11 +192,6 @@ public class Transceiver extends UDPTransceiver
 		implements TransceiverInterface, RetryTracker {
 	private static final Logger log = getLogger(Transceiver.class);
 
-	/**
-	 * Where executables are written to prior to launching them.
-	 */
-	private static final int EXECUTABLE_ADDRESS = 0x67800000;
-
 	private static final String SCAMP_NAME = "SC&MP";
 
 	private static final Version SCAMP_VERSION = new Version(3, 0, 1);
@@ -232,6 +228,22 @@ public class Transceiver extends UDPTransceiver
 	 * Where to read router diagnostic counters from.
 	 */
 	private static final int ROUTER_DIAGNOSTIC_COUNTER_ADDR = 0xf100002c;
+
+	/** Where executables are written to prior to launching them. */
+	private static final MemoryLocation EXECUTABLE_ADDRESS =
+			new MemoryLocation(0x67800000);
+
+	/** Where the system variables are located. */
+	private static final MemoryLocation SYS_VARS =
+			new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS);
+
+	/** Where the router's registers are located. */
+	private static final MemoryLocation ROUTER_BASE =
+			new MemoryLocation(ROUTER_REGISTER_BASE_ADDRESS);
+
+	/** Where to read router diagnostic counters from. */
+	private static final MemoryLocation ROUTER_DIAGNOSTICS =
+			new MemoryLocation(ROUTER_DIAGNOSTIC_COUNTER_ADDR);
 
 	/**
 	 * How much data to pile into SCAMP before reducing the number of messages
@@ -734,9 +746,8 @@ public class Transceiver extends UDPTransceiver
 	private Object getSystemVariable(HasChipLocation chip,
 			SystemVariableDefinition dataItem)
 			throws IOException, ProcessException {
-		ByteBuffer buffer =
-				readMemory(chip, SYSTEM_VARIABLE_BASE_ADDRESS + dataItem.offset,
-						dataItem.type.value);
+		ByteBuffer buffer = readMemory(chip, SYS_VARS.add(dataItem.offset),
+				dataItem.type.value);
 		switch (dataItem.type) {
 		case BYTE:
 			return Byte.toUnsignedInt(buffer.get());
@@ -750,6 +761,8 @@ public class Transceiver extends UDPTransceiver
 			byte[] dst = (byte[]) dataItem.getDefault();
 			buffer.get(dst);
 			return dst;
+		case ADDRESS:
+			return new MemoryLocation(buffer.getInt());
 		default:
 			// Unreachable
 			throw new IllegalStateException();
@@ -1040,8 +1053,8 @@ public class Transceiver extends UDPTransceiver
 	public MachineDimensions getMachineDimensions()
 			throws IOException, ProcessException {
 		if (dimensions == null) {
-			ByteBuffer data = readMemory(BOOT_CHIP,
-					SYSTEM_VARIABLE_BASE_ADDRESS + y_size.offset, 2);
+			ByteBuffer data =
+					readMemory(BOOT_CHIP, SYS_VARS.add(y_size.offset), 2);
 			int height = toUnsignedInt(data.get());
 			int width = toUnsignedInt(data.get());
 			dimensions = new MachineDimensions(width, height);
@@ -1410,8 +1423,7 @@ public class Transceiver extends UDPTransceiver
 	public void setWatchDogTimeoutOnChip(HasChipLocation chip, int watchdog)
 			throws IOException, ProcessException {
 		// write data
-		writeMemory(chip,
-				SYSTEM_VARIABLE_BASE_ADDRESS + software_watchdog_count.offset,
+		writeMemory(chip, SYS_VARS.add(software_watchdog_count.offset),
 				oneByte(watchdog));
 	}
 
@@ -1420,11 +1432,8 @@ public class Transceiver extends UDPTransceiver
 	public void enableWatchDogTimerOnChip(HasChipLocation chip,
 			boolean watchdog) throws IOException, ProcessException {
 		// write data
-		writeMemory(chip,
-				SYSTEM_VARIABLE_BASE_ADDRESS + software_watchdog_count.offset,
-				oneByte(watchdog
-						? (Integer) software_watchdog_count.getDefault()
-						: 0));
+		writeMemory(chip, SYS_VARS.add(software_watchdog_count.offset), oneByte(
+				watchdog ? (Integer) software_watchdog_count.getDefault() : 0));
 	}
 
 	@Override
@@ -1716,21 +1725,24 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board,
-			int baseAddress, int length) throws ProcessException, IOException {
+			MemoryLocation baseAddress, int length)
+			throws ProcessException, IOException {
 		return new BMPReadMemoryProcess(bmpConnection(bmp), this).read(board,
 				baseAddress, length);
 	}
 
 	@Override
-	public void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws IOException, ProcessException {
 		new BMPWriteMemoryProcess(bmpConnection(bmp), this).writeMemory(board,
 				baseAddress, data);
 	}
 
 	@Override
-	public void writeBMPMemory(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws IOException, ProcessException {
+	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws IOException, ProcessException {
 		BMPWriteMemoryProcess wmp =
 				new BMPWriteMemoryProcess(bmpConnection(bmp), this);
 		try (BufferedInputStream f =
@@ -1740,18 +1752,17 @@ public class Transceiver extends UDPTransceiver
 		}
 	}
 
-	private static final int FLASH_BUFFER_INDEX = 5;
-
 	@Override
-	public int getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
+	public MemoryLocation getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
 			throws IOException, ProcessException {
 		return bmpCall(bmp, new ReadSerialVector(board)).vector
-				.get(FLASH_BUFFER_INDEX);
+				.getFlashBuffer();
 	}
 
 	@Override
 	public ByteBuffer readSerialFlash(BMPCoords bmp, BMPBoard board,
-			int baseAddress, int length) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return new BMPReadSerialFlashProcess(bmpConnection(bmp), this)
 				.read(board, baseAddress, length);
 	}
@@ -1761,28 +1772,32 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public int readSerialFlashCRC(BMPCoords bmp, BMPBoard board,
-			int address, int length) throws IOException, ProcessException {
+			MemoryLocation address, int length)
+			throws IOException, ProcessException {
 		return bmpCall(bmp, CRC_TIMEOUT, BMP_RETRIES /* =default */,
 				new ReadSerialFlashCRC(board, address, length)).crc;
 	}
 
 	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			ByteBuffer data) throws ProcessException, IOException {
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, ByteBuffer data)
+			throws ProcessException, IOException {
 		new BMPWriteSerialFlashProcess(bmpConnection(bmp), this).write(board,
 				baseAddress, data);
 	}
 
 	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size, InputStream stream) throws ProcessException, IOException {
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size, InputStream stream)
+			throws ProcessException, IOException {
 		new BMPWriteSerialFlashProcess(bmpConnection(bmp), this).write(board,
 				baseAddress, stream, size);
 	}
 
 	@Override
-	public void writeSerialFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			File file) throws ProcessException, IOException {
+	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, File file)
+			throws ProcessException, IOException {
 		try (BufferedInputStream f =
 				new BufferedInputStream(new FileInputStream(file))) {
 			// The file had better fit...
@@ -1792,29 +1807,31 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	@Override
-	public void writeBMPFlash(BMPCoords bmp, BMPBoard board, int address)
-			throws IOException, ProcessException {
+	public void writeBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation address) throws IOException, ProcessException {
 		bmpCall(bmp, new WriteFlashBuffer(board, address, true));
 	}
 
 	@Deprecated
 	@Override
-	public int eraseBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size) throws IOException, ProcessException {
+	public MemoryLocation eraseBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size)
+			throws IOException, ProcessException {
 		return bmpCall(bmp, new EraseFlash(board, baseAddress, size)).address;
 	}
 
 	@Deprecated
 	@Override
-	public void chunkBMPFlash(BMPCoords bmp, BMPBoard board, int address)
-			throws IOException, ProcessException {
+	public void chunkBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation address) throws IOException, ProcessException {
 		bmpCall(bmp, new WriteFlashBuffer(board, address, false));
 	}
 
 	@Deprecated
 	@Override
-	public void copyBMPFlash(BMPCoords bmp, BMPBoard board, int baseAddress,
-			int size) throws IOException, ProcessException {
+	public void copyBMPFlash(BMPCoords bmp, BMPBoard board,
+			MemoryLocation baseAddress, int size)
+			throws IOException, ProcessException {
 		// NB: no retries of this! Not idempotent!
 		bmpCall(bmp, (int) (MSEC_PER_SEC * BMP_TIMEOUT), 0,
 				new UpdateFlash(board, baseAddress, size));
@@ -1857,7 +1874,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public void writeMemory(HasCoreLocation core, int baseAddress,
+	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
 			throws IOException, ProcessException {
 		writeProcess(numBytes).writeMemory(core, baseAddress, dataStream,
@@ -1866,7 +1883,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public void writeMemory(HasCoreLocation core, int baseAddress,
+	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			File dataFile) throws IOException, ProcessException {
 		writeProcess(dataFile.length()).writeMemory(core, baseAddress,
 				dataFile);
@@ -1874,7 +1891,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public void writeMemory(HasCoreLocation core, int baseAddress,
+	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			ByteBuffer data) throws IOException, ProcessException {
 		writeProcess(data.remaining()).writeMemory(core, baseAddress, data);
 	}
@@ -1882,7 +1899,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, InputStream dataStream, int numBytes)
+			MemoryLocation baseAddress, InputStream dataStream, int numBytes)
 			throws IOException, ProcessException {
 		writeProcess(numBytes).writeLink(core, link, baseAddress, dataStream,
 				numBytes);
@@ -1891,7 +1908,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, File dataFile)
+			MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException {
 		writeProcess(dataFile.length()).writeLink(core, link, baseAddress,
 				dataFile);
@@ -1900,15 +1917,16 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, ByteBuffer data)
+			MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException {
 		writeProcess(data.remaining()).writeLink(core, link, baseAddress, data);
 	}
 
 	@Override
 	@ParallelUnsafe
-	public void writeMemoryFlood(int baseAddress, InputStream dataStream,
-			int numBytes) throws IOException, ProcessException {
+	public void writeMemoryFlood(MemoryLocation baseAddress,
+			InputStream dataStream, int numBytes)
+			throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
@@ -1921,7 +1939,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelUnsafe
-	public void writeMemoryFlood(int baseAddress, File dataFile)
+	public void writeMemoryFlood(MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
@@ -1935,7 +1953,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelUnsafe
-	public void writeMemoryFlood(int baseAddress, ByteBuffer data)
+	public void writeMemoryFlood(MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException {
 		WriteMemoryFloodProcess process =
 				new WriteMemoryFloodProcess(scpSelector, this);
@@ -1948,8 +1966,9 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public ByteBuffer readMemory(HasCoreLocation core, int baseAddress,
-			int length) throws IOException, ProcessException {
+	public ByteBuffer readMemory(HasCoreLocation core,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return new ReadMemoryProcess(scpSelector, this).readMemory(core,
 				baseAddress, length);
 	}
@@ -1965,7 +1984,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public ByteBuffer readNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, int length) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return new ReadMemoryProcess(scpSelector, this).readLink(core, link,
 				baseAddress, length);
 	}
@@ -2198,15 +2218,15 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public int mallocSDRAM(HasChipLocation chip, int size, AppID appID, int tag)
-			throws IOException, ProcessException {
+	public MemoryLocation mallocSDRAM(HasChipLocation chip, int size,
+			AppID appID, int tag) throws IOException, ProcessException {
 		return simpleProcess()
 				.execute(new SDRAMAlloc(chip, appID, size, tag)).baseAddress;
 	}
 
 	@Override
 	@ParallelSafe
-	public void freeSDRAM(HasChipLocation chip, int baseAddress)
+	public void freeSDRAM(HasChipLocation chip, MemoryLocation baseAddress)
 			throws IOException, ProcessException {
 		simpleProcess().execute(new SDRAMDeAlloc(chip, baseAddress));
 	}
@@ -2248,7 +2268,8 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip,
 			AppID appID) throws IOException, ProcessException {
-		int address = (int) getSystemVariable(chip, router_table_copy_address);
+		MemoryLocation address = (MemoryLocation) getSystemVariable(chip,
+				router_table_copy_address);
 		return new MulticastRoutesControlProcess(scpSelector, this)
 				.getRoutes(chip, address, appID);
 	}
@@ -2288,9 +2309,8 @@ public class Transceiver extends UDPTransceiver
 					+ "the end user knows what they are doing.");
 		}
 
-		int address =
-				(ROUTER_REGISTER_BASE_ADDRESS + ROUTER_FILTER_CONTROLS_OFFSET
-						+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
+		MemoryLocation address = ROUTER_BASE.add(ROUTER_FILTER_CONTROLS_OFFSET
+				+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
 		writeMemory(chip, address, diagnosticFilter.getFilterWord());
 	}
 
@@ -2303,9 +2323,8 @@ public class Transceiver extends UDPTransceiver
 					"router filter positions must be between 0 and "
 							+ NO_ROUTER_DIAGNOSTIC_FILTERS);
 		}
-		int address =
-				ROUTER_REGISTER_BASE_ADDRESS + ROUTER_FILTER_CONTROLS_OFFSET
-						+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE;
+		MemoryLocation address = ROUTER_BASE.add(ROUTER_FILTER_CONTROLS_OFFSET
+				+ position * ROUTER_DIAGNOSTIC_FILTER_SIZE);
 		Response response = simpleProcess()
 				.execute(new ReadMemory(chip, address, WORD_SIZE));
 		return new DiagnosticFilter(response.data.getInt());
@@ -2329,7 +2348,7 @@ public class Transceiver extends UDPTransceiver
 				clearData |= 1 << counterID + ENABLE_SHIFT;
 			}
 		}
-		writeMemory(chip, ROUTER_DIAGNOSTIC_COUNTER_ADDR, clearData);
+		writeMemory(chip, ROUTER_DIAGNOSTICS, clearData);
 	}
 
 	@Override
@@ -2443,7 +2462,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafe
-	public void fillMemory(HasChipLocation chip, int baseAddress,
+	public void fillMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			int repeatValue, int size, FillDataType dataType)
 			throws ProcessException, IOException {
 		if (repeatValue < 1) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -38,7 +38,6 @@ import static uk.ac.manchester.spinnaker.messages.model.CPUState.WATCHDOG;
 import static uk.ac.manchester.spinnaker.messages.model.Signal.START;
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.sdram_heap_address;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPRequest.BOOT_CHIP;
-import static uk.ac.manchester.spinnaker.transceiver.Address.convert;
 import static uk.ac.manchester.spinnaker.transceiver.FillDataType.WORD;
 import static uk.ac.manchester.spinnaker.transceiver.Utils.getVcpuAddress;
 
@@ -67,7 +66,9 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.MachineDimensions;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.MulticastRoutingEntry;
+import uk.ac.manchester.spinnaker.machine.Processor;
 import uk.ac.manchester.spinnaker.machine.RoutingEntry;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
@@ -502,8 +503,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>0</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser0RegisterAddress(HasCoreLocation core) {
-		return getVcpuAddress(core) + CPU_USER_0_START_ADDRESS;
+	default MemoryLocation getUser0RegisterAddress(HasCoreLocation core) {
+		return getVcpuAddress(core).add(CPU_USER_0_START_ADDRESS);
 	}
 
 	/**
@@ -515,8 +516,22 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>0</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser0RegisterAddress(int p) {
-		return getVcpuAddress(p) + CPU_USER_0_START_ADDRESS;
+	default MemoryLocation getUser0RegisterAddress(int p) {
+		return getVcpuAddress(p).add(CPU_USER_0_START_ADDRESS);
+	}
+
+	/**
+	 * Get the address of user<sub>0</sub> for a given processor on the board.
+	 * <i>This does not read from the processor.</i>
+	 *
+	 * @param processor
+	 *            the processor to get the user<sub>0</sub> address for
+	 * @return The address for user<sub>0</sub> register for this processor
+	 */
+	@ParallelSafe
+	default MemoryLocation getUser0RegisterAddress(Processor processor) {
+		return getVcpuAddress(processor.processorId)
+				.add(CPU_USER_0_START_ADDRESS);
 	}
 
 	/**
@@ -529,8 +544,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>1</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser1RegisterAddress(HasCoreLocation core) {
-		return getVcpuAddress(core) + CPU_USER_1_START_ADDRESS;
+	default MemoryLocation getUser1RegisterAddress(HasCoreLocation core) {
+		return getVcpuAddress(core).add(CPU_USER_1_START_ADDRESS);
 	}
 
 	/**
@@ -542,8 +557,22 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>1</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser1RegisterAddress(int p) {
-		return getVcpuAddress(p) + CPU_USER_1_START_ADDRESS;
+	default MemoryLocation getUser1RegisterAddress(int p) {
+		return getVcpuAddress(p).add(CPU_USER_1_START_ADDRESS);
+	}
+
+	/**
+	 * Get the address of user<sub>1</sub> for a given processor on the board.
+	 * <i>This does not read from the processor.</i>
+	 *
+	 * @param processor
+	 *            the processor to get the user<sub>1</sub> address for
+	 * @return The address for user<sub>1</sub> register for this processor
+	 */
+	@ParallelSafe
+	default MemoryLocation getUser1RegisterAddress(Processor processor) {
+		return getVcpuAddress(processor.processorId)
+				.add(CPU_USER_1_START_ADDRESS);
 	}
 
 	/**
@@ -556,8 +585,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>2</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser2RegisterAddress(HasCoreLocation core) {
-		return getVcpuAddress(core) + CPU_USER_2_START_ADDRESS;
+	default MemoryLocation getUser2RegisterAddress(HasCoreLocation core) {
+		return getVcpuAddress(core).add(CPU_USER_2_START_ADDRESS);
 	}
 
 	/**
@@ -569,8 +598,22 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @return The address for user<sub>0</sub> register for this processor
 	 */
 	@ParallelSafe
-	default int getUser2RegisterAddress(int p) {
-		return getVcpuAddress(p) + CPU_USER_2_START_ADDRESS;
+	default MemoryLocation getUser2RegisterAddress(int p) {
+		return getVcpuAddress(p).add(CPU_USER_2_START_ADDRESS);
+	}
+
+	/**
+	 * Get the address of user<sub>2</sub> for a given processor on the board.
+	 * <i>This does not read from the processor.</i>
+	 *
+	 * @param processor
+	 *            the processor to get the user<sub>2</sub> address for
+	 * @return The address for user<sub>0</sub> register for this processor
+	 */
+	@ParallelSafe
+	default MemoryLocation getUser2RegisterAddress(Processor processor) {
+		return getVcpuAddress(processor.processorId)
+				.add(CPU_USER_2_START_ADDRESS);
 	}
 
 	/**
@@ -1439,33 +1482,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, long baseAddress,
-			InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
-		writeMemory(chip, convert(baseAddress), dataStream, numBytes);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataStream
-	 *            The stream of data that is to be written.
-	 * @param numBytes
-	 *            The amount of data to be written in bytes.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or reading from the
-	 *             input stream.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, int baseAddress,
+	default void writeMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
 			throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataStream, numBytes);
@@ -1491,33 +1508,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, long baseAddress,
-			InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
-		writeMemory(core, convert(baseAddress), dataStream, numBytes);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataStream
-	 *            The stream of data that is to be written.
-	 * @param numBytes
-	 *            The amount of data to be written in bytes.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or reading from the
-	 *             input stream.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	void writeMemory(HasCoreLocation core, int baseAddress,
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
 			throws IOException, ProcessException;
 
@@ -1539,30 +1530,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, long baseAddress,
-			File dataFile) throws IOException, ProcessException {
-		writeMemory(chip, convert(baseAddress), dataFile);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataFile
-	 *            The file holding the data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or reading from the
-	 *             file.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, int baseAddress,
+	default void writeMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			File dataFile) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataFile);
 	}
@@ -1585,31 +1553,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, long baseAddress,
-			File dataFile) throws IOException, ProcessException {
-		writeMemory(core, convert(baseAddress), dataFile);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataFile
-	 *            The file holding the data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or reading from the
-	 *             file.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	void writeMemory(HasCoreLocation core, int baseAddress, File dataFile)
-			throws IOException, ProcessException;
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			File dataFile) throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1628,29 +1573,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, long baseAddress,
-			int dataWord) throws IOException, ProcessException {
-		writeMemory(chip, convert(baseAddress), dataWord);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataWord
-	 *            The word that is to be written (as 4 bytes).
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, int baseAddress,
+	default void writeMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			int dataWord) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, dataWord);
 	}
@@ -1672,29 +1595,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, long baseAddress,
-			int dataWord) throws IOException, ProcessException {
-		writeMemory(core, convert(baseAddress), dataWord);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataWord
-	 *            The word that is to be written (as 4 bytes).
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, int baseAddress,
+	default void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			int dataWord) throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
@@ -1718,30 +1619,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, long baseAddress,
+	default void writeMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			byte[] data) throws IOException, ProcessException {
-		writeMemory(chip, convert(baseAddress), wrap(data));
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, int baseAddress, byte[] data)
-			throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, wrap(data));
 	}
 
@@ -1762,30 +1641,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, long baseAddress,
+	default void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			byte[] data) throws IOException, ProcessException {
-		writeMemory(core, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, int baseAddress, byte[] data)
-			throws IOException, ProcessException {
 		writeMemory(core, baseAddress, wrap(data));
 	}
 
@@ -1807,30 +1664,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, long baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
-		writeMemory(chip, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written. The data should be from the
-	 *            <i>position</i> to the <i>limit</i>.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default void writeMemory(HasChipLocation chip, int baseAddress,
+	default void writeMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			ByteBuffer data) throws IOException, ProcessException {
 		writeMemory(chip.getScampCore(), baseAddress, data);
 	}
@@ -1853,31 +1687,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void writeMemory(HasCoreLocation core, long baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
-		writeMemory(core, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the SDRAM on the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is that is to be
-	 *            written to
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written. The data should be from the
-	 *            <i>position</i> to the <i>limit</i>.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	void writeMemory(HasCoreLocation core, int baseAddress, ByteBuffer data)
-			throws IOException, ProcessException;
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			ByteBuffer data) throws IOException, ProcessException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
@@ -1908,42 +1719,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(chip, link, convert(baseAddress), dataStream,
-				numBytes);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be written
-	 *            to
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataStream
-	 *            The stream of data that is to be written.
-	 * @param numBytes
-	 *            The amount of data to be written in bytes.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the input stream.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, InputStream dataStream, int numBytes)
+			MemoryLocation baseAddress, InputStream dataStream, int numBytes)
 			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataStream,
 				numBytes);
@@ -1978,44 +1754,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(core, link, convert(baseAddress), dataStream,
-				numBytes);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the core whose neighbour is to be written
-	 *            to; the CPU to use is typically 0 (or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataStream
-	 *            The stream of data that is to be written.
-	 * @param numBytes
-	 *            The amount of data to be written in bytes.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the input stream.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
 	void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, InputStream dataStream, int numBytes)
+			MemoryLocation baseAddress, InputStream dataStream, int numBytes)
 			throws IOException, ProcessException;
 
 	/**
@@ -2045,39 +1785,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, File dataFile)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(chip, link, convert(baseAddress), dataFile);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be written
-	 *            to
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataFile
-	 *            The file holding the data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the file.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, File dataFile)
+			MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataFile);
 	}
@@ -2109,41 +1817,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, File dataFile)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(core, link, convert(baseAddress), dataFile);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the core whose neighbour is to be written
-	 *            to; the CPU to use is typically 0 (or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataFile
-	 *            The name of the file holding the data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the file.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
 	void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, File dataFile)
+			MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException;
 
 	/**
@@ -2172,38 +1847,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, int dataWord)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(chip, link, convert(baseAddress), dataWord);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be written
-	 *            to
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataWord
-	 *            The word that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, int dataWord)
+			MemoryLocation baseAddress, int dataWord)
 			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataWord);
 	}
@@ -2235,39 +1879,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, int dataWord)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(core, link, convert(baseAddress), dataWord);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the core whose neighbour is to be written
-	 *            to; the CPU to use is typically 0 (or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataWord
-	 *            The word that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, int dataWord)
+			MemoryLocation baseAddress, int dataWord)
 			throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
@@ -2300,38 +1912,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, byte[] data)
+			MemoryLocation baseAddress, byte[] data)
 			throws IOException, ProcessException {
-		writeNeighbourMemory(chip, link, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be written
-	 *            to
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, byte[] data) throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
 
@@ -2362,39 +1944,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, byte[] data)
+			MemoryLocation baseAddress, byte[] data)
 			throws IOException, ProcessException {
-		writeNeighbourMemory(core, link, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the core whose neighbour is to be written
-	 *            to; the CPU to use is typically 0 (or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, byte[] data) throws IOException, ProcessException {
 		writeNeighbourMemory(core, link, baseAddress, wrap(data));
 	}
 
@@ -2425,39 +1976,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(chip, link, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be written
-	 *            to
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written. The data should be from the
-	 *            <i>position</i> to the <i>limit</i>.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, ByteBuffer data)
+			MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
@@ -2489,41 +2008,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafeWithCare
-	default void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
-		writeNeighbourMemory(core, link, convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the core whose neighbour is to be written
-	 *            to; the CPU to use is typically 0 (or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written. The data should be from the
-	 *            <i>position</i> to the <i>limit</i>.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
 	void writeNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, ByteBuffer data)
+			MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException;
 
 	/**
@@ -2547,34 +2033,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelUnsafe
-	default void writeMemoryFlood(long baseAddress, InputStream dataStream,
-			int numBytes) throws IOException, ProcessException {
-		writeMemoryFlood(convert(baseAddress), dataStream, numBytes);
-	}
-
-	/**
-	 * Write to the SDRAM of all chips.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context. It has interlocking, but you should not rely on
-	 * it.
-	 *
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataStream
-	 *            The stream of data that is to be written.
-	 * @param numBytes
-	 *            The amount of data to be written in bytes.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the input stream.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelUnsafe
-	void writeMemoryFlood(int baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, ProcessException;
+	void writeMemoryFlood(MemoryLocation baseAddress, InputStream dataStream,
+			int numBytes) throws IOException, ProcessException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2595,31 +2055,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelUnsafe
-	default void writeMemoryFlood(long baseAddress, File dataFile)
-			throws IOException, ProcessException {
-		writeMemoryFlood(convert(baseAddress), dataFile);
-	}
-
-	/**
-	 * Write to the SDRAM of all chips.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context. It has interlocking, but you should not rely on
-	 * it.
-	 *
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataFile
-	 *            The name of the file holding the data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking or with reading from
-	 *             the file.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelUnsafe
-	void writeMemoryFlood(int baseAddress, File dataFile)
+	void writeMemoryFlood(MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException;
 
 	/**
@@ -2640,30 +2076,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelUnsafe
-	default void writeMemoryFlood(long baseAddress, int dataWord)
-			throws IOException, ProcessException {
-		writeMemoryFlood(convert(baseAddress), dataWord);
-	}
-
-	/**
-	 * Write to the SDRAM of all chips.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context. It has interlocking, but you should not rely on
-	 * it.
-	 *
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param dataWord
-	 *            The word that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelUnsafe
-	default void writeMemoryFlood(int baseAddress, int dataWord)
+	default void writeMemoryFlood(MemoryLocation baseAddress, int dataWord)
 			throws IOException, ProcessException {
 		ByteBuffer b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
@@ -2688,30 +2101,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelUnsafe
-	default void writeMemoryFlood(long baseAddress, byte[] data)
-			throws IOException, ProcessException {
-		writeMemoryFlood(convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the SDRAM of all chips.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context. It has interlocking, but you should not rely on
-	 * it.
-	 *
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelUnsafe
-	default void writeMemoryFlood(int baseAddress, byte[] data)
+	default void writeMemoryFlood(MemoryLocation baseAddress, byte[] data)
 			throws IOException, ProcessException {
 		writeMemoryFlood(baseAddress, wrap(data));
 	}
@@ -2735,31 +2125,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelUnsafe
-	default void writeMemoryFlood(long baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
-		writeMemoryFlood(convert(baseAddress), data);
-	}
-
-	/**
-	 * Write to the SDRAM of all chips.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context. It has interlocking, but you should not rely on
-	 * it.
-	 *
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory is to be
-	 *            written
-	 * @param data
-	 *            The data that is to be written. The data should be from the
-	 *            <i>position</i> to the <i>limit</i>.
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelUnsafe
-	void writeMemoryFlood(int baseAddress, ByteBuffer data)
+	void writeMemoryFlood(MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException;
 
 	/**
@@ -2781,8 +2147,9 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default ByteBuffer readMemory(HasChipLocation chip, int baseAddress,
-			int length) throws IOException, ProcessException {
+	default ByteBuffer readMemory(HasChipLocation chip,
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return readMemory(chip.getScampCore(), baseAddress, length);
 	}
 
@@ -2805,56 +2172,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	ByteBuffer readMemory(HasCoreLocation core, int baseAddress, int length)
-			throws IOException, ProcessException;
-
-	/**
-	 * Read some areas of SDRAM from the board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip where the memory is to be read
-	 *            from
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory to be read
-	 *            starts
-	 * @param length
-	 *            The length of the data to be read in bytes
-	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default ByteBuffer readMemory(HasChipLocation chip, long baseAddress,
-			int length) throws IOException, ProcessException {
-		return readMemory(chip, convert(baseAddress), length);
-	}
-
-	/**
-	 * Read some areas of SDRAM from the board.
-	 *
-	 * @param core
-	 *            The coordinates of the core where the memory is to be read
-	 *            from
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory to be read
-	 *            starts
-	 * @param length
-	 *            The length of the data to be read in bytes
-	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	default ByteBuffer readMemory(HasCoreLocation core, long baseAddress,
-			int length) throws IOException, ProcessException {
-		return readMemory(core, convert(baseAddress), length);
-	}
+	ByteBuffer readMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			int length) throws IOException, ProcessException;
 
 	/**
 	 * Read the contents of an allocated block on the heap from the board. The
@@ -2931,7 +2250,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	default ByteBuffer readNeighbourMemory(HasChipLocation chip, Direction link,
-			int baseAddress, int length) throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException {
 		return readNeighbourMemory(chip.getScampCore(), link, baseAddress,
 				length);
 	}
@@ -2965,71 +2285,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 */
 	@ParallelSafeWithCare
 	ByteBuffer readNeighbourMemory(HasCoreLocation core, Direction link,
-			int baseAddress, int length) throws IOException, ProcessException;
-
-	/**
-	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip whose neighbour is to be read from
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory to be read
-	 *            starts
-	 * @param length
-	 *            The length of the data to be read in bytes
-	 * @return A little-endian buffer of data that has been read, positioned at
-	 *         the start of the data
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default ByteBuffer readNeighbourMemory(HasChipLocation chip, Direction link,
-			long baseAddress, int length) throws IOException, ProcessException {
-		return readNeighbourMemory(chip, link, convert(baseAddress), length);
-	}
-
-	/**
-	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP
-	 * command. If sent to a BMP, this command can be used to communicate with
-	 * the FPGAs' debug registers; in that case, the link must be the direction
-	 * with the same ID as the ID of the FPGA to communicate with.
-	 * <p>
-	 * <strong>WARNING!</strong> This operation is <em>unsafe</em> in a
-	 * multi-threaded context if the link leaves the current board.
-	 *
-	 * @param core
-	 *            The coordinates of the chip whose neighbour is to be read
-	 *            from, plus the CPU to use (typically 0, or if a BMP, the slot
-	 *            number)
-	 * @param link
-	 *            The link direction to send the request along
-	 * @param baseAddress
-	 *            The address in SDRAM where the region of memory to be read
-	 *            starts
-	 * @param length
-	 *            The length of the data to be read in bytes
-	 * @return A little-endian buffer of data that has been read, positioned at
-	 *         the start of the data
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafeWithCare
-	default ByteBuffer readNeighbourMemory(HasCoreLocation core, Direction link,
-			long baseAddress, int length) throws IOException, ProcessException {
-		return readNeighbourMemory(core, link, convert(baseAddress), length);
-	}
+			MemoryLocation baseAddress, int length)
+			throws IOException, ProcessException;
 
 	/**
 	 * Sends a stop request for an application ID.
@@ -3462,7 +2719,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default int mallocSDRAM(HasChipLocation chip, int size)
+	default MemoryLocation mallocSDRAM(HasChipLocation chip, int size)
 			throws IOException, ProcessException {
 		return mallocSDRAM(chip, size, DEFAULT, 0);
 	}
@@ -3483,8 +2740,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default int mallocSDRAM(HasChipLocation chip, int size, AppID appID)
-			throws IOException, ProcessException {
+	default MemoryLocation mallocSDRAM(HasChipLocation chip, int size,
+			AppID appID) throws IOException, ProcessException {
 		return mallocSDRAM(chip, size, appID, 0);
 	}
 
@@ -3508,8 +2765,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	int mallocSDRAM(HasChipLocation chip, int size, AppID appID, int tag)
-			throws IOException, ProcessException;
+	MemoryLocation mallocSDRAM(HasChipLocation chip, int size, AppID appID,
+			int tag) throws IOException, ProcessException;
 
 	/**
 	 * Free allocated SDRAM.
@@ -3524,25 +2781,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void freeSDRAM(HasChipLocation chip, long baseAddress)
-			throws IOException, ProcessException {
-		freeSDRAM(chip, convert(baseAddress));
-	}
-
-	/**
-	 * Free allocated SDRAM.
-	 *
-	 * @param chip
-	 *            The coordinates of the chip onto which to free memory
-	 * @param baseAddress
-	 *            The base address of the allocated memory
-	 * @throws IOException
-	 *             If anything goes wrong with networking.
-	 * @throws ProcessException
-	 *             If SpiNNaker rejects a message.
-	 */
-	@ParallelSafe
-	void freeSDRAM(HasChipLocation chip, int baseAddress)
+	void freeSDRAM(HasChipLocation chip, MemoryLocation baseAddress)
 			throws IOException, ProcessException;
 
 	/**
@@ -3907,7 +3146,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	default void fillMemory(HasChipLocation chip, int baseAddress,
+	default void fillMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			int repeatValue, int size) throws ProcessException, IOException {
 		fillMemory(chip, baseAddress, repeatValue, size, WORD);
 	}
@@ -3933,8 +3172,8 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 */
 	@ParallelSafe
-	void fillMemory(HasChipLocation chip, int baseAddress, int repeatValue,
-			int size, FillDataType dataType)
+	void fillMemory(HasChipLocation chip, MemoryLocation baseAddress,
+			int repeatValue, int size, FillDataType dataType)
 			throws ProcessException, IOException;
 
 	/**
@@ -4382,34 +3621,4 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	@ParallelSafeWithCare
 	void loadSystemRouterTables(CoreSubsets monitorCores)
 			throws IOException, ProcessException;
-}
-
-/**
- * Constants used by the transceiver, but not exported by it.
- *
- * @author Donal Fellows
- */
-abstract class Address {
-	private Address() {
-	}
-
-	/** Maximum legal SpiNNaker address. */
-	private static final long MAX_ADDR = 0xFFFFFFFFL;
-
-	/**
-	 * Convert an address to a 32-bit integer.
-	 *
-	 * @param baseAddress
-	 *            The address as a long.
-	 * @return the address as an int.
-	 * @throws IllegalArgumentException
-	 *             if the value is outside the unsigned 32-bit integer range.
-	 */
-	static int convert(long baseAddress) {
-		if (baseAddress < 0 || baseAddress > MAX_ADDR) {
-			throw new IllegalArgumentException(
-					"address must be in 32-bit unsigned integer range");
-		}
-		return (int) baseAddress;
-	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -554,7 +554,9 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *
 	 * @param p
 	 *            the processor ID to get the user<sub>1</sub> address for
-	 * @return The address for user<sub>1</sub> register for this processor
+	 * @return The address for user<sub>1</sub> register for this processor;
+	 *         this will be in System RAM and be accessible from any core of the
+	 *         chip.
 	 */
 	@ParallelSafe
 	default MemoryLocation getUser1RegisterAddress(int p) {
@@ -567,7 +569,9 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *
 	 * @param processor
 	 *            the processor to get the user<sub>1</sub> address for
-	 * @return The address for user<sub>1</sub> register for this processor
+	 * @return The address for user<sub>1</sub> register for this processor;
+	 *         this will be in System RAM and be accessible from any core of the
+	 *         chip.
 	 */
 	@ParallelSafe
 	default MemoryLocation getUser1RegisterAddress(Processor processor) {
@@ -582,7 +586,9 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 * @param core
 	 *            the coordinates of the core to get the user<sub>2</sub>
 	 *            address for
-	 * @return The address for user<sub>2</sub> register for this processor
+	 * @return The address for user<sub>2</sub> register for this processor;
+	 *         this will be in System RAM and be accessible from any core of the
+	 *         chip.
 	 */
 	@ParallelSafe
 	default MemoryLocation getUser2RegisterAddress(HasCoreLocation core) {
@@ -1579,7 +1585,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	}
 
 	/**
-	 * Write to the SDRAM on the board.
+	 * Write to the SDRAM (or System RAM) on the board.
 	 *
 	 * @param core
 	 *            The coordinates of the core where the memory is that is to be
@@ -1670,7 +1676,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	}
 
 	/**
-	 * Write to the SDRAM on the board.
+	 * Write to the SDRAM (or System RAM) on the board.
 	 *
 	 * @param core
 	 *            The coordinates of the core where the memory is that is to be
@@ -1689,6 +1695,60 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	@ParallelSafe
 	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			ByteBuffer data) throws IOException, ProcessException;
+
+	/**
+	 * Write to the user<sub>0</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core whose register is to be
+	 *            written to
+	 * @param value
+	 *            The word of data that is to be written.
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default void writeUser0(HasCoreLocation core, int value)
+			throws ProcessException, IOException {
+		writeMemory(core.getScampCore(), getUser0RegisterAddress(core), value);
+	}
+
+	/**
+	 * Write to the user<sub>1</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core whose register is to be
+	 *            written to
+	 * @param value
+	 *            The word of data that is to be written.
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default void writeUser1(HasCoreLocation core, int value)
+			throws ProcessException, IOException {
+		writeMemory(core.getScampCore(), getUser1RegisterAddress(core), value);
+	}
+
+	/**
+	 * Write to the user<sub>2</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core whose register is to be
+	 *            written to
+	 * @param value
+	 *            The word of data that is to be written.
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default void writeUser2(HasCoreLocation core, int value)
+			throws ProcessException, IOException {
+		writeMemory(core.getScampCore(), getUser2RegisterAddress(core), value);
+	}
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
@@ -2154,7 +2214,7 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	}
 
 	/**
-	 * Read some areas of SDRAM from the board.
+	 * Read some areas of SDRAM (or System RAM) from the board.
 	 *
 	 * @param core
 	 *            The coordinates of the core where the memory is to be read
@@ -2222,6 +2282,57 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	void readRegion(BufferManagerStorage.Region region,
 			BufferManagerStorage storage)
 			throws IOException, ProcessException, StorageException;
+
+	/**
+	 * Read the user<sub>0</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core to read the register of
+	 * @return The contents of the register
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default int readUser0(HasCoreLocation core)
+			throws ProcessException, IOException {
+		MemoryLocation user0 = getUser0RegisterAddress(core);
+		return readMemory(core.getScampCore(), user0, WORD_SIZE).getInt();
+	}
+
+	/**
+	 * Read the user<sub>1</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core to read the register of
+	 * @return The contents of the register
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default int readUser1(HasCoreLocation core)
+			throws ProcessException, IOException {
+		MemoryLocation user1 = getUser1RegisterAddress(core);
+		return readMemory(core.getScampCore(), user1, WORD_SIZE).getInt();
+	}
+
+	/**
+	 * Read the user<sub>2</sub> register of a core.
+	 *
+	 * @param core
+	 *            The coordinates of the core to read the register of
+	 * @return The contents of the register
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 */
+	default int readUser2(HasCoreLocation core)
+			throws ProcessException, IOException {
+		MemoryLocation user2 = getUser2RegisterAddress(core);
+		return readMemory(core.getScampCore(), user2, WORD_SIZE).getInt();
+	}
 
 	/**
 	 * Read some areas of memory on a neighbouring chip using a LINK_READ SCP

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.UDPConnection;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.BMPConnectionData;
 
 /**
@@ -38,6 +39,9 @@ public abstract class Utils {
 	 * The size of buffer to allocate for SpiNNaker messages.
 	 */
 	private static final int SPINNAKER_MESSAGE_BUFFER_SIZE = 300;
+
+	private static final MemoryLocation CPU_INFO =
+			new MemoryLocation(CPU_INFO_OFFSET);
 
 	private Utils() {
 	}
@@ -69,8 +73,8 @@ public abstract class Utils {
 	 *            The core number
 	 * @return the address
 	 */
-	public static int getVcpuAddress(int p) {
-		return CPU_INFO_OFFSET + (CPU_INFO_BYTES * p);
+	public static MemoryLocation getVcpuAddress(int p) {
+		return CPU_INFO.add(CPU_INFO_BYTES * p);
 	}
 
 	/**
@@ -80,8 +84,8 @@ public abstract class Utils {
 	 *            The core
 	 * @return the address
 	 */
-	public static int getVcpuAddress(HasCoreLocation core) {
-		return CPU_INFO_OFFSET + (CPU_INFO_BYTES * core.getP());
+	public static MemoryLocation getVcpuAddress(HasCoreLocation core) {
+		return CPU_INFO.add(CPU_INFO_BYTES * core.getP());
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Utils.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.spinnaker.transceiver;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.Constants.CPU_INFO_BYTES;
-import static uk.ac.manchester.spinnaker.messages.Constants.CPU_INFO_OFFSET;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.CPU_INFO;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -39,9 +39,6 @@ public abstract class Utils {
 	 * The size of buffer to allocate for SpiNNaker messages.
 	 */
 	private static final int SPINNAKER_MESSAGE_BUFFER_SIZE = 300;
-
-	private static final MemoryLocation CPU_INFO =
-			new MemoryLocation(CPU_INFO_OFFSET);
 
 	private Utils() {
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryFloodProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryFloodProcess.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.FloodFillData;
 import uk.ac.manchester.spinnaker.messages.scp.FloodFillEnd;
 import uk.ac.manchester.spinnaker.messages.scp.FloodFillStart;
@@ -70,8 +71,8 @@ class WriteMemoryFloodProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(byte nearestNeighbourID, int baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
+			ByteBuffer data) throws IOException, ProcessException {
 		data = data.asReadOnlyBuffer();
 		int numBytes = data.remaining();
 		synchronousCall(
@@ -86,7 +87,7 @@ class WriteMemoryFloodProcess extends MultiConnectionProcess<SCPConnection> {
 					baseAddress, tmp));
 			blockID++;
 			numBytes -= chunk;
-			baseAddress += chunk;
+			baseAddress = baseAddress.add(chunk);
 			data.position(data.position() + chunk);
 		}
 		finish();
@@ -114,7 +115,7 @@ class WriteMemoryFloodProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(byte nearestNeighbourID, int baseAddress,
+	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
 			throws IOException, ProcessException {
 		synchronousCall(
@@ -133,7 +134,7 @@ class WriteMemoryFloodProcess extends MultiConnectionProcess<SCPConnection> {
 					baseAddress, buffer, 0, chunk));
 			blockID++;
 			numBytes -= chunk;
-			baseAddress += chunk;
+			baseAddress = baseAddress.add(chunk);
 		}
 		finish();
 		checkForError();
@@ -155,8 +156,8 @@ class WriteMemoryFloodProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(byte nearestNeighbourID, int baseAddress, File dataFile)
-			throws IOException, ProcessException {
+	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
+			File dataFile) throws IOException, ProcessException {
 		try (InputStream s =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
 			writeMemory(nearestNeighbourID, baseAddress, s,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
@@ -34,6 +34,7 @@ import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.WriteLink;
@@ -89,7 +90,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 		 *            The block of data to write with this message.
 		 * @return The message to send.
 		 */
-		T getMessage(int baseAddress, ByteBuffer data);
+		T getMessage(MemoryLocation baseAddress, ByteBuffer data);
 	}
 
 	/**
@@ -112,7 +113,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
-			int baseAddress, ByteBuffer data)
+			MemoryLocation baseAddress, ByteBuffer data)
 			throws IOException, ProcessException {
 		writeMemoryFlow(baseAddress, data, (addr, bytes) -> new WriteLink(core,
 				linkDirection, addr, bytes));
@@ -138,7 +139,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
-			int baseAddress, InputStream data, int bytesToWrite)
+			MemoryLocation baseAddress, InputStream data, int bytesToWrite)
 			throws IOException, ProcessException {
 		writeMemoryFlow(baseAddress, data, bytesToWrite, (addr,
 				bytes) -> new WriteLink(core, linkDirection, addr, bytes));
@@ -163,7 +164,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
-			int baseAddress, File dataFile)
+			MemoryLocation baseAddress, File dataFile)
 			throws IOException, ProcessException {
 		try (InputStream data =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
@@ -189,8 +190,8 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(HasCoreLocation core, int baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			ByteBuffer data) throws IOException, ProcessException {
 		writeMemoryFlow(baseAddress, data,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -212,8 +213,9 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(HasCoreLocation core, int baseAddress, InputStream data,
-			int bytesToWrite) throws IOException, ProcessException {
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			InputStream data, int bytesToWrite)
+			throws IOException, ProcessException {
 		writeMemoryFlow(baseAddress, data, bytesToWrite,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -234,8 +236,8 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
 	 */
-	void writeMemory(HasCoreLocation core, int baseAddress, File dataFile)
-			throws IOException, ProcessException {
+	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
+			File dataFile) throws IOException, ProcessException {
 		try (InputStream data =
 				new BufferedInputStream(new FileInputStream(dataFile))) {
 			writeMemoryFlow(baseAddress, data, (int) dataFile.length(),
@@ -260,11 +262,12 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
-			int baseAddress, ByteBuffer data, MessageProvider<T> msgProvider)
+			MemoryLocation baseAddress, ByteBuffer data,
+			MessageProvider<T> msgProvider)
 			throws IOException, ProcessException {
 		int offset = data.position();
 		int bytesToWrite = data.remaining();
-		int writePosition = baseAddress;
+		MemoryLocation writePosition = baseAddress;
 		while (bytesToWrite > 0) {
 			int bytesToSend = min(bytesToWrite, UDP_MESSAGE_MAX_SIZE);
 			ByteBuffer tmp = data.asReadOnlyBuffer();
@@ -272,7 +275,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 			tmp.limit(offset + bytesToSend);
 			sendRequest(msgProvider.getMessage(writePosition, tmp));
 			offset += bytesToSend;
-			writePosition += bytesToSend;
+			writePosition = writePosition.add(bytesToSend);
 			bytesToWrite -= bytesToSend;
 		}
 		finish();
@@ -298,10 +301,10 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 	 *             If SpiNNaker rejects a message.
 	 */
 	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
-			int baseAddress, InputStream data, int bytesToWrite,
+			MemoryLocation baseAddress, InputStream data, int bytesToWrite,
 			MessageProvider<T> msgProvider)
 			throws IOException, ProcessException {
-		int writePosition = baseAddress;
+		MemoryLocation writePosition = baseAddress;
 		ByteBuffer workingBuffer = allocate(UDP_MESSAGE_MAX_SIZE);
 		while (bytesToWrite > 0) {
 			int bytesToSend = min(bytesToWrite, UDP_MESSAGE_MAX_SIZE);
@@ -312,7 +315,7 @@ class WriteMemoryProcess extends MultiConnectionProcess<SCPConnection> {
 			}
 			tmp.limit(bytesToSend);
 			sendRequest(msgProvider.getMessage(writePosition, tmp));
-			writePosition += bytesToSend;
+			writePosition = writePosition.add(bytesToSend);
 			bytesToWrite -= bytesToSend;
 		}
 		finish();

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -24,6 +24,7 @@ import static uk.ac.manchester.spinnaker.machine.Direction.EAST;
 import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.BUFFERED_SDRAM_START;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import testconfig.BoardTestConfiguration;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion.Response;
 import uk.ac.manchester.spinnaker.messages.scp.ReadLink;
@@ -76,14 +76,13 @@ public class TestUDPConnection {
 		assertEquals(scpResponse.result, RC_OK);
 	}
 
-	private static final MemoryLocation ADDR = new MemoryLocation(0x70000000);
-
 	private static final int LINK_SIZE = 250;
 
 	@Test
 	public void testSCPReadLinkWithBoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
-		ReadLink scpReq = new ReadLink(ZERO_CHIP, EAST, ADDR, LINK_SIZE);
+		ReadLink scpReq =
+				new ReadLink(ZERO_CHIP, EAST, BUFFERED_SDRAM_START, LINK_SIZE);
 		scpReq.scpRequestHeader.issueSequenceNumber(emptySet());
 		SCPResultMessage result;
 		try (SCPConnection connection =
@@ -102,7 +101,8 @@ public class TestUDPConnection {
 	public void testSCPReadMemoryWithBoard() throws Exception {
 		boardConfig.setUpRemoteBoard();
 		ReadMemory scpReq =
-				new ReadMemory(ZERO_CHIP, ADDR, UDP_MESSAGE_MAX_SIZE);
+				new ReadMemory(ZERO_CHIP, BUFFERED_SDRAM_START,
+						UDP_MESSAGE_MAX_SIZE);
 		scpReq.scpRequestHeader.issueSequenceNumber(emptySet());
 		SCPResultMessage result;
 		try (SCPConnection connection =

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static uk.ac.manchester.spinnaker.machine.Direction.EAST;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
 
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import testconfig.BoardTestConfiguration;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion.Response;
 import uk.ac.manchester.spinnaker.messages.scp.ReadLink;
@@ -74,7 +76,7 @@ public class TestUDPConnection {
 		assertEquals(scpResponse.result, RC_OK);
 	}
 
-	private static final int ADDR = 0x70000000;
+	private static final MemoryLocation ADDR = new MemoryLocation(0x70000000);
 
 	private static final int LINK_SIZE = 250;
 
@@ -123,7 +125,7 @@ public class TestUDPConnection {
 			try (SCPConnection connection =
 					new SCPConnection(boardConfig.remotehost)) {
 				ReadMemory scp =
-						new ReadMemory(ZERO_CHIP, 0, UDP_MESSAGE_MAX_SIZE);
+						new ReadMemory(ZERO_CHIP, NULL, UDP_MESSAGE_MAX_SIZE);
 				scp.scpRequestHeader.issueSequenceNumber(emptySet());
 				connection.send(scp);
 				connection.receiveSCPResponse(2);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestSCPMessageAssembly.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestSCPMessageAssembly.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.spinnaker.messages.scp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.ac.manchester.spinnaker.machine.Direction.EAST;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_VER;
 
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class TestSCPMessageAssembly {
 
 	@Test
 	void testCreateNewLinkSCPPacket() {
-		ReadLink scp = new ReadLink(ZERO_CORE, EAST, 0, 252);
+		ReadLink scp = new ReadLink(ZERO_CORE, EAST, NULL, 252);
 		assertEquals(0, scp.argument1);
 		assertEquals(252, scp.argument2);
 		assertEquals(0, scp.argument3);
@@ -55,7 +56,7 @@ class TestSCPMessageAssembly {
 
 	@Test
 	void testCreateNewMemorySCPPacket() {
-		ReadMemory scp = new ReadMemory(ZERO_CORE, 0, 252);
+		ReadMemory scp = new ReadMemory(ZERO_CORE, NULL, 252);
 		assertEquals(0, scp.argument1);
 		assertEquals(252, scp.argument2);
 		assertEquals(2, scp.argument3);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static testconfig.BoardTestConfiguration.NOHOST;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.FIVE;
-import static uk.ac.manchester.spinnaker.messages.Constants.SYSTEM_VARIABLE_BASE_ADDRESS;
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.software_watchdog_count;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.SYS_VARS;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
 import java.io.IOException;
@@ -222,9 +222,7 @@ class TestTransceiver {
 					MockWriteTransceiver.Write write =
 							txrx.writtenMemory.get(writeItem++);
 					assertEquals(chip.getScampCore(), write.core);
-					assertEquals(
-							new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS
-									+ software_watchdog_count.offset),
+					assertEquals(SYS_VARS.add(software_watchdog_count.offset),
 							write.address);
 					assertArrayEquals(expectedData, write.data);
 				}

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -57,6 +57,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.machine.MachineDimensions;
 import uk.ac.manchester.spinnaker.machine.MachineVersion;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.VirtualMachine;
 import uk.ac.manchester.spinnaker.utils.InetFactory;
 
@@ -222,8 +223,8 @@ class TestTransceiver {
 							txrx.writtenMemory.get(writeItem++);
 					assertEquals(chip.getScampCore(), write.core);
 					assertEquals(
-							SYSTEM_VARIABLE_BASE_ADDRESS
-									+ software_watchdog_count.offset,
+							new MemoryLocation(SYSTEM_VARIABLE_BASE_ADDRESS
+									+ software_watchdog_count.offset),
 							write.address);
 					assertArrayEquals(expectedData, write.data);
 				}
@@ -266,13 +267,14 @@ class MockWriteTransceiver extends Transceiver {
 
 		final byte[] data;
 
-		final int address;
+		final MemoryLocation address;
 
 		final int offset;
 
 		final int numBytes;
 
-		Write(HasCoreLocation core, int baseAddress, ByteBuffer data) {
+		Write(HasCoreLocation core, MemoryLocation baseAddress,
+				ByteBuffer data) {
 			this.core = core.asCoreLocation();
 			this.address = baseAddress;
 			this.data = data.array().clone();
@@ -308,7 +310,7 @@ class MockWriteTransceiver extends Transceiver {
 	}
 
 	@Override
-	public void writeMemory(HasCoreLocation core, int baseAddress,
+	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			ByteBuffer data) {
 		writtenMemory.add(new Write(core, baseAddress, data));
 	}

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -73,6 +73,7 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.CoreSubsets;
 import uk.ac.manchester.spinnaker.machine.Machine;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.MulticastRoutingEntry;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
@@ -189,7 +190,7 @@ public class TransceiverITCase {
 	private static final ChipLocation SCAMP = ZERO_ZERO;
 
 	/** Where we like to read and write when testing. */
-	private static final int MEM = 0x70000000;
+	private static final MemoryLocation MEM = new MemoryLocation(0x70000000);
 
 	private void boardReady(Transceiver txrx) throws Exception {
 		VersionInfo versionInfo = txrx.ensureBoardIsReady();

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TransceiverITCase.java
@@ -47,6 +47,7 @@ import static uk.ac.manchester.spinnaker.messages.model.DiagnosticFilter.PacketT
 import static uk.ac.manchester.spinnaker.messages.model.RouterDiagnostics.RouterRegister.EXT_PP;
 import static uk.ac.manchester.spinnaker.messages.model.RouterDiagnostics.RouterRegister.LOC_PP;
 import static uk.ac.manchester.spinnaker.messages.model.Signal.STOP;
+import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.BUFFERED_SDRAM_START;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -190,7 +191,7 @@ public class TransceiverITCase {
 	private static final ChipLocation SCAMP = ZERO_ZERO;
 
 	/** Where we like to read and write when testing. */
-	private static final MemoryLocation MEM = new MemoryLocation(0x70000000);
+	private static final MemoryLocation MEM = BUFFERED_SDRAM_START;
 
 	private void boardReady(Transceiver txrx) throws Exception {
 		VersionInfo versionInfo = txrx.ensureBoardIsReady();

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
@@ -201,6 +201,10 @@ public class Executor implements Closeable {
 		buffer.putInt(DSE_VERSION);
 	}
 
+	private static void putAddress(MemoryLocation loc, ByteBuffer buf) {
+		buf.putInt(loc == null ? 0 : loc.address);
+	}
+
 	/**
 	 * Get the pointer table stored in a buffer.
 	 *
@@ -211,7 +215,7 @@ public class Executor implements Closeable {
 		assert buffer.order() == LITTLE_ENDIAN;
 		for (MemoryRegion reg : memRegions) {
 			if (reg != null) {
-				buffer.putInt(reg.getRegionBase().address);
+				putAddress(reg.getRegionBase(), buffer);
 				if (reg instanceof MemoryRegionReal) {
 					// Work out the checksum
 					MemoryRegionReal regReal = (MemoryRegionReal) reg;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
@@ -201,10 +201,6 @@ public class Executor implements Closeable {
 		buffer.putInt(DSE_VERSION);
 	}
 
-	private static void putAddress(MemoryLocation loc, ByteBuffer buf) {
-		buf.putInt(loc == null ? 0 : loc.address);
-	}
-
 	/**
 	 * Get the pointer table stored in a buffer.
 	 *
@@ -215,7 +211,7 @@ public class Executor implements Closeable {
 		assert buffer.order() == LITTLE_ENDIAN;
 		for (MemoryRegion reg : memRegions) {
 			if (reg != null) {
-				putAddress(reg.getRegionBase(), buffer);
+				buffer.putInt(reg.getRegionBase().address);
 				if (reg instanceof MemoryRegionReal) {
 					// Work out the checksum
 					MemoryRegionReal regReal = (MemoryRegionReal) reg;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Executor.java
@@ -41,6 +41,8 @@ import java.util.Collection;
 
 import org.slf4j.Logger;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * Used to execute a SpiNNaker data specification language file to produce a
  * memory image.
@@ -176,12 +178,12 @@ public class Executor implements Closeable {
 	 *
 	 * @param startAddress The base address to set.
 	 */
-	public void setBaseAddress(int startAddress) {
+	public void setBaseAddress(MemoryLocation startAddress) {
 		int nextOffset = APP_PTR_TABLE_BYTE_SIZE;
 		for (MemoryRegion reg : memRegions) {
 			if (reg instanceof MemoryRegionReal) {
 				MemoryRegionReal r = (MemoryRegionReal) reg;
-				r.setRegionBase(nextOffset + startAddress);
+				r.setRegionBase(startAddress.add(nextOffset));
 				nextOffset += r.getAllocatedSize();
 			}
 		}
@@ -209,7 +211,7 @@ public class Executor implements Closeable {
 		assert buffer.order() == LITTLE_ENDIAN;
 		for (MemoryRegion reg : memRegions) {
 			if (reg != null) {
-				buffer.putInt(reg.getRegionBase());
+				buffer.putInt(reg.getRegionBase().address);
 				if (reg instanceof MemoryRegionReal) {
 					// Work out the checksum
 					MemoryRegionReal regReal = (MemoryRegionReal) reg;

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Functions.java
@@ -237,11 +237,11 @@ class Functions implements FunctionAPI {
 							+ " (inclusive)");
 		}
 		if (!referenceable) {
-			memRegions.set(new MemoryRegionReal(region, 0, unfilled, size));
+			memRegions.set(new MemoryRegionReal(region, unfilled, size));
 		} else {
-			int reference = spec.getInt();
+			Reference reference = new Reference(spec.getInt());
 			memRegions.set(
-					new MemoryRegionReal(region, 0, unfilled, size, reference));
+					new MemoryRegionReal(region, unfilled, size, reference));
 			referenceableRegions.add(region);
 		}
 		spaceAllocated += size;
@@ -260,7 +260,7 @@ class Functions implements FunctionAPI {
 		if (!memRegions.isEmpty(region)) {
 			throw new RegionInUseException(region);
 		}
-		int reference = spec.getInt();
+		Reference reference = new Reference(spec.getInt());
 		memRegions.set(new MemoryRegionReference(region, reference));
 		regionsToFill.add(region);
 	}

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
@@ -16,12 +16,19 @@
  */
 package uk.ac.manchester.spinnaker.data_spec;
 
+import static java.util.Objects.requireNonNull;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
+
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
- * Marker of something that is a memory region.
+ * Marker of something that is a memory region. All memory regions have an
+ * address in memory where they start (which is only chosen late in the region
+ * creation process) and an index in the process's table of regions.
  */
 public abstract class MemoryRegion {
+	/** The base address of the region. Set after the fact. */
+	private MemoryLocation baseAddress = NULL;
 
 	/** @return the index of the memory region. */
 	public abstract int getIndex();
@@ -29,15 +36,21 @@ public abstract class MemoryRegion {
 	/**
 	 * Get the address of the first byte in the region.
 	 *
-	 * @return The address.
+	 * @return The address. Never {@code null}, but may be
+	 *         {@link MemoryLocation#NULL NULL} if not yet otherwise set.
 	 */
-	public abstract MemoryLocation getRegionBase();
+	public final MemoryLocation getRegionBase() {
+		return baseAddress;
+	}
 
 	/**
 	 * Set the address of the first byte in the region.
 	 *
 	 * @param baseAddress
-	 *            The address to set.
+	 *            The address to set. Must not be {@code null}.
 	 */
-	protected abstract void setRegionBase(MemoryLocation baseAddress);
+	public final void setRegionBase(MemoryLocation baseAddress) {
+		this.baseAddress =
+				requireNonNull(baseAddress, "base address must not be null");
+	}
 }

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegion.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.data_spec;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * Marker of something that is a memory region.
  */
@@ -29,7 +31,7 @@ public abstract class MemoryRegion {
 	 *
 	 * @return The address.
 	 */
-	public abstract int getRegionBase();
+	public abstract MemoryLocation getRegionBase();
 
 	/**
 	 * Set the address of the first byte in the region.
@@ -37,5 +39,5 @@ public abstract class MemoryRegion {
 	 * @param baseAddress
 	 *            The address to set.
 	 */
-	protected abstract void setRegionBase(int baseAddress);
+	protected abstract void setRegionBase(MemoryLocation baseAddress);
 }

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReal.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReal.java
@@ -20,8 +20,11 @@ import static java.lang.Math.max;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 
 import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * A memory region storage object.
@@ -47,7 +50,7 @@ public final class MemoryRegionReal extends MemoryRegion {
 	private boolean unfilled;
 
 	/** The base address of the region. Set after the fact. */
-	private int regionBaseAddress;
+	private MemoryLocation regionBaseAddress;
 
 	/** The index of the memory region. */
 	private final int index;
@@ -71,7 +74,7 @@ public final class MemoryRegionReal extends MemoryRegion {
 		this.index = index;
 		memPointer = memoryPointer;
 		maxWritePointer = 0;
-		regionBaseAddress = 0;
+		regionBaseAddress = NULL;
 		this.unfilled = unfilled;
 		reference = null;
 		buffer = allocate(size).order(LITTLE_ENDIAN);
@@ -96,7 +99,7 @@ public final class MemoryRegionReal extends MemoryRegion {
 		this.index = index;
 		memPointer = memoryPointer;
 		maxWritePointer = 0;
-		regionBaseAddress = 0;
+		regionBaseAddress = NULL;
 		this.unfilled = unfilled;
 		this.reference = reference;
 		buffer = allocate(size).order(LITTLE_ENDIAN);
@@ -160,12 +163,12 @@ public final class MemoryRegionReal extends MemoryRegion {
 	}
 
 	@Override
-	public int getRegionBase() {
+	public MemoryLocation getRegionBase() {
 		return regionBaseAddress;
 	}
 
 	@Override
-	protected void setRegionBase(int address) {
+	protected void setRegionBase(MemoryLocation address) {
 		regionBaseAddress = address;
 	}
 

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReal.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReal.java
@@ -20,11 +20,8 @@ import static java.lang.Math.max;
 import static java.nio.ByteBuffer.allocate;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
-import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 
 import java.nio.ByteBuffer;
-
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * A memory region storage object.
@@ -33,10 +30,6 @@ import uk.ac.manchester.spinnaker.machine.MemoryLocation;
  * of their fundamental object identity.
  */
 public final class MemoryRegionReal extends MemoryRegion {
-
-	/** The write pointer position, saying where the start of the block is. */
-	private int memPointer;
-
 	/** The maximum point where writes have happened up to within the region. */
 	private int maxWritePointer;
 
@@ -49,32 +42,25 @@ public final class MemoryRegionReal extends MemoryRegion {
 	 */
 	private boolean unfilled;
 
-	/** The base address of the region. Set after the fact. */
-	private MemoryLocation regionBaseAddress;
-
 	/** The index of the memory region. */
 	private final int index;
 
 	/** A reference for the region, {@code null} if none. */
-	private final Integer reference;
+	private final Reference reference;
 
 	/**
 	 * Create a memory region.
 	 *
 	 * @param index
 	 *            the index of the memory region
-	 * @param memoryPointer
-	 *            where the start of the block is
 	 * @param unfilled
 	 *            whether this is an unfilled region
 	 * @param size
 	 *            the allocated size of the memory region
 	 */
-	MemoryRegionReal(int index, int memoryPointer, boolean unfilled, int size) {
+	MemoryRegionReal(int index, boolean unfilled, int size) {
 		this.index = index;
-		memPointer = memoryPointer;
 		maxWritePointer = 0;
-		regionBaseAddress = NULL;
 		this.unfilled = unfilled;
 		reference = null;
 		buffer = allocate(size).order(LITTLE_ENDIAN);
@@ -85,8 +71,6 @@ public final class MemoryRegionReal extends MemoryRegion {
 	 *
 	 * @param index
 	 *            the index of the memory region
-	 * @param memoryPointer
-	 *            where the start of the block is
 	 * @param unfilled
 	 *            whether this is an unfilled region
 	 * @param size
@@ -94,19 +78,13 @@ public final class MemoryRegionReal extends MemoryRegion {
 	 * @param reference
 	 *            the reference of the memory region
 	 */
-	MemoryRegionReal(int index, int memoryPointer, boolean unfilled, int size,
-			int reference) {
+	MemoryRegionReal(int index, boolean unfilled, int size,
+			Reference reference) {
 		this.index = index;
-		memPointer = memoryPointer;
 		maxWritePointer = 0;
-		regionBaseAddress = NULL;
 		this.unfilled = unfilled;
-		this.reference = reference;
+		this.reference = requireNonNull(reference);
 		buffer = allocate(size).order(LITTLE_ENDIAN);
-	}
-
-	public int getMemoryPointer() {
-		return memPointer;
 	}
 
 	public int getAllocatedSize() {
@@ -162,16 +140,6 @@ public final class MemoryRegionReal extends MemoryRegion {
 		maxWritePointer = max(maxWritePointer, address);
 	}
 
-	@Override
-	public MemoryLocation getRegionBase() {
-		return regionBaseAddress;
-	}
-
-	@Override
-	protected void setRegionBase(MemoryLocation address) {
-		regionBaseAddress = address;
-	}
-
 	/**
 	 * Get the reference of the region.
 	 *
@@ -179,7 +147,7 @@ public final class MemoryRegionReal extends MemoryRegion {
 	 * @throws NullPointerException
 	 *             if there is no reference.
 	 */
-	public int getReference() {
-		return requireNonNull(reference, "no such reference").intValue();
+	public Reference getReference() {
+		return requireNonNull(reference, "no such reference");
 	}
 }

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReference.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReference.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.data_spec;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+
 /**
  * A reference to another region.
  */
@@ -27,7 +29,7 @@ public final class MemoryRegionReference extends MemoryRegion {
 	private final int reference;
 
 	/** The base address of the actual region referenced. */
-	private int baseAddress;
+	private MemoryLocation baseAddress;
 
 	/**
 	 * Create a reference to another region.
@@ -53,12 +55,12 @@ public final class MemoryRegionReference extends MemoryRegion {
 	}
 
 	@Override
-	public void setRegionBase(int baseAddress) {
+	public void setRegionBase(MemoryLocation baseAddress) {
 		this.baseAddress = baseAddress;
 	}
 
 	@Override
-	public int getRegionBase() {
+	public MemoryLocation getRegionBase() {
 		return baseAddress;
 	}
 

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReference.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/MemoryRegionReference.java
@@ -16,7 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.data_spec;
 
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A reference to another region.
@@ -26,10 +26,7 @@ public final class MemoryRegionReference extends MemoryRegion {
 	private final int index;
 
 	/** The reference of the region. */
-	private final int reference;
-
-	/** The base address of the actual region referenced. */
-	private MemoryLocation baseAddress;
+	private final Reference reference;
 
 	/**
 	 * Create a reference to another region.
@@ -39,9 +36,9 @@ public final class MemoryRegionReference extends MemoryRegion {
 	 * @param reference
 	 *            The reference to make.
 	 */
-	MemoryRegionReference(int index, int reference) {
+	MemoryRegionReference(int index, Reference reference) {
 		this.index = index;
-		this.reference = reference;
+		this.reference = requireNonNull(reference);
 	}
 
 	@Override
@@ -50,23 +47,13 @@ public final class MemoryRegionReference extends MemoryRegion {
 	}
 
 	/** @return The reference of the region. */
-	public int getReference() {
+	public Reference getReference() {
 		return reference;
-	}
-
-	@Override
-	public void setRegionBase(MemoryLocation baseAddress) {
-		this.baseAddress = baseAddress;
-	}
-
-	@Override
-	public MemoryLocation getRegionBase() {
-		return baseAddress;
 	}
 
 	@Override
 	public String toString() {
 		return "MemoryRegionReference(index:" + index + ", reference:"
-			+ reference + ", Region Base:" + baseAddress + ")";
+			+ reference + ", Region Base:" + getRegionBase() + ")";
 	}
 }

--- a/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Reference.java
+++ b/SpiNNaker-data-specification/src/main/java/uk/ac/manchester/spinnaker/data_spec/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,27 +16,37 @@
  */
 package uk.ac.manchester.spinnaker.data_spec;
 
-import static org.junit.jupiter.api.Assertions.*;
+/**
+ * A reference handle to another region.
+ */
+public final class Reference {
+	/** The reference of the region. */
+	private final int ref;
 
-import org.junit.jupiter.api.Test;
+	/**
+	 * Create a reference to another region.
+	 *
+	 * @param index
+	 *            The index of this region.
+	 * @param reference
+	 *            The reference to make.
+	 */
+	Reference(int reference) {
+		ref = reference;
+	}
 
-class TestMemoryRegion {
+	@Override
+	public String toString() {
+		return Integer.toString(ref);
+	}
 
-	@Test
-	void test() {
-		MemoryRegionReal r = new MemoryRegionReal(77, false, 5);
-		assertEquals(77, r.getIndex());
-		assertEquals(5, r.getAllocatedSize());
-		assertFalse(r.isUnfilled());
-		assertEquals(5, r.getRemainingSpace());
-		assertEquals(0, r.getWritePointer());
-		r.writeIntoRegionData(new byte[] {
-			1, 2, 3, 4
-		});
-		assertEquals(77, r.getIndex());
-		assertEquals(5, r.getAllocatedSize());
-		assertFalse(r.isUnfilled());
-		assertEquals(1, r.getRemainingSpace());
-		assertEquals(4, r.getWritePointer());
+	@Override
+	public int hashCode() {
+		return ref;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return (other instanceof Reference) && ((Reference) other).ref == ref;
 	}
 }

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
@@ -116,7 +116,7 @@ public class TestDataSpecExecutor {
 		MemoryRegion reg4 = executor.getRegion(4);
 		assertTrue(reg4 instanceof MemoryRegionReference);
 		MemoryRegionReference region4 = (MemoryRegionReference) reg4;
-		assertEquals(region4.getReference(), 2);
+		assertEquals(region4.getReference(), new Reference(2));
 
 		// Test referencing
 		assertArrayEquals(executor.getReferenceableRegions().toArray(),

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestDataSpecExecutor.java
@@ -19,12 +19,18 @@ package uk.ac.manchester.spinnaker.data_spec;
 import static java.io.File.createTempFile;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.stream.IntStream.range;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.ac.manchester.spinnaker.data_spec.Constants.APPDATA_MAGIC_NUM;
 import static uk.ac.manchester.spinnaker.data_spec.Constants.DSE_VERSION;
 import static uk.ac.manchester.spinnaker.data_spec.Constants.MAX_MEM_REGIONS;
 import static uk.ac.manchester.spinnaker.data_spec.Generator.makeSpec;
 import static uk.ac.manchester.spinnaker.data_spec.Generator.makeSpecStream;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,7 +42,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestDataSpecExecutor {
-
 	@Test
 	void testSimpleSpec() throws IOException, DataSpecificationException {
 		ByteBuffer spec = makeSpec(s -> {
@@ -124,7 +129,7 @@ public class TestDataSpecExecutor {
 
 		// Test the pointer table
 		ByteBuffer buffer = ByteBuffer.allocate(4096).order(LITTLE_ENDIAN);
-		executor.setBaseAddress(0);
+		executor.setBaseAddress(NULL);
 		executor.addPointerTable(buffer);
 		IntBuffer table = ((ByteBuffer) buffer.flip()).asIntBuffer();
 		assertEquals(MAX_MEM_REGIONS * 3, table.limit());

--- a/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
+++ b/SpiNNaker-data-specification/src/test/java/uk/ac/manchester/spinnaker/data_spec/TestMemoryRegionCollection.java
@@ -45,7 +45,7 @@ class TestMemoryRegionCollection {
 		assertEquals(1, c.size());
 		assertFalse(c.isEmpty());
 		assertTrue(new MemoryRegionCollection(0).isEmpty());
-		MemoryRegionReal mr = new MemoryRegionReal(0, 123, false, 5);
+		MemoryRegionReal mr = new MemoryRegionReal(0, false, 5);
 		c.set(mr);
 		assertThrows(RegionInUseException.class, () -> c.set(mr));
 		assertFalse(c.isEmpty(0));
@@ -69,8 +69,8 @@ class TestMemoryRegionCollection {
 	@Test
 	void testMultiRegions() throws RegionInUseException {
 		MemoryRegionCollection c = new MemoryRegionCollection(6);
-		MemoryRegionReal mr1 = new MemoryRegionReal(2, 123, true, 5);
-		MemoryRegionReal mr2 = new MemoryRegionReal(4, 123, false, 7);
+		MemoryRegionReal mr1 = new MemoryRegionReal(2, true, 5);
+		MemoryRegionReal mr2 = new MemoryRegionReal(4, false, 7);
 		c.set(mr1);
 		c.set(mr2);
 		assertTrue(c.needsToWriteRegion(1));
@@ -81,7 +81,7 @@ class TestMemoryRegionCollection {
 			null, null, mr1, null, mr2, null, null
 		}, c.toArray(new Object[7]));
 		assertFalse(c.containsAll(Arrays.asList(mr1, mr2,
-				new MemoryRegionReal(5, 123, true, 123))));
+				new MemoryRegionReal(5, true, 123))));
 		assertThrows(IllegalArgumentException.class,
 				() -> c.needsToWriteRegion(6));
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
@@ -18,6 +18,7 @@ package uk.ac.manchester.spinnaker.front_end.download;
 
 import static java.util.Collections.synchronizedMap;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -147,7 +148,7 @@ class BufferedReceivingData {
 					location.asCoreLocation());
 		}
 		storage.appendRecordingContents(
-				new Region(location, location.region, 0, 0), data);
+				new Region(location, location.region, NULL, 0), data);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
@@ -37,6 +37,7 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.RegionLocation;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
 import uk.ac.manchester.spinnaker.storage.StorageException;
@@ -188,17 +189,17 @@ public class DataReceiver extends BoardLocalSupport {
 		return value >= 0 && value <= MAX_UINT;
 	}
 
-	private void readSomeData(RegionLocation location, long address,
+	private void readSomeData(RegionLocation location, MemoryLocation address,
 			long length)
 			throws IOException, StorageException, ProcessException {
-		if (!is32bit(address) || !is32bit(length)) {
+		if (!is32bit(length)) {
 			throw new IllegalArgumentException("non-32-bit argument");
 		}
 		if (log.isDebugEnabled()) {
 			log.debug("< Reading {} bytes from {} at {}", length, location,
 					address);
 		}
-		ByteBuffer data = requestData(location, (int) address, (int) length);
+		ByteBuffer data = requestData(location, address, (int) length);
 		receivedData.flushingDataFromRegion(location, data);
 	}
 
@@ -215,8 +216,9 @@ public class DataReceiver extends BoardLocalSupport {
 	 * @throws IOException
 	 *             if communications fail
 	 */
-	private ByteBuffer requestData(HasCoreLocation location, long address,
-			int length) throws IOException, ProcessException {
+	private ByteBuffer requestData(HasCoreLocation location,
+			MemoryLocation address, int length)
+			throws IOException, ProcessException {
 		if (length < 1) {
 			// Crazy negative lengths get an exception
 			return allocate(length);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import uk.ac.manchester.spinnaker.connections.SDPConnection;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 
@@ -88,8 +89,8 @@ final class GatherDownloadConnection extends SDPConnection {
 	 * @throws IOException
 	 *             If message sending fails.
 	 */
-	void sendStart(CoreLocation extraMonitorCore, int address, int length,
-			int transactionId) throws IOException {
+	void sendStart(CoreLocation extraMonitorCore, MemoryLocation address,
+			int length, int transactionId) throws IOException {
 		sendMsg(StartSendingMessage.create(extraMonitorCore, address, length,
 				transactionId));
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -16,8 +16,6 @@
  */
 package uk.ac.manchester.spinnaker.front_end.download;
 
-import static java.lang.Integer.toUnsignedLong;
-import static java.lang.Long.toHexString;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
@@ -124,7 +122,7 @@ public class RecordingRegionDataGatherer extends DataGatherer
 				index, region);
 		List<Region> regionPieces = new ArrayList<>(1);
 		if (region.size > 0) {
-			regionPieces.add(new Region(placement, index, (int) region.data,
+			regionPieces.add(new Region(placement, index, region.data,
 					(int) region.size));
 		}
 		return regionPieces;
@@ -132,15 +130,14 @@ public class RecordingRegionDataGatherer extends DataGatherer
 
 	@Override
 	protected void storeData(Region r, ByteBuffer data) {
-		String addr = toHexString(toUnsignedLong(r.startAddress));
 		if (data == null) {
-			log.warn("failed to download data for {} R:{} from 0x{}:{}", r.core,
-					r.regionIndex, addr, r.size);
+			log.warn("failed to download data for {} R:{} from {}:{}", r.core,
+					r.regionIndex, r.startAddress, r.size);
 			return;
 		}
 		dbWorker.execute(() -> {
-			log.info("storing region data for {} R:{} from 0x{} as {} bytes",
-					r.core, r.regionIndex, addr, data.remaining());
+			log.info("storing region data for {} R:{} from {} as {} bytes",
+					r.core, r.regionIndex, r.startAddress, data.remaining());
 			try {
 				database.appendRecordingContents(r, data);
 				numWrites++;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/StartSendingMessage.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/StartSendingMessage.java
@@ -25,6 +25,7 @@ import static uk.ac.manchester.spinnaker.messages.sdp.SDPPort.EXTRA_MONITOR_CORE
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * A message used to request fast data transfer from SpiNNaker to Host.
@@ -46,13 +47,13 @@ public final class StartSendingMessage extends GatherProtocolMessage {
 	 *            the transaction ID needed
 	 * @return The created message.
 	 */
-	static StartSendingMessage create(HasCoreLocation destination, int address,
-			int length, int transactionId) {
+	static StartSendingMessage create(HasCoreLocation destination,
+			MemoryLocation address, int length, int transactionId) {
 		ByteBuffer payload =
 				allocate(NUM_WORDS * WORD_SIZE).order(LITTLE_ENDIAN);
 		payload.putInt(START_SENDING_DATA.value);
 		payload.putInt(transactionId);
-		payload.putInt(address);
+		payload.putInt(address.address);
 		payload.putInt(length);
 		payload.flip();
 		return new StartSendingMessage(destination, payload);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
@@ -18,7 +18,6 @@ package uk.ac.manchester.spinnaker.front_end.download.request;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.OBJECT;
 import static java.util.Collections.unmodifiableList;
-import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
@@ -127,8 +125,7 @@ public class Gather implements HasCoreLocation {
 	 */
 	public void updateTransactionIdFromMachine(Transceiver txrx)
 			throws IOException, ProcessException {
-		MemoryLocation address = txrx.getUser1RegisterAddress(this);
-		transactionId = txrx.readMemory(this, address, WORD_SIZE).getInt();
+		transactionId = txrx.readUser1(this);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
@@ -126,7 +127,7 @@ public class Gather implements HasCoreLocation {
 	 */
 	public void updateTransactionIdFromMachine(Transceiver txrx)
 			throws IOException, ProcessException {
-		int address = txrx.getUser1RegisterAddress(this);
+		MemoryLocation address = txrx.getUser1RegisterAddress(this);
 		transactionId = txrx.readMemory(this, address, WORD_SIZE).getInt();
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 
@@ -124,7 +125,7 @@ public class Monitor implements HasCoreLocation {
 	 */
 	public void updateTransactionIdFromMachine(Transceiver txrx)
 			throws IOException, ProcessException {
-		int address = txrx.getUser1RegisterAddress(this);
+		MemoryLocation address = txrx.getUser1RegisterAddress(this);
 		transactionId = txrx.readMemory(this, address, WORD_SIZE).getInt();
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
@@ -19,7 +19,6 @@ package uk.ac.manchester.spinnaker.front_end.download.request;
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.OBJECT;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
-import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
-import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 
@@ -125,8 +123,7 @@ public class Monitor implements HasCoreLocation {
 	 */
 	public void updateTransactionIdFromMachine(Transceiver txrx)
 			throws IOException, ProcessException {
-		MemoryLocation address = txrx.getUser1RegisterAddress(this);
-		transactionId = txrx.readMemory(this, address, WORD_SIZE).getInt();
+		transactionId = txrx.readUser1(this);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Vertex.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Vertex.java
@@ -17,8 +17,12 @@
 package uk.ac.manchester.spinnaker.front_end.download.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.OBJECT;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * Vertex recording region information.
@@ -41,6 +45,17 @@ public class Vertex {
 	 * buffers).
 	 */
 	private final long recordingRegionBaseAddress;
+
+	/**
+	 * Address at which to find recording metadata. This was allocated during
+	 * data specification execution, and contains a description of <i>all</i>
+	 * the recording regions owned by a vertex (it may well have several, e.g.,
+	 * spikes and voltages). This points to a structure that includes the
+	 * addresses of the per-region metadata, and those point in turn to the
+	 * actual buffers used to do the recording (which are <i>circular</i>
+	 * buffers).
+	 */
+	private final MemoryLocation base;
 
 	/** The IDs of the regions recording. */
 	private final int[] recordedRegionIds;
@@ -65,6 +80,7 @@ public class Vertex {
 		this.label = label;
 		this.recordingRegionBaseAddress = recordingRegionBaseAddress;
 		this.recordedRegionIds = recordedRegionIds;
+		this.base = new MemoryLocation(recordingRegionBaseAddress);
 	}
 
 	/**
@@ -85,6 +101,16 @@ public class Vertex {
 	 */
 	public long getBaseAddress() {
 		return recordingRegionBaseAddress;
+	}
+
+	/**
+	 * Get the recording region base address.
+	 *
+	 * @return the base address of the recording region
+	 */
+	@JsonIgnore
+	public MemoryLocation getBase() {
+		return base;
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecutionContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecutionContext.java
@@ -33,6 +33,7 @@ import uk.ac.manchester.spinnaker.data_spec.MemoryRegionReal;
 import uk.ac.manchester.spinnaker.data_spec.MemoryRegionReference;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 
@@ -71,7 +72,7 @@ class ExecutionContext implements AutoCloseable {
 	 * @throws IOException
 	 *             If there's a problem with I/O.
 	 */
-	void execute(Executor executor, CoreLocation core, int start)
+	void execute(Executor executor, CoreLocation core, MemoryLocation start)
 			throws DataSpecificationException, ProcessException, IOException {
 		executor.execute();
 		executor.setBaseAddress(start);
@@ -85,7 +86,8 @@ class ExecutionContext implements AutoCloseable {
 	}
 
 	private CoreToFill linkRegionReferences(Executor executor,
-			CoreLocation core, int start) throws DataSpecificationException {
+			CoreLocation core, MemoryLocation start)
+			throws DataSpecificationException {
 		for (int region : executor.getReferenceableRegions()) {
 			MemoryRegionReal r = (MemoryRegionReal) executor.getRegion(region);
 			int ref = r.getReference();
@@ -118,7 +120,7 @@ class ExecutionContext implements AutoCloseable {
 	}
 
 	private void writeHeader(HasCoreLocation core, Executor executor,
-			int startAddress) throws IOException, ProcessException {
+			MemoryLocation startAddress) throws IOException, ProcessException {
 		ByteBuffer b = allocate(APP_PTR_TABLE_BYTE_SIZE)
 				.order(LITTLE_ENDIAN);
 
@@ -193,9 +195,9 @@ class ExecutionContext implements AutoCloseable {
 	private static class RegionToRef {
 		final CoreLocation core;
 
-		final int pointer;
+		final MemoryLocation pointer;
 
-		RegionToRef(CoreLocation core, int pointer) {
+		RegionToRef(CoreLocation core, MemoryLocation pointer) {
 			this.core = core;
 			this.pointer = pointer;
 		}
@@ -210,13 +212,13 @@ class ExecutionContext implements AutoCloseable {
 	private static class CoreToFill {
 		final Executor executor;
 
-		final int start;
+		final MemoryLocation start;
 
 		final CoreLocation core;
 
 		final List<MemoryRegionReference> refs = new ArrayList<>();
 
-		CoreToFill(Executor executor, int start, CoreLocation core) {
+		CoreToFill(Executor executor, MemoryLocation start, CoreLocation core) {
 			this.executor = executor;
 			this.start = start;
 			this.core = core;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInProtocol.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastDataInProtocol.java
@@ -36,6 +36,7 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 
@@ -119,13 +120,13 @@ class FastDataInProtocol {
 	 *            The transaction id of this stream.
 	 * @return The message indicating the start of the data.
 	 */
-	SDPMessage dataToLocation(int baseAddress, int numPackets,
+	SDPMessage dataToLocation(MemoryLocation baseAddress, int numPackets,
 			int transactionId) {
 		ByteBuffer payload =
 				allocate(BYTES_FOR_LOCATION_PACKET).order(LITTLE_ENDIAN);
 		payload.putInt(SEND_DATA_TO_LOCATION.value);
 		payload.putInt(transactionId);
-		payload.putInt(baseAddress);
+		payload.putInt(baseAddress.address);
 		payload.putShort((short) boardLocalDestination.getY());
 		payload.putShort((short) boardLocalDestination.getX());
 		payload.putInt(numPackets - 1);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -249,8 +249,7 @@ public class FastExecuteDataSpecification extends BoardLocalSupport
 					new HashMap<CoreToLoad, MemoryLocation>();
 			for (CoreToLoad ctl : cores) {
 				MemoryLocation start = malloc(ctl, ctl.sizeToWrite);
-				MemoryLocation user0 = txrx.getUser0RegisterAddress(ctl.core);
-				txrx.writeMemory(ctl.core.getScampCore(), user0, start.address);
+				txrx.writeUser0(ctl.core, start.address);
 				addresses.put(ctl, start);
 			}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
@@ -17,7 +17,6 @@
 package uk.ac.manchester.spinnaker.front_end.dse;
 
 import static java.lang.Integer.toUnsignedLong;
-import static java.lang.Long.toHexString;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.front_end.Constants.CORE_DATA_SDRAM_BASE_TAG;
 import static uk.ac.manchester.spinnaker.front_end.Constants.PARALLEL_SIZE;
@@ -38,6 +37,7 @@ import uk.ac.manchester.spinnaker.front_end.BoardLocalSupport;
 import uk.ac.manchester.spinnaker.front_end.Progress;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.storage.ConnectionProvider;
 import uk.ac.manchester.spinnaker.storage.DSEStorage;
@@ -293,14 +293,13 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 								+ board.ethernetAddress + ")",
 						e);
 			}
-			int start = malloc(ctl, ctl.sizeToWrite);
+			MemoryLocation start = malloc(ctl, ctl.sizeToWrite);
 			try (Executor executor =
 					new Executor(ds, machine.getChipAt(ctl.core).sdram)) {
 				context.execute(executor, ctl.core, start);
 				int size = executor.getConstructedDataSize();
-				log.info("loading data onto {} ({} bytes at 0x{})",
-						ctl.core.asChipLocation(), toUnsignedLong(size),
-						toHexString(toUnsignedLong(start)));
+				log.info("loading data onto {} ({} bytes at {})",
+						ctl.core.asChipLocation(), toUnsignedLong(size), start);
 				int written = APP_PTR_TABLE_BYTE_SIZE;
 
 				for (MemoryRegion reg : executor.regions()) {
@@ -310,8 +309,8 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 					}
 				}
 
-				int user0 = txrx.getUser0RegisterAddress(ctl.core);
-				txrx.writeMemory(ctl.core.getScampCore(), user0, start);
+				MemoryLocation user0 = txrx.getUser0RegisterAddress(ctl.core);
+				txrx.writeMemory(ctl.core.getScampCore(), user0, start.address);
 				bar.update();
 				storage.saveLoadingMetadata(ctl, start, size, written);
 			} catch (DataSpecificationException e) {
@@ -323,7 +322,7 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 			}
 		}
 
-		private int malloc(CoreToLoad ctl, int bytesUsed)
+		private MemoryLocation malloc(CoreToLoad ctl, int bytesUsed)
 				throws IOException, ProcessException {
 			return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed,
 					new AppID(ctl.appID),
@@ -347,7 +346,8 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 		 *             If SCAMP rejects the request.
 		 */
 		private int writeRegion(HasCoreLocation core, MemoryRegionReal region,
-				int baseAddress) throws IOException, ProcessException {
+				MemoryLocation baseAddress)
+				throws IOException, ProcessException {
 			ByteBuffer data = region.getRegionData().duplicate();
 
 			data.flip();

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
@@ -309,8 +309,7 @@ public class HostExecuteDataSpecification extends BoardLocalSupport
 					}
 				}
 
-				MemoryLocation user0 = txrx.getUser0RegisterAddress(ctl.core);
-				txrx.writeMemory(ctl.core.getScampCore(), user0, start.address);
+				txrx.writeUser0(ctl.core, start.address);
 				bar.update();
 				storage.saveLoadingMetadata(ctl, start, size, written);
 			} catch (DataSpecificationException e) {

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
@@ -26,6 +26,9 @@ import static java.lang.String.format;
  * @author Donal Fellows
  */
 public final class MemoryLocation implements Comparable<MemoryLocation> {
+	/** Number of bytes in a SpiNNaker (ARM) word. */
+	private static final int WORD_SIZE = 4;
+
 	/** The zero memory location. Often means "no actual address". */
 	public static final MemoryLocation NULL = new MemoryLocation(0);
 
@@ -57,6 +60,20 @@ public final class MemoryLocation implements Comparable<MemoryLocation> {
 
 	public boolean isNull() {
 		return address == 0;
+	}
+
+	/**
+	 * How many bytes is this location's address above a word-aligned address?
+	 *
+	 * @return The number of bytes offset.
+	 */
+	public int subWordAlignment() {
+		return address % WORD_SIZE;
+	}
+
+	/** @return Whether this is a word-aligned location. */
+	public boolean isAligned() {
+		return subWordAlignment() == 0;
 	}
 
 	@Override

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.spinnaker.machine;
 
 import static java.lang.Integer.compareUnsigned;
+import static java.lang.String.format;
 
 /**
  * A location in SpiNNaker or BMP memory. Does not say which address space this
@@ -101,7 +102,8 @@ public final class MemoryLocation implements Comparable<MemoryLocation> {
 
 	@Override
 	public String toString() {
-		return "0x" + Integer.toHexString(address);
+		// Leading '0x' then exactly 8 hexadecimal characters; 10 chars total
+		return format("%#010x", address);
 	}
 
 	/** Maximum legal SpiNNaker address. It's a 32-bit machine. */

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/MemoryLocation.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.machine;
+
+import static java.lang.Integer.compareUnsigned;
+
+/**
+ * A location in SpiNNaker or BMP memory. Does not say which address space this
+ * is in.
+ *
+ * @author Donal Fellows
+ */
+public final class MemoryLocation implements Comparable<MemoryLocation> {
+	/** The zero memory location. Often means "no actual address". */
+	public static final MemoryLocation NULL = new MemoryLocation(0);
+
+	/** The actual location. */
+	public final int address;
+
+	public MemoryLocation(int address) {
+		this.address = address;
+	}
+
+	public MemoryLocation(long address) {
+		this.address = convert(address);
+	}
+
+	public MemoryLocation add(int offset) {
+		return new MemoryLocation(address + offset);
+	}
+
+	/**
+	 * Get the difference between this location and another.
+	 *
+	 * @param other
+	 *            The other location.
+	 * @return This location's address minus the other location's address.
+	 */
+	public int diff(MemoryLocation other) {
+		return address - other.address;
+	}
+
+	public boolean isNull() {
+		return address == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return address;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (!(other instanceof MemoryLocation)) {
+			return false;
+		}
+		MemoryLocation o = (MemoryLocation) other;
+		return o.address == address;
+	}
+
+	@Override
+	public int compareTo(MemoryLocation other) {
+		return compareUnsigned(address, other.address);
+	}
+
+	/**
+	 * Test if this location is less than another location.
+	 *
+	 * @param other
+	 *            The other location.
+	 * @return True if this location's address comes before.
+	 */
+	public boolean lessThan(MemoryLocation other) {
+		return compareTo(other) < 0;
+	}
+
+	/**
+	 * Test if this location is greater than another location.
+	 *
+	 * @param other
+	 *            The other location.
+	 * @return True if this location's address comes after.
+	 */
+	public boolean greaterThan(MemoryLocation other) {
+		return compareTo(other) > 0;
+	}
+
+	@Override
+	public String toString() {
+		return "0x" + Integer.toHexString(address);
+	}
+
+	/** Maximum legal SpiNNaker address. It's a 32-bit machine. */
+	private static final long MAX_ADDR = 0xFFFFFFFFL;
+
+	/**
+	 * Convert an address to a 32-bit integer.
+	 *
+	 * @param baseAddress
+	 *            The address as a long.
+	 * @return the address as an int.
+	 * @throws IllegalArgumentException
+	 *             if the value is outside the unsigned 32-bit integer range.
+	 */
+	private static int convert(long baseAddress) {
+		if (baseAddress < 0 || baseAddress > MAX_ADDR) {
+			throw new IllegalArgumentException(
+					"address must be in 32-bit unsigned integer range");
+		}
+		return (int) baseAddress;
+	}
+}

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -175,12 +175,12 @@ public interface BufferManagerStorage extends DatabaseAPI {
 				MemoryLocation startLocation, int size) {
 			this.core = core.asCoreLocation();
 			this.regionIndex = regionIndex;
-			this.realSize = size;
-			this.initialIgnore = startLocation.address % INT_SIZE;
+			realSize = size;
+			initialIgnore = startLocation.subWordAlignment();
 			size += initialIgnore;
-			this.startAddress = startLocation.add(-initialIgnore);
+			startAddress = startLocation.add(-initialIgnore);
 			// Looks weird, but works
-			this.finalIgnore = (INT_SIZE - (size % INT_SIZE)) % INT_SIZE;
+			finalIgnore = (INT_SIZE - (size % INT_SIZE)) % INT_SIZE;
 			size += finalIgnore;
 			this.size = size;
 		}

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * The interface supported by the storage system.
@@ -129,7 +130,7 @@ public interface BufferManagerStorage extends DatabaseAPI {
 		 * Where should the data be downloaded from? <em>This is not necessarily
 		 * the start of the region.</em>
 		 */
-		public final int startAddress;
+		public final MemoryLocation startAddress;
 
 		/**
 		 * How much data should be downloaded? <em>This is not necessarily the
@@ -163,22 +164,21 @@ public interface BufferManagerStorage extends DatabaseAPI {
 		 * @param regionIndex
 		 *            What was the index of the region in the table of regions
 		 *            for the core?
-		 * @param startAddress
+		 * @param startLocation
 		 *            Where should the data be downloaded from? <em>This is not
 		 *            necessarily the start of the region.</em>
 		 * @param size
 		 *            How much data should be downloaded? <em>This is not
 		 *            necessarily the size of the region.</em>
 		 */
-		public Region(HasCoreLocation core, int regionIndex, int startAddress,
-				int size) {
+		public Region(HasCoreLocation core, int regionIndex,
+				MemoryLocation startLocation, int size) {
 			this.core = core.asCoreLocation();
 			this.regionIndex = regionIndex;
 			this.realSize = size;
-			this.initialIgnore = startAddress % INT_SIZE;
-			startAddress -= initialIgnore;
+			this.initialIgnore = startLocation.address % INT_SIZE;
 			size += initialIgnore;
-			this.startAddress = startAddress;
+			this.startAddress = startLocation.add(-initialIgnore);
 			// Looks weird, but works
 			this.finalIgnore = (INT_SIZE - (size % INT_SIZE)) % INT_SIZE;
 			size += finalIgnore;

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/DSEStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/DSEStorage.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 
 /**
  * The interface supported by the DSE part of the storage system.
@@ -97,7 +98,7 @@ public interface DSEStorage extends DatabaseAPI {
 	 * @throws StorageException
 	 *             If the database access fails.
 	 */
-	void saveLoadingMetadata(CoreToLoad coreToLoad, int startAddress,
+	void saveLoadingMetadata(CoreToLoad coreToLoad, MemoryLocation startAddress,
 			int memoryUsed, int memoryWritten) throws StorageException;
 
 	/**

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
@@ -129,7 +129,7 @@ public class SQLiteBufferStorage
 			// core_id, local_region_index, address
 			s.setInt(FIRST, coreID);
 			s.setInt(SECOND, region.regionIndex);
-			s.setInt(THIRD, region.startAddress);
+			s.setInt(THIRD, region.startAddress.address);
 			s.executeUpdate();
 			try (ResultSet keys = s.getGeneratedKeys()) {
 				while (keys.next()) {

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteDataSpecStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteDataSpecStorage.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.storage.DSEDatabaseEngine;
 import uk.ac.manchester.spinnaker.storage.DSEStorage;
 import uk.ac.manchester.spinnaker.storage.StorageException;
@@ -205,19 +206,19 @@ public class SQLiteDataSpecStorage extends SQLiteConnectionManager<DSEStorage>
 	}
 
 	@Override
-	public void saveLoadingMetadata(CoreToLoad core, int startAddress,
+	public void saveLoadingMetadata(CoreToLoad core, MemoryLocation start,
 			int memoryUsed, int memoryWritten) throws StorageException {
 		callV(conn -> saveLoadingMetadata(conn, sanitise(core, "save metadata"),
-				startAddress, memoryUsed, memoryWritten),
+				start, memoryUsed, memoryWritten),
 				"saving data loading metadata");
 	}
 
 	private static void saveLoadingMetadata(Connection conn,
-			CoreToLoadImpl core, int startAddress, int memoryUsed,
+			CoreToLoadImpl core, MemoryLocation start, int memoryUsed,
 			int memoryWritten) throws SQLException {
 		try (PreparedStatement s =
 				conn.prepareStatement(ADD_LOADING_METADATA)) {
-			s.setInt(FIRST, startAddress);
+			s.setInt(FIRST, start.address);
 			s.setInt(SECOND, memoryUsed);
 			s.setInt(THIRD, memoryWritten);
 			s.setInt(FOURTH, core.id);

--- a/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
+++ b/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
@@ -22,6 +22,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -63,7 +64,7 @@ class TestSQLiteStorage {
 		assertEquals(emptyList(), storage.getCoresWithStorage());
 
 		BufferManagerStorage.Region rr =
-				new BufferManagerStorage.Region(core, 0, 0, 100);
+				new BufferManagerStorage.Region(core, 0, NULL, 100);
 		storage.appendRecordingContents(rr, bytes("def"));
 		assertArrayEquals("def".getBytes(UTF_8),
 				storage.getRecordingRegionContents(rr));
@@ -80,7 +81,7 @@ class TestSQLiteStorage {
 
 		// append creates
 		BufferManagerStorage.Region rr =
-				new BufferManagerStorage.Region(core, 1, 0, 100);
+				new BufferManagerStorage.Region(core, 1, NULL, 100);
 		storage.appendRecordingContents(rr, bytes("ab"));
 		storage.appendRecordingContents(rr, bytes("cd"));
 		storage.appendRecordingContents(rr, bytes("ef"));


### PR DESCRIPTION
There were too many methods in the transceiver still taking multiple `int`s as arguments despite there being many different meanings to them. Using a custom type for the memory location resolves that. It also gets rid of the signed/unsigned problem; it's a memory location! (Internally it uses standard unsigned handling methods when appropriate.)
