### PR TITLE
Add link to error prone docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 							<!-- This isn't modular so javadoc 14 gets snooty
 							<link>https://javaee.github.io/javaee-spec/javadocs/</link>
 							-->
+							<link>https://errorprone.info/api/latest/</link>
 						</links>
 						<notimestamp>true</notimestamp>
 						<additionalOptions>
@@ -990,6 +991,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<link>https://docs.spring.io/spring-boot/docs/current/api/</link>
 								<link>https://javaee.github.io/javaee-spec/javadocs/</link>
 								<link>https://cxf.apache.org/javadoc/latest-3.0.x/</link>
+								<link>https://errorprone.info/api/latest/</link>
 							</links>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
The annotations (e.g., `@Immutable`) now appear in our API in some places.
