### PR TITLE
Add in explicit dependency resolution step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,10 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
 
-    - name: Resolve Dependencies
-      run: mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
     - name: Compile
       run: mvn clean install --settings $SETTINGS_FILE -B -DskipTests=true -Dmaven.javadoc.skip=true -P "!jsp-precompile"
+    - name: Resolve Remaining Dependencies
+      run: mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
 
   test:
     needs: compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,7 @@ jobs:
       run: mvn clean install --settings $SETTINGS_FILE -B -DskipTests=true -Dmaven.javadoc.skip=true -P "!jsp-precompile"
     - name: Resolve Remaining Dependencies
       # Explicit get of error_prone_core because of MDEP-830
-      run: |
-        mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
-        mvn dependency:get --settings $SETTINGS_FILE -B -Dartifact=$EXTRA_ARTIFACT
-      env:
-        EXTRA_ARTIFACT: com.google.errorprone:error_prone_core:2.15.0
+      run: mvn dependency:resolve-plugins dependency:resolve dependency:get@fetch-error-prone --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
 
   test:
     needs: compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         cache: 'maven'
 
     - name: Resolve Dependencies
-      run: mvn dependency:resolve-plugin dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
+      run: mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
     - name: Compile
       run: mvn clean install --settings $SETTINGS_FILE -B -DskipTests=true -Dmaven.javadoc.skip=true -P "!jsp-precompile"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
 
+    - name: Resolve Dependencies
+      run: mvn dependency:resolve-plugin dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
     - name: Compile
       run: mvn clean install --settings $SETTINGS_FILE -B -DskipTests=true -Dmaven.javadoc.skip=true -P "!jsp-precompile"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,12 @@ jobs:
     - name: Compile
       run: mvn clean install --settings $SETTINGS_FILE -B -DskipTests=true -Dmaven.javadoc.skip=true -P "!jsp-precompile"
     - name: Resolve Remaining Dependencies
-      run: mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
+      # Explicit get of error_prone_core because of MDEP-830
+      run: |
+        mvn dependency:resolve-plugins dependency:resolve --settings $SETTINGS_FILE -B -P "CheckForFIXME,ErrorProne,KeycloakClient,devtools"
+        mvn dependency:get --settings $SETTINGS_FILE -B -Dartifact=$EXTRA_ARTIFACT
+      env:
+        EXTRA_ARTIFACT: com.google.errorprone:error_prone_core:2.15.0
 
   test:
     needs: compile

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<swagger.version>4.14.2</swagger.version>
 		<jsontaglib.version>1.0.5</jsontaglib.version>
 		<jython.version>2.7.3</jython.version>
-		<!-- When you update this, check .github/workflows/build.yml too -->
 		<error-prone.version>2.15.0</error-prone.version>
 	</properties>
 
@@ -1060,6 +1059,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						</plugin>
 					</plugins>
 				</pluginManagement>
+				<plugins>
+					<plugin>
+						<!-- Explicit get of error_prone_core because of MDEP-830 -->
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>fetch-error-prone</id>
+								<goals>
+									<goal>get</goal>
+								</goals>
+								<!-- This is NOT bound to a phase! -->
+								<configuration>
+									<groupId>com.google.errorprone</groupId>
+									<artifactId>error_prone_core</artifactId>
+									<version>${error-prone.version}</version>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
 			</build>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -555,26 +555,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.apache.sling</groupId>
 					<artifactId>jspc-maven-plugin</artifactId>
-					<!-- <version>2.3.0</version> -->
-					<!-- 2.3.2 is BROKEN, and we don't need it anyway -->
 					<version>2.3.4</version>
-					<!--
-					<dependencies>
-					-->
-						<!-- WHY ARE THESE NOT JUST PROVIDED BY DEFAULT?! -->
-					<!--
-						<dependency>
-							<groupId>org.apache.sling</groupId>
-							<artifactId>org.apache.sling.feature</artifactId>
-							<version>1.2.30</version>
-						</dependency>
-						<dependency>
-							<groupId>org.osgi</groupId>
-							<artifactId>org.osgi.framework</artifactId>
-							<version>1.10.0</version>
-						</dependency>
-					</dependencies>
-					-->
 				</plugin>
 				<plugin>
 					<groupId>org.apache.rat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<swagger.version>4.14.2</swagger.version>
 		<jsontaglib.version>1.0.5</jsontaglib.version>
 		<jython.version>2.7.3</jython.version>
+		<!-- When you update this, check .github/workflows/build.yml too -->
 		<error-prone.version>2.15.0</error-prone.version>
 	</properties>
 


### PR DESCRIPTION
The output in build logs when downloading dependencies is awful. This PR tries to put that all in its own build stage (in batch mode) so that that noise isn't spread everywhere. 

**TRICKY POINT:** extra maven profiles have to be activated when doing this so dependencies in those steps are also found.