### PR TITLE
Quarantine the keycloak client

### DIFF
--- a/keycloak-management-client/src/main/java/uk/ac/manchester/spinnaker/tools/CredentialDB.java
+++ b/keycloak-management-client/src/main/java/uk/ac/manchester/spinnaker/tools/CredentialDB.java
@@ -77,6 +77,7 @@ public class CredentialDB implements AutoCloseable {
 
 		private final String pass;
 
+		/** Make an instance. */
 		DBContainedCredentials() throws SQLException, IllegalStateException {
 			try (var s = db.createStatement();
 					var rs = s.executeQuery(

--- a/keycloak-management-client/src/main/java/uk/ac/manchester/spinnaker/tools/EBRAINSDevCredentials.java
+++ b/keycloak-management-client/src/main/java/uk/ac/manchester/spinnaker/tools/EBRAINSDevCredentials.java
@@ -97,6 +97,7 @@ interface EBRAINSDevCredentials {
 	}
 }
 
+/** Utilities for {@link EBRAINSDevCredentials}. */
 abstract class EBRAINSDevCredentialsUtils {
 	private EBRAINSDevCredentialsUtils() {
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -887,14 +887,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			</build>
 		</profile>
 		<profile>
-			<!-- This module needs Java 11 to build at all. -->
 			<id>JDK11AndLater</id>
 			<activation>
 				<jdk>[1.11,)</jdk>
 			</activation>
-			<modules>
-				<module>keycloak-management-client</module>
-			</modules>
 			<build>
 				<pluginManagement>
 					<plugins>
@@ -909,6 +905,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 					</plugins>
 				</pluginManagement>
 			</build>
+		</profile>
+		<profile>
+			<!-- This module needs Java 11 to build at all. -->
+			<id>KeycloakClient</id>
+			<modules>
+				<module>keycloak-management-client</module>
+			</modules>
 		</profile>
 		<profile>
 			<id>JDK8</id>


### PR DESCRIPTION
It's just too nasty for Javadoc, with it claiming that the code uses modules when it doesn't and I don't understand why. That blocks publishing the docs, but since it is just for a tool that's really of not much use to anyone outside of very special circumstances, I don't mind that.

To build the keycloak client code as part of any main build, you'll need to select the additional profile `KeycloakClient` using normal Maven mechanisms.

Also, this PR add a few more doc comments to the keycloak client, since this might be the last time they get touched...
