### PR TITLE
Adjust dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "spalloc-server"
+    target-branch: "java-11-spalloc"
     labels:
       - "bug"
       - "dependabot"


### PR DESCRIPTION
`spalloc-server` branch is merged, but `java-11-spalloc` is relevant
