### PR TITLE
Add InterruptedException to general transceiver operation profile

### DIFF
--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ClientSession.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ClientSession.java
@@ -517,7 +517,8 @@ final class ClientSession implements Session {
 				// Don't know what went wrong! Log might say
 				throw new IOException("undiagnosed connection failure");
 			}
-		} catch (IOException | InterruptedException | RuntimeException e) {
+		} catch (IOException | InterruptedException | RuntimeException
+				| Error e) {
 			throw e;
 		} catch (Exception e) {
 			throw new IOException("unexpected exception", e);

--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ClientUtils.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ClientUtils.java
@@ -36,19 +36,17 @@ abstract class ClientUtils {
 	 * @param timeout
 	 *            Timeout, in milliseconds.
 	 * @return The message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws SocketTimeoutException
 	 *             If a timeout happens.
 	 */
 	static ByteBuffer receiveHelper(BlockingQueue<ByteBuffer> received,
-			long timeout) throws SocketTimeoutException {
-		try {
-			var msg = received.poll(timeout, MILLISECONDS);
-			if (isNull(msg)) {
-				throw new SocketTimeoutException();
-			}
-			return msg;
-		} catch (InterruptedException e) {
+		long timeout) throws SocketTimeoutException, InterruptedException {
+		var msg = received.poll(timeout, MILLISECONDS);
+		if (isNull(msg)) {
 			throw new SocketTimeoutException();
 		}
+		return msg;
 	}
 }

--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedBootConnection.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedBootConnection.java
@@ -89,7 +89,7 @@ final class ProxiedBootConnection extends BootConnection {
 
 	@Override
 	protected ByteBuffer doReceive(int timeout)
-			throws IOException {
+			throws IOException, InterruptedException {
 		if (isClosed() && receiveQueue.isEmpty()) {
 			throw new EOFException("connection closed");
 		}

--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedEIEIOListenerConnection.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedEIEIOListenerConnection.java
@@ -82,7 +82,7 @@ final class ProxiedEIEIOListenerConnection extends EIEIOConnection {
 
 	@Override
 	protected ByteBuffer doReceive(int timeout)
-			throws IOException {
+			throws IOException, InterruptedException {
 		if (isClosed() && receiveQueue.isEmpty()) {
 			throw new EOFException("connection closed");
 		}

--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedSCPConnection.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedSCPConnection.java
@@ -91,7 +91,7 @@ final class ProxiedSCPConnection extends SCPConnection {
 
 	@Override
 	protected ByteBuffer doReceive(int timeout)
-			throws IOException {
+			throws IOException, InterruptedException {
 		if (isClosed() && receiveQueue.isEmpty()) {
 			throw new EOFException("connection closed");
 		}

--- a/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedTransceiver.java
+++ b/SpiNNaker-allocator/src/main/java/uk/ac/manchester/spinnaker/allocator/ProxiedTransceiver.java
@@ -36,12 +36,14 @@ final class ProxiedTransceiver extends Transceiver {
 	 *            The proxy handle.
 	 * @throws IOException
 	 *             If we couldn't finish setting up our networking.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws SpinnmanExcception
 	 *             If SpiNNaker rejects a message.
 	 */
 	ProxiedTransceiver(Collection<Connection> connections,
 			ProxyProtocolClient websocket)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		// Assume unwrapped
 		super(TRIAD_NO_WRAPAROUND, connections, null, null, null, null,
 				null);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
@@ -365,12 +365,13 @@ public class FirmwareLoader {
 		return s.slice().order(LITTLE_ENDIAN);
 	}
 
-	private ByteBuffer readFlashData() throws ProcessException, IOException {
+	private ByteBuffer readFlashData()
+			throws ProcessException, IOException, InterruptedException {
 		return txrx.readBMPMemory(board, FLASH_DATA_ADDRESS, FLASH_DATA_LENGTH);
 	}
 
 	private ByteBuffer readFlashDataHead()
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return txrx.readBMPMemory(board, FLASH_DATA_ADDRESS,
 				FLASH_DATA_LENGTH / 2);
 	}
@@ -401,7 +402,7 @@ public class FirmwareLoader {
 	}
 
 	private void updateFlashData(ByteBuffer data)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		data.putInt(CRC_OFFSET, ~crc(data, 0, CRC_OFFSET));
 		data.position(0);
 		var fb = txrx.getSerialFlashBuffer(board);
@@ -413,7 +414,8 @@ public class FirmwareLoader {
 		}
 	}
 
-	private void logBMPVersion() throws ProcessException, IOException {
+	private void logBMPVersion()
+			throws ProcessException, IOException, InterruptedException {
 		var info = txrx.readBMPVersion(board);
 		// TODO validate which field is which; some of these seem... unlikely
 		log.info("BMP INFO:       {}",
@@ -430,7 +432,8 @@ public class FirmwareLoader {
 	 * them separate for our use case and that avoids doing some network
 	 * traffic.
 	 */
-	private void listFPGABootChunks() throws ProcessException, IOException {
+	private void listFPGABootChunks()
+			throws ProcessException, IOException, InterruptedException {
 		var data = readFlashDataHead();
 		for (int i = 0; i < NUM_DATA_SECTORS; i++) {
 			var chunk = slice(data, DATA_SECTOR_CHUNK_SIZE * i,
@@ -514,12 +517,14 @@ public class FirmwareLoader {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 * @throws UpdateFailedException
 	 *             If the flash data sector read back does not match what we
 	 *             wanted to write.
 	 */
 	public void setupRegisters(RegisterSet... settings)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		var data = new ArrayList<Integer>();
 		for (var r : settings) {
 			data.add(r.address.address | r.fpga.value);
@@ -553,9 +558,11 @@ public class FirmwareLoader {
 	 * @throws UpdateFailedException
 	 *             If the flash data sector read back does not match what we
 	 *             wanted to write.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	public void setupBitfile(String handle, int slot, FPGA chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var resource = firmware.resource(handle);
 		int mtime = firmware.mtime(handle);
 		var name = resource.getFilename();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
@@ -140,7 +140,8 @@ class SpiNNaker1 implements SpiNNakerControl {
 	}
 
 	@PostConstruct
-	void initTransceiver() throws IOException, SpinnmanException {
+	void initTransceiver()
+			throws IOException, SpinnmanException, InterruptedException {
 		txrx = txrxFactory.getTransciever(machine, bmp);
 		txrx.bind(ROOT_BMP);
 	}
@@ -176,9 +177,11 @@ class SpiNNaker1 implements SpiNNakerControl {
 	 * @throws FPGAReloadRequired
 	 *             If the FPGA is in such a bad state that the FPGA definitions
 	 *             for the board need to be reloaded.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private boolean isGoodFPGA(BMPBoard board, FPGA fpga)
-			throws FPGAReloadRequired {
+			throws FPGAReloadRequired, InterruptedException {
 		int flag;
 		try {
 			flag = txrx.readFPGARegister(fpga, FLAG, board);
@@ -209,9 +212,11 @@ class SpiNNaker1 implements SpiNNakerControl {
 	 *             If a BMP rejects a message.
 	 * @throws IOException
 	 *             If network I/O fails.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private boolean canBoardManageFPGAs(BMPBoard board)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		var vi = txrx.readBMPVersion(board);
 		return vi.versionNumber.majorVersion >= BMP_VERSION_MIN;
 	}
@@ -223,7 +228,8 @@ class SpiNNaker1 implements SpiNNakerControl {
 	 * that link. We assume that the other end of the link also behaves.
 	 */
 	@Override
-	public void setLinkOff(Link link) throws ProcessException, IOException {
+	public void setLinkOff(Link link)
+			throws ProcessException, IOException, InterruptedException {
 		var board = requireNonNull(idToBoard.get(link.getBoard()));
 		var d = link.getLink();
 		// skip FPGA link configuration if old BMP version
@@ -242,9 +248,12 @@ class SpiNNaker1 implements SpiNNakerControl {
 	 * @throws FPGAReloadRequired
 	 *             If an FPGA is in such a bad state that the FPGA definitions
 	 *             for the board need to be reloaded.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 * @see #isGoodFPGA(Integer, FPGA)
 	 */
-	private boolean hasGoodFPGAs(BMPBoard board) throws FPGAReloadRequired {
+	private boolean hasGoodFPGAs(BMPBoard board)
+			throws FPGAReloadRequired, InterruptedException {
 		for (var fpga : FPGA.values()) {
 			if (fpga.isSingleFPGA() && !isGoodFPGA(board, fpga)) {
 				return false;
@@ -318,13 +327,13 @@ class SpiNNaker1 implements SpiNNakerControl {
 
 	@Override
 	public String readSerial(BMPBoard board)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return txrx.readBoardSerialNumber(board);
 	}
 
 	@Override
 	public Blacklist readBlacklist(BMPBoard board)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return txrx.readBlacklist(board);
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
@@ -69,8 +69,11 @@ public interface SpiNNakerControl {
 	 *             If a BMP rejects a message.
 	 * @throws IOException
 	 *             If network I/O fails.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	void setLinkOff(Link link) throws ProcessException, IOException;
+	void setLinkOff(Link link)
+			throws ProcessException, IOException, InterruptedException;
 
 	/**
 	 * Turn off boards managed by a BMP. Turning off a board also turns off its

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
@@ -120,10 +120,12 @@ public class TransceiverFactory
 
 	@Override
 	public BMPTransceiverInterface getTransciever(Machine machineDescription,
-			BMPCoords bmp) throws IOException, SpinnmanException {
+			BMPCoords bmp)
+			throws IOException, SpinnmanException, InterruptedException {
 		try {
 			synchronized (txrxMap) {
-				return txrxMap.computeIfAbsent(
+				return txrxMap
+						.computeIfAbsent(
 						new Key(machineDescription.getName(), bmp),
 						__ -> makeTransceiver(machineDescription, bmp));
 			}
@@ -133,6 +135,8 @@ public class TransceiverFactory
 				throw (IOException) t;
 			} else if (t instanceof SpinnmanException) {
 				throw (SpinnmanException) t;
+			} else if (t instanceof InterruptedException) {
+				throw (InterruptedException) t;
 			}
 			throw e;
 		}
@@ -160,7 +164,7 @@ public class TransceiverFactory
 			} else {
 				return makeTransceiver(connData);
 			}
-		} catch (IOException | SpinnmanException e) {
+		} catch (IOException | SpinnmanException | InterruptedException e) {
 			throw new TransceiverFactoryException(
 					"failed to build BMP transceiver", e);
 		}
@@ -192,9 +196,11 @@ public class TransceiverFactory
 	 *             If network access fails
 	 * @throws SpinnmanException
 	 *             If transceiver building fails
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private Transceiver makeTransceiver(BMPConnectionData data)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		int count = 0;
 		while (true) {
 			try {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactoryAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactoryAPI.java
@@ -46,7 +46,9 @@ public interface TransceiverFactoryAPI<T extends BMPTransceiverInterface> {
 	 *             If low-level things go wrong.
 	 * @throws SpinnmanException
 	 *             If the transceiver can't be built.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	T getTransciever(Machine machineDescription, BMPCoords bmp)
-			throws IOException, SpinnmanException;
+			throws IOException, SpinnmanException, InterruptedException;
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/ProxyUDPConnection.java
@@ -91,7 +91,8 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 	 *         socket timed out (not an error!)
 	 */
 	@Override
-	public Optional<ByteBuffer> receiveMessage(int timeout) throws IOException {
+	public Optional<ByteBuffer> receiveMessage(int timeout)
+			throws IOException, InterruptedException {
 		try {
 			// Raw buffer, including header bytes
 			var msg = receive(timeout);
@@ -167,13 +168,16 @@ public class ProxyUDPConnection extends UDPConnection<Optional<ByteBuffer>> {
 				e.addSuppressed(e1);
 			}
 			log.warn("problem in SpiNNaker-to-client part of {}", name, e);
+		} catch (InterruptedException e) {
+			// We've been interrupted, so we're done.
+			return;
 		} finally {
 			log.debug("shutting down listener {}", name);
 			me.setName(oldThreadName);
 		}
 	}
 
-	private void mainLoop() throws IOException {
+	private void mainLoop() throws IOException, InterruptedException {
 		while (session.isOpen() && !isClosed()) {
 			var msg = receiveMessage(TIMEOUT);
 			if (msg.isPresent()) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BMPConnection.java
@@ -95,12 +95,14 @@ public class BMPConnection extends UDPConnection<SDPMessage>
 	}
 
 	@Override
-	public SCPResultMessage receiveSCPResponse(int timeout) throws IOException {
+	public SCPResultMessage receiveSCPResponse(int timeout)
+			throws IOException, InterruptedException {
 		return new SCPResultMessage(receive(timeout));
 	}
 
 	@Override
-	public SDPMessage receiveMessage(int timeout) throws IOException {
+	public SDPMessage receiveMessage(int timeout)
+			throws IOException, InterruptedException {
 		return new SDPMessage(receive(timeout), true);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/BootConnection.java
@@ -98,7 +98,8 @@ public class BootConnection extends UDPConnection<BootMessage>
 	}
 
 	@Override
-	public BootMessage receiveMessage(int timeout) throws IOException {
+	public BootMessage receiveMessage(int timeout)
+			throws IOException, InterruptedException {
 		return new BootMessage(receive(timeout));
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/ConnectionListener.java
@@ -154,17 +154,16 @@ public class ConnectionListener<MessageType> extends Thread
 	 * @throws IOException
 	 *             If other things go wrong with the comms, or if the callbacks
 	 *             throw it.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	private void runStep() throws IOException {
+	private void runStep() throws IOException, InterruptedException {
 		var message = connection.receiveMessage(timeout);
 		for (var future : checkpointCallbacks().stream().map(
 				callback -> callbackPool.submit(() -> callback.handle(message)))
 				.collect(toList())) {
 			try {
 				future.get();
-			} catch (InterruptedException e) {
-				log.warn("unexpected exception; not waiting for the future", e);
-				break;
 			} catch (ExecutionException ee) {
 				try {
 					throw ee.getCause();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/DelegatingSCPConnection.java
@@ -71,7 +71,7 @@ public class DelegatingSCPConnection extends SCPConnection {
 
 	@Override
 	protected ByteBuffer doReceive(int timeout)
-			throws SocketTimeoutException, IOException {
+			throws SocketTimeoutException, IOException, InterruptedException {
 		return delegate.doReceive(timeout);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
@@ -161,8 +161,11 @@ public class EIEIOConnection
 	 * @return the command ID
 	 * @throws IOException
 	 *             If receiving fails.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	protected EIEIOCommand receiveCommand() throws IOException {
+	protected EIEIOCommand receiveCommand()
+			throws IOException, InterruptedException {
 		var msg = receiveMessage();
 		if (msg instanceof EIEIOCommandMessage) {
 			return ((EIEIOCommandMessage) msg).getHeader().command;
@@ -197,7 +200,7 @@ public class EIEIOConnection
 
 	@Override
 	public EIEIOMessage<? extends EIEIOHeader> receiveMessage(int timeout)
-			throws IOException {
+			throws IOException, InterruptedException {
 		var b = receive(timeout);
 		short header = b.getShort();
 		if ((header & MASK) == FLAG) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/NotificationConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/NotificationConnection.java
@@ -114,7 +114,8 @@ public class NotificationConnection
 	}
 
 	@Override
-	public NotificationMessage receiveMessage(int timeout) throws IOException {
+	public NotificationMessage receiveMessage(int timeout)
+			throws IOException, InterruptedException {
 		var b = receive(timeout);
 		return AbstractNotificationMessage.build(b);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -142,7 +142,7 @@ public class SCPConnection extends SDPConnection
 
 	@Override
 	public SCPResultMessage receiveSCPResponse(int timeout)
-			throws IOException {
+			throws IOException, InterruptedException {
 		return new SCPResultMessage(receive(timeout));
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SDPConnection.java
@@ -98,7 +98,7 @@ public class SDPConnection extends UDPConnection<SDPMessage>
 
 	@Override
 	public SDPMessage receiveMessage(int timeout)
-			throws IOException, InterruptedIOException {
+			throws IOException, InterruptedIOException, InterruptedException {
 		var buffer = receive(timeout);
 		buffer.getShort(); // SKIP TWO PADDING BYTES
 		return new SDPMessage(buffer, false);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/UDPConnection.java
@@ -339,9 +339,11 @@ public abstract class UDPConnection<T>
 	 *             If the connection is closed
 	 * @throws IOException
 	 *             If an error occurs receiving the data
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public final ByteBuffer receive(Integer timeout)
-			throws SocketTimeoutException, IOException {
+			throws SocketTimeoutException, IOException, InterruptedException {
 		if (timeout != null) {
 			return receive(convertTimeout(timeout));
 		}
@@ -367,9 +369,11 @@ public abstract class UDPConnection<T>
 	 *             If the connection is closed
 	 * @throws IOException
 	 *             If an error occurs receiving the data
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public final ByteBuffer receive(int timeout)
-			throws SocketTimeoutException, IOException {
+			throws SocketTimeoutException, IOException, InterruptedException {
 		if (isClosed()) {
 			throw new EOFException();
 		}
@@ -389,10 +393,12 @@ public abstract class UDPConnection<T>
 	 *             If a timeout occurs before any data is received
 	 * @throws IOException
 	 *             If an error occurs receiving the data
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@ForOverride
 	protected ByteBuffer doReceive(int timeout)
-			throws SocketTimeoutException, IOException {
+			throws SocketTimeoutException, IOException, InterruptedException {
 		socket.setSoTimeout(timeout);
 		var buffer = allocate(receivePacketSize);
 		var pkt = new DatagramPacket(buffer.array(), receivePacketSize);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/AsyncCommsTask.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/AsyncCommsTask.java
@@ -48,11 +48,13 @@ public interface AsyncCommsTask {
 	 *            and the exception caught while sending it.
 	 * @throws IOException
 	 *             If things go really wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted (prior to sending).
 	 */
 	<T extends CheckOKResponse> void sendRequest(SCPRequest<T> request,
 			Consumer<T> callback,
 			BiConsumer<SCPRequest<?>, Throwable> errorCallback)
-			throws IOException;
+			throws IOException, InterruptedException;
 
 	/**
 	 * Indicate the end of the packets to be sent. This must be called to ensure
@@ -60,8 +62,10 @@ public interface AsyncCommsTask {
 	 *
 	 * @throws IOException
 	 *             If anything goes wrong with communications.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	void finish() throws IOException;
+	void finish() throws IOException, InterruptedException;
 
 	/**
 	 * Send a one-way request.
@@ -73,7 +77,9 @@ public interface AsyncCommsTask {
 	 *            The one-way SCP request to be sent.
 	 * @throws IOException
 	 *             If things go really wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted (prior to sending).
 	 */
 	<T extends NoResponse> void sendOneWayRequest(SCPRequest<T> request)
-			throws IOException;
+			throws IOException, InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/AsyncCommsTask.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/AsyncCommsTask.java
@@ -17,9 +17,9 @@
 package uk.ac.manchester.spinnaker.connections.model;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import uk.ac.manchester.spinnaker.connections.SCPErrorHandler;
 import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
 import uk.ac.manchester.spinnaker.messages.scp.NoResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
@@ -44,13 +44,14 @@ public interface AsyncCommsTask {
 	 *            {@code null} if the response doesn't need to be processed.
 	 * @param errorCallback
 	 *            A callback function to call when an error is found when
-	 *            processing the message; takes the original SCPRequest, and the
-	 *            exception caught while sending it.
+	 *            processing the message; takes the original {@link SCPRequest},
+	 *            and the exception caught while sending it.
 	 * @throws IOException
 	 *             If things go really wrong.
 	 */
 	<T extends CheckOKResponse> void sendRequest(SCPRequest<T> request,
-			Consumer<T> callback, SCPErrorHandler errorCallback)
+			Consumer<T> callback,
+			BiConsumer<SCPRequest<?>, Throwable> errorCallback)
 			throws IOException;
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/MessageReceiver.java
@@ -38,10 +38,13 @@ public interface MessageReceiver<MessageType> extends SocketHolder {
 	 * @return the received message
 	 * @throws IOException
 	 *             If there is an error receiving the message
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalArgumentException
 	 *             If one of the fields of the SpiNNaker message is invalid
 	 */
-	default MessageType receiveMessage() throws IOException {
+	default MessageType receiveMessage()
+			throws IOException, InterruptedException {
 		return receiveMessage(0);
 	}
 
@@ -55,11 +58,14 @@ public interface MessageReceiver<MessageType> extends SocketHolder {
 	 * @return the received message
 	 * @throws IOException
 	 *             If there is an error receiving the message
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws SocketTimeoutException
 	 *             If there is a timeout during receiving
 	 * @throws IllegalArgumentException
 	 *             If one of the fields of the SpiNNaker message is invalid
 	 */
 	@UsedInJavadocOnly(SocketTimeoutException.class)
-	MessageType receiveMessage(int timeout) throws IOException;
+	MessageType receiveMessage(int timeout)
+			throws IOException, InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPErrorHandler.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPErrorHandler.java
@@ -14,7 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.connections;
+package uk.ac.manchester.spinnaker.connections.model;
+
+import java.util.function.BiConsumer;
 
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 
@@ -24,7 +26,8 @@ import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
  * @author Donal Fellows
  */
 @FunctionalInterface
-public interface SCPErrorHandler {
+public interface SCPErrorHandler extends BiConsumer<SCPRequest<?>, Throwable> {
+
 	/**
 	 * A callback function to call when an error is found when processing an SCP
 	 * message.
@@ -34,5 +37,7 @@ public interface SCPErrorHandler {
 	 * @param exception
 	 *            the exception caught while sending the request.
 	 */
-	void handleError(SCPRequest<?> request, Throwable exception);
+	default void handleError(SCPRequest<?> request, Throwable exception) {
+		this.accept(request, exception);
+	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/model/SCPReceiver.java
@@ -42,9 +42,11 @@ public interface SCPReceiver extends SocketHolder {
 	 *             If there is an error receiving the message
 	 * @throws SocketTimeoutException
 	 *             If there is a timeout before a message is received
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	default SCPResultMessage receiveSCPResponse(Integer timeout)
-			throws SocketTimeoutException, IOException {
+			throws SocketTimeoutException, IOException, InterruptedException {
 		return receiveSCPResponse(convertTimeout(timeout));
 	}
 
@@ -62,7 +64,9 @@ public interface SCPReceiver extends SocketHolder {
 	 *             If there is an error receiving the message
 	 * @throws SocketTimeoutException
 	 *             If there is a timeout before a message is received
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	SCPResultMessage receiveSCPResponse(int timeout)
-			throws SocketTimeoutException, IOException;
+			throws SocketTimeoutException, IOException, InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/BaseIO.java
@@ -85,8 +85,11 @@ abstract class BaseIO implements AbstractIO {
 	 *             If IO fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	abstract byte[] doRead(int numBytes) throws IOException, ProcessException;
+	abstract byte[] doRead(int numBytes)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Do the actual write.
@@ -101,9 +104,11 @@ abstract class BaseIO implements AbstractIO {
 	 *             If IO fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	abstract void doWrite(byte[] bytes, int start, int len)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Do the actual fill.
@@ -118,9 +123,11 @@ abstract class BaseIO implements AbstractIO {
 	 *             If IO fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	abstract void doFill(int value, FillDataType type, int len)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	private void inRange(int delta) throws EOFException {
 		var newAddr = current.add(delta);
@@ -130,7 +137,8 @@ abstract class BaseIO implements AbstractIO {
 	}
 
 	@Override
-	public byte[] read(Integer numBytes) throws IOException, ProcessException {
+	public byte[] read(Integer numBytes)
+			throws IOException, ProcessException, InterruptedException {
 		if (numBytes != null && numBytes == 0) {
 			return new byte[0];
 		}
@@ -143,7 +151,8 @@ abstract class BaseIO implements AbstractIO {
 	}
 
 	@Override
-	public int write(byte[] data) throws IOException, ProcessException {
+	public int write(byte[] data)
+			throws IOException, ProcessException, InterruptedException {
 		int n = data.length;
 		inRange(n);
 		doWrite(data, 0, n);
@@ -153,7 +162,7 @@ abstract class BaseIO implements AbstractIO {
 
 	@Override
 	public void fill(int value, Integer size, FillDataType type)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		int len = (size == null) ? end.diff(current) : size;
 		inRange(len);
 		if (len < 0 || len % type.size != 0) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/ChipMemoryIO.java
@@ -122,8 +122,11 @@ final class ChipMemoryIO {
 	 *             If the OS has a problem sending or receiving a message.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	void flushWriteBuffer() throws IOException, ProcessException {
+	void flushWriteBuffer()
+			throws IOException, ProcessException, InterruptedException {
 		if (writeBuffer.position() > 0) {
 			var t = hold;
 			if (t == null) {
@@ -146,9 +149,11 @@ final class ChipMemoryIO {
 	 *             If the OS has a problem sending or receiving a message.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setCurrentAddress(MemoryLocation address)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		flushWriteBuffer();
 		currentAddress = address;
 		writeAddress = address;
@@ -164,8 +169,11 @@ final class ChipMemoryIO {
 	 *             If the OS has a problem sending or receiving a message.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	byte[] read(int numBytes) throws IOException, ProcessException {
+	byte[] read(int numBytes)
+			throws IOException, ProcessException, InterruptedException {
 		if (numBytes == 0) {
 			return new byte[0];
 		}
@@ -188,8 +196,11 @@ final class ChipMemoryIO {
 	 *             If the OS has a problem sending or receiving a message.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	void write(byte[] data) throws IOException, ProcessException {
+	void write(byte[] data)
+			throws IOException, ProcessException, InterruptedException {
 		int numBytes = data.length;
 
 		var t = txrx();
@@ -228,9 +239,11 @@ final class ChipMemoryIO {
 	 *             If the OS has a problem sending or receiving a message.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void fill(int value, int size, FillDataType type)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var t = txrx();
 		flushWriteBuffer();
 		t.fillMemory(core, currentAddress, value, size, type);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/io/MemoryIO.java
@@ -57,7 +57,8 @@ public class MemoryIO extends BaseIO {
 	}
 
 	@Override
-	public void close() throws ProcessException, IOException {
+	public void close()
+			throws ProcessException, IOException, InterruptedException {
 		synchronized (io) {
 			io.flushWriteBuffer();
 		}
@@ -88,14 +89,16 @@ public class MemoryIO extends BaseIO {
 	}
 
 	@Override
-	public void flush() throws IOException, ProcessException {
+	public void flush()
+			throws IOException, ProcessException, InterruptedException {
 		synchronized (io) {
 			io.flushWriteBuffer();
 		}
 	}
 
 	@Override
-	byte[] doRead(int size) throws IOException, ProcessException {
+	byte[] doRead(int size)
+			throws IOException, ProcessException, InterruptedException {
 		synchronized (io) {
 			io.setCurrentAddress(current);
 			return io.read(size);
@@ -104,7 +107,7 @@ public class MemoryIO extends BaseIO {
 
 	@Override
 	void doWrite(byte[] data, int from, int len)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronized (io) {
 			io.setCurrentAddress(current);
 			io.write(data);
@@ -113,7 +116,7 @@ public class MemoryIO extends BaseIO {
 
 	@Override
 	void doFill(int value, FillDataType type, int len)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronized (io) {
 			io.setCurrentAddress(current);
 			io.fill(value, len, type);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocAPI.java
@@ -63,8 +63,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	default Version version() throws IOException, SpallocServerException {
+	default Version version()
+			throws IOException, SpallocServerException, InterruptedException {
 		return version(null);
 	}
 
@@ -81,9 +84,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	Version version(@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+	Version version(@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Create a job.
@@ -101,11 +107,13 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@Deprecated(forRemoval = true)
 	default int createJob(List<@PositiveOrZero Integer> args,
 			Map<@NotBlank String, @NotNull Object> kwargs)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return createJob(args, kwargs, null);
 	}
 
@@ -119,9 +127,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default int createJob(@Valid CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return createJob(builder, null);
 	}
 
@@ -140,10 +150,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	int createJob(@Valid CreateJob builder, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Create a job.
@@ -167,12 +179,15 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@Deprecated(forRemoval = true) // TODO remove this
 	int createJob(List<@PositiveOrZero Integer> args,
 			Map<@NotBlank String, @NotNull Object> kwargs,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Keep a job alive. Needs to be regularly called.
@@ -183,9 +198,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void jobKeepAlive(int jobID)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		jobKeepAlive(jobID, null);
 	}
 
@@ -203,9 +220,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	void jobKeepAlive(int jobID, @Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+	void jobKeepAlive(int jobID, @Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Get the state of a job.
@@ -217,9 +237,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default JobState getJobState(int jobID)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getJobState(jobID, null);
 	}
 
@@ -238,10 +260,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	JobState getJobState(int jobID, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Get information about a job's allocated machine.
@@ -253,9 +277,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default JobMachineInfo getJobMachineInfo(int jobID)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getJobMachineInfo(jobID, null);
 	}
 
@@ -274,10 +300,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	JobMachineInfo getJobMachineInfo(int jobID, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Turn on a job's allocated boards.
@@ -288,9 +316,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void powerOnJobBoards(int jobID)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		powerOnJobBoards(jobID, null);
 	}
 
@@ -308,10 +338,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void powerOnJobBoards(int jobID, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Turn off a job's allocated boards.
@@ -322,9 +354,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void powerOffJobBoards(int jobID)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		powerOffJobBoards(jobID, null);
 	}
 
@@ -342,10 +376,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void powerOffJobBoards(int jobID, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Destroy a job.
@@ -358,9 +394,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void destroyJob(int jobID, @NotBlank String reason)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		destroyJob(jobID, reason, null);
 	}
 
@@ -380,11 +418,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void destroyJob(int jobID, @NotBlank String reason,
 			@Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Enable or disable notifications of changes in job state.
@@ -399,9 +439,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void notifyJob(Integer jobID, boolean enable)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		notifyJob(jobID, enable, null);
 	}
 
@@ -423,10 +465,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void notifyJob(Integer jobID, boolean enable, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Enable or disable notifications of changes in machine state.
@@ -442,9 +486,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default void notifyMachine(String machineName, boolean enable)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		notifyMachine(machineName, enable, null);
 	}
 
@@ -467,11 +513,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void notifyMachine(String machineName, boolean enable,
 			@Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * List all jobs.
@@ -482,9 +530,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default List<JobDescription> listJobs()
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return listJobs(null);
 	}
 
@@ -502,9 +552,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	List<JobDescription> listJobs(@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+	List<JobDescription> listJobs(@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * List all known machines.
@@ -515,9 +568,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default List<Machine> listMachines()
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return listMachines(null);
 	}
 
@@ -535,9 +590,12 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	List<Machine> listMachines(@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+	List<Machine> listMachines(@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Get the physical location of a board.
@@ -552,10 +610,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardPhysicalCoordinates getBoardPosition(
 			@NotBlank String machineName, @Valid BoardCoordinates coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords, null);
 	}
 
@@ -572,10 +632,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardPhysicalCoordinates getBoardPosition(
 			@NotBlank String machineName, @Valid TriadCoords coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords, null);
 	}
 
@@ -597,11 +659,14 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardPhysicalCoordinates getBoardPosition(
 			@NotBlank String machineName, @Valid BoardCoordinates coords,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException {
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords.toStandardCoords(),
 				timeout);
 	}
@@ -624,11 +689,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	BoardPhysicalCoordinates getBoardPosition(@NotBlank String machineName,
 			@Valid TriadCoords coords, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Get the logical location of a board.
@@ -643,10 +710,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardCoordinates getBoardPosition(@NotBlank String machineName,
 			@Valid BoardPhysicalCoordinates coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords, null);
 	}
 
@@ -663,10 +732,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardCoordinates getBoardPosition(@NotBlank String machineName,
 			@Valid PhysicalCoords coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords, null);
 	}
 
@@ -688,11 +759,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default BoardCoordinates getBoardPosition(@NotBlank String machineName,
 			@Valid BoardPhysicalCoordinates coords, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException {
+			SpallocServerException, InterruptedException {
 		return getBoardPosition(machineName, coords.toStandardCoords(),
 				timeout);
 	}
@@ -715,11 +788,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	BoardCoordinates getBoardPosition(@NotBlank String machineName,
 			@Valid PhysicalCoords coords, @Positive Integer timeout)
 			throws IOException, SpallocProtocolTimeoutException,
-			SpallocServerException;
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Locate a chip within a job's allocation.
@@ -734,9 +809,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(int jobID, @Valid HasChipLocation chip)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(jobID, chip, null);
 	}
 
@@ -758,10 +835,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	WhereIs whereIs(int jobID, @Valid HasChipLocation chip,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Locate a chip within a machine.
@@ -776,10 +856,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid HasChipLocation chip)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(machine, chip, null);
 	}
 
@@ -801,10 +883,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	WhereIs whereIs(@NotBlank String machine, @Valid HasChipLocation chip,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Locate a board within a machine.
@@ -819,10 +904,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid BoardPhysicalCoordinates coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(machine, coords, null);
 	}
 
@@ -839,10 +926,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid PhysicalCoords coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(machine, coords, null);
 	}
 
@@ -864,11 +953,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid BoardPhysicalCoordinates coords, @Positive Integer timeout)
-			throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException {
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException {
 		return whereIs(machine, coords.toStandardCoords(), timeout);
 	}
 
@@ -890,10 +981,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	WhereIs whereIs(@NotBlank String machine, @Valid PhysicalCoords coords,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Locate a board within a machine.
@@ -908,10 +1002,12 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid BoardCoordinates coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(machine, coords, null);
 	}
 
@@ -928,9 +1024,11 @@ public interface SpallocAPI {
 	 *             if the server returns an exception response.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine, @Valid TriadCoords coords)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return whereIs(machine, coords, null);
 	}
 
@@ -952,11 +1050,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default WhereIs whereIs(@NotBlank String machine,
 			@Valid BoardCoordinates coords, @Positive Integer timeout)
-			throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException {
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException {
 		return whereIs(machine, coords.toStandardCoords(), timeout);
 	}
 
@@ -978,10 +1078,13 @@ public interface SpallocAPI {
 	 *             if the request times out.
 	 * @throws IOException
 	 *             if network communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	WhereIs whereIs(@NotBlank String machine, @Valid TriadCoords coords,
-			@Positive Integer timeout) throws IOException,
-			SpallocProtocolTimeoutException, SpallocServerException;
+			@Positive Integer timeout)
+			throws IOException, SpallocProtocolTimeoutException,
+			SpallocServerException, InterruptedException;
 
 	/**
 	 * Return the next notification to arrive. Waits indefinitely.
@@ -991,10 +1094,13 @@ public interface SpallocAPI {
 	 * @see MachinesChangedNotification
 	 * @throws SpallocProtocolException
 	 *             If the socket is unusable or becomes disconnected.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 * @throws RuntimeException
 	 *             If there is a timeout.
 	 */
-	default Notification waitForNotification() throws SpallocProtocolException {
+	default Notification waitForNotification()
+			throws SpallocProtocolException, InterruptedException {
 		try {
 			return waitForNotification(null);
 		} catch (SpallocProtocolTimeoutException e) {
@@ -1021,7 +1127,10 @@ public interface SpallocAPI {
 	 *             negative).
 	 * @throws SpallocProtocolException
 	 *             If the socket is unusable or becomes disconnected.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	Notification waitForNotification(Integer timeout)
-			throws SpallocProtocolException, SpallocProtocolTimeoutException;
+			throws SpallocProtocolException, SpallocProtocolTimeoutException,
+			InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocClient.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocClient.java
@@ -187,7 +187,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public Notification waitForNotification(Integer timeout)
-			throws SpallocProtocolException, SpallocProtocolTimeoutException {
+			throws SpallocProtocolException, SpallocProtocolTimeoutException,
+			InterruptedException {
 		// If we already have a notification, return it
 		var n = notifications.poll();
 		if (n != null) {
@@ -214,7 +215,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public Version version(Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(new VersionCommand(), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("version result: {}", result);
@@ -224,7 +225,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public int createJob(CreateJob builder, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(builder.build(), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("create result: {}", result);
@@ -235,7 +236,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 	@Deprecated(forRemoval = true) // TODO remove this
 	@Override
 	public int createJob(List<Integer> args, Map<String, Object> kwargs,
-			Integer timeout) throws IOException, SpallocServerException {
+			Integer timeout)
+			throws IOException, SpallocServerException, InterruptedException {
 		// If no owner, don't bother with the call
 		if (!kwargs.containsKey(USER_PROPERTY)) {
 			throw new SpallocServerException(
@@ -262,7 +264,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void jobKeepAlive(int jobID, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(new JobKeepAliveCommand(jobID), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("keepalive result: {}", result);
@@ -271,7 +273,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public JobState getJobState(int jobID, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new GetJobStateCommand(jobID), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("get-state result: {}", json);
@@ -281,7 +283,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public JobMachineInfo getJobMachineInfo(int jobID, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new GetJobMachineInfoCommand(jobID), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("get-info result: {}", json);
@@ -291,7 +293,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void powerOnJobBoards(int jobID, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(new PowerOnJobBoardsCommand(jobID), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("power-on result: {}", result);
@@ -300,7 +302,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void powerOffJobBoards(int jobID, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(new PowerOffJobBoardsCommand(jobID), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("power-off result: {}", result);
@@ -309,7 +311,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void destroyJob(int jobID, String reason, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = call(new DestroyJobCommand(jobID, reason), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("destroy result: {}", result);
@@ -318,7 +320,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void notifyJob(Integer jobID, boolean enable, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		Command<?> c;
 		if (enable) {
 			if (jobID == null) {
@@ -341,7 +343,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public void notifyMachine(String machineName, boolean enable,
-			Integer timeout) throws IOException, SpallocServerException {
+			Integer timeout)
+			throws IOException, SpallocServerException, InterruptedException {
 		Command<?> c;
 		if (enable) {
 			if (machineName == null) {
@@ -364,7 +367,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public List<JobDescription> listJobs(Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new ListJobsCommand(), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("list-jobs result: {}", json);
@@ -374,7 +377,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public List<Machine> listMachines(Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new ListMachinesCommand(), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("list-machines result: {}", json);
@@ -385,7 +388,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 	@Override
 	public BoardPhysicalCoordinates getBoardPosition(String machineName,
 			TriadCoords coords, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new GetBoardPositionCommand(machineName, coords),
 				timeout);
 		if (log.isDebugEnabled()) {
@@ -397,7 +400,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 	@Override
 	public BoardCoordinates getBoardPosition(String machineName,
 			PhysicalCoords coords, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new GetBoardAtPositionCommand(machineName, coords),
 				timeout);
 		if (log.isDebugEnabled()) {
@@ -408,7 +411,7 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public WhereIs whereIs(int jobID, HasChipLocation chip, Integer timeout)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new WhereIsJobChipCommand(jobID, chip), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("where-is result: {}", json);
@@ -418,7 +421,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public WhereIs whereIs(String machine, HasChipLocation chip,
-			Integer timeout) throws IOException, SpallocServerException {
+			Integer timeout)
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new WhereIsMachineChipCommand(machine, chip), timeout);
 		if (log.isDebugEnabled()) {
 			log.debug("where-is result: {}", json);
@@ -428,7 +432,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 
 	@Override
 	public WhereIs whereIs(String machine, PhysicalCoords coords,
-			Integer timeout) throws IOException, SpallocServerException {
+			Integer timeout)
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new WhereIsMachineBoardPhysicalCommand(machine, coords),
 				timeout);
 		if (log.isDebugEnabled()) {
@@ -438,8 +443,8 @@ public class SpallocClient extends SpallocConnection implements SpallocAPI {
 	}
 
 	@Override
-	public WhereIs whereIs(String machine, TriadCoords coords,
-			Integer timeout) throws IOException, SpallocServerException {
+	public WhereIs whereIs(String machine, TriadCoords coords, Integer timeout)
+			throws IOException, SpallocServerException, InterruptedException {
 		var json = call(new WhereIsMachineBoardLogicalCommand(machine, coords),
 				timeout);
 		if (log.isDebugEnabled()) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
@@ -505,18 +505,17 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	}
 
 	private void keepalive() {
-		while (!stopping) {
-			try {
+		try {
+			while (!stopping) {
 				client.jobKeepAlive(id, timeout);
 				if (!interrupted()) {
 					sleep(keepaliveTime / 2);
 				}
-			} catch (IOException | SpallocServerException e) {
-				log.debug("exception in keepalive; terminating", e);
-				stopping = true;
-			} catch (InterruptedException e) {
-				log.trace("interrupted in keepalive", e);
 			}
+		} catch (IOException | SpallocServerException e) {
+			log.debug("exception in keepalive; terminating", e);
+		} catch (InterruptedException e) {
+			log.trace("interrupted in keepalive", e);
 		}
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJob.java
@@ -194,10 +194,12 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	public SpallocJob(String hostname, Integer timeout, CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		this(hostname, config.getPort(), timeout, builder);
 	}
 
@@ -212,10 +214,12 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	public SpallocJob(String hostname, CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		this(hostname, config.getPort(), f2ms(config.getTimeout()), builder);
 	}
 
@@ -228,10 +232,12 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	public SpallocJob(CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		this(config.getHost(), config.getPort(), f2ms(config.getTimeout()),
 				builder);
 	}
@@ -249,9 +255,11 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws IllegalArgumentException
 	 *             If a bad builder is given.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	public SpallocJob(SpallocClient client, CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		this(client, f2ms(config.getTimeout()), builder);
 	}
 
@@ -268,11 +276,13 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 * @throws IllegalArgumentException
 	 *             If a bad builder is given.
 	 */
 	public SpallocJob(SpallocClient client, Integer timeout, CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		if (builder == null) {
 			throw new IllegalArgumentException("a builder must be specified");
 		}
@@ -305,6 +315,8 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 * @throws IllegalArgumentException
 	 *             If a bad builder is given.
 	 */
@@ -312,7 +324,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	@SuppressWarnings("MustBeClosed")
 	public SpallocJob(String hostname, Integer port, Integer timeout,
 			CreateJob builder)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		if (Objects.isNull(builder)) {
 			throw new IllegalArgumentException("a builder must be specified");
 		}
@@ -354,10 +366,12 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws JobDestroyedException
 	 *             If the job doesn't exist (any more).
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
-	public SpallocJob(int id)
-			throws IOException, SpallocServerException, JobDestroyedException {
+	public SpallocJob(int id) throws IOException, SpallocServerException,
+			JobDestroyedException, InterruptedException {
 		this(config.getHost(), config.getPort(), f2ms(config.getTimeout()), id);
 	}
 
@@ -374,10 +388,13 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws JobDestroyedException
 	 *             If the job doesn't exist (any more).
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	public SpallocJob(String hostname, int id)
-			throws IOException, SpallocServerException, JobDestroyedException {
+			throws IOException, SpallocServerException, JobDestroyedException,
+			InterruptedException {
 		this(hostname, config.getPort(), f2ms(config.getTimeout()), id);
 	}
 
@@ -396,10 +413,13 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws JobDestroyedException
 	 *             If the job doesn't exist (any more).
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	public SpallocJob(String hostname, Integer timeout, int id)
-			throws IOException, SpallocServerException, JobDestroyedException {
+			throws IOException, SpallocServerException, JobDestroyedException,
+			InterruptedException {
 		this(hostname, config.getPort(), timeout, id);
 	}
 
@@ -436,11 +456,14 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws JobDestroyedException
 	 *             If the job doesn't exist (any more).
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	@MustBeClosed
 	@SuppressWarnings("MustBeClosed")
 	public SpallocJob(String hostname, int port, Integer timeout, int id)
-			throws IOException, SpallocServerException, JobDestroyedException {
+			throws IOException, SpallocServerException, JobDestroyedException,
+			InterruptedException {
 		this.client = new SpallocClient(hostname, port, timeout);
 		this.timeout = timeout;
 		this.id = id;
@@ -506,11 +529,14 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	/**
 	 * Reconnect to the server and check version.
-	 *
+	 * <p>
 	 * If reconnection fails, the error is reported as a warning but no
 	 * exception is raised.
+	 *
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	private void reconnect() {
+	private void reconnect() throws InterruptedException {
 		try {
 			client.connect(timeout);
 			assertCompatibleVersion();
@@ -539,11 +565,13 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 * @throws IllegalStateException
 	 *             If the server is not compatible with this client.
 	 */
 	protected void assertCompatibleVersion()
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var v = client.version(timeout);
 		if (MIN_VER.compareTo(v) <= 0 && MAX_VER.compareTo(v) > 0) {
 			return;
@@ -555,7 +583,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public void destroy(String reason)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		try {
 			client.destroyJob(id, reason, timeout);
 		} finally {
@@ -566,7 +594,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public void setPower(Boolean powerOn)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		if (powerOn == null) {
 			return;
 		}
@@ -583,7 +611,8 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 		return id;
 	}
 
-	private JobState getStatus() throws IOException, SpallocServerException {
+	private JobState getStatus()
+			throws IOException, SpallocServerException, InterruptedException {
 		if (statusCache == null || statusTimestamp < currentTimeMillis()
 				- STATUS_CACHE_PERIOD) {
 			statusCache = client.getJobState(id, timeout);
@@ -597,23 +626,26 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	}
 
 	@Override
-	public State getState() throws IOException, SpallocServerException {
+	public State getState()
+			throws IOException, SpallocServerException, InterruptedException {
 		return getStatus().getState();
 	}
 
 	@Override
-	public Boolean getPower() throws IOException, SpallocServerException {
+	public Boolean getPower()
+			throws IOException, SpallocServerException, InterruptedException {
 		return getStatus().getPower();
 	}
 
 	@Override
 	public String getDestroyReason()
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		return getStatus().getReason();
 	}
 
 	private void retrieveMachineInfo()
-			throws IOException, SpallocServerException, IllegalStateException {
+			throws IOException, SpallocServerException, IllegalStateException,
+			InterruptedException {
 		/*
 		 * Check the job is still not QUEUED as then machine info is all nulls
 		 * getJobMachineInfo works if the Job is in State.POWER
@@ -633,7 +665,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public List<Connection> getConnections()
-			throws IOException, SpallocServerException, IllegalStateException {
+			throws IOException, SpallocServerException, InterruptedException {
 		if (machineInfoCache == null
 				|| machineInfoCache.getConnections() == null) {
 			retrieveMachineInfo();
@@ -642,7 +674,8 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	}
 
 	@Override
-	public String getHostname() throws IOException, SpallocServerException {
+	public String getHostname()
+			throws IOException, SpallocServerException, InterruptedException {
 		for (Connection c : getConnections()) {
 			if (c.getChip().onSameChipAs(ZERO_ZERO)) {
 				return c.getHostname();
@@ -653,20 +686,22 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public MachineDimensions getDimensions()
-			throws IOException, SpallocServerException, IllegalStateException {
+			throws IOException, SpallocServerException,
+			InterruptedException {
 		if (machineInfoCache == null || machineInfoCache.getWidth() == 0) {
 			retrieveMachineInfo();
 		}
 		if (machineInfoCache == null || machineInfoCache.getWidth() == 0) {
 			return null;
 		}
-		return new MachineDimensions(machineInfoCache.getWidth(),
+		return new MachineDimensions(
+				machineInfoCache.getWidth(),
 				machineInfoCache.getHeight());
 	}
 
 	@Override
-	public String getMachineName()
-			throws IOException, SpallocServerException, IllegalStateException {
+	public String getMachineName() throws IOException, SpallocServerException,
+			InterruptedException {
 		if (machineInfoCache == null
 				|| machineInfoCache.getMachineName() == null) {
 			retrieveMachineInfo();
@@ -679,7 +714,8 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public List<BoardCoordinates> getBoards()
-			throws IOException, SpallocServerException, IllegalStateException {
+			throws IOException, SpallocServerException, IllegalStateException,
+			InterruptedException {
 		if (machineInfoCache == null || machineInfoCache.getBoards() == null) {
 			retrieveMachineInfo();
 		}
@@ -691,7 +727,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public State waitForStateChange(State oldState, Integer timeout)
-			throws SpallocServerException {
+			throws SpallocServerException, InterruptedException {
 		var finishTime = makeTimeout(timeout);
 
 		// We may get disconnected while waiting so keep listening...
@@ -726,7 +762,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 				 */
 				try {
 					doReconnect(finishTime);
-				} catch (IOException | InterruptedException e1) {
+				} catch (IOException e1) {
 					log.error("problem when reconnecting after disconnect", e1);
 				}
 			}
@@ -749,9 +785,11 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	 *             If the server throws an exception.
 	 * @throws IOException
 	 *             If communications fail.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	private boolean doWaitForAChange(Long finishTime)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		/*
 		 * Since we're about to block holding the client lock, we must be
 		 * responsible for keeping everything alive.
@@ -814,7 +852,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 	@Override
 	public void waitUntilReady(Integer timeout)
 			throws JobDestroyedException, IOException, SpallocServerException,
-			SpallocStateChangeTimeoutException {
+			SpallocStateChangeTimeoutException, InterruptedException {
 		State curState = null;
 		var finishTime = makeTimeout(timeout);
 		while (!timedOut(finishTime)) {
@@ -856,7 +894,7 @@ public class SpallocJob implements AutoCloseable, SpallocJobAPI {
 
 	@Override
 	public BoardPhysicalCoordinates whereIs(HasChipLocation chip)
-			throws IOException, SpallocServerException {
+			throws IOException, SpallocServerException, InterruptedException {
 		var result = client.whereIs(id, chip, timeout);
 		if (result == null) {
 			throw new IllegalStateException(

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/SpallocJobAPI.java
@@ -38,8 +38,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	default void destroy() throws IOException, SpallocServerException {
+	default void destroy()
+			throws IOException, SpallocServerException, InterruptedException {
 		destroy(null);
 	}
 
@@ -53,8 +56,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	void destroy(String reason) throws IOException, SpallocServerException;
+	void destroy(String reason)
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * Turn the boards allocated to the job on or off.
@@ -72,8 +78,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	void setPower(Boolean powerOn) throws IOException, SpallocServerException;
+	void setPower(Boolean powerOn)
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * Reset (power-cycle) the boards allocated to the job.
@@ -87,8 +96,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	default void reset() throws IOException, SpallocServerException {
+	default void reset()
+			throws IOException, SpallocServerException, InterruptedException {
 		setPower(true);
 	}
 
@@ -101,8 +113,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	State getState() throws IOException, SpallocServerException;
+	State getState()
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * @return The current power state of the job.
@@ -110,8 +125,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	Boolean getPower() throws IOException, SpallocServerException;
+	Boolean getPower()
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * @return The reason for destruction of the job, or {@code null} if there
@@ -122,8 +140,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	String getDestroyReason() throws IOException, SpallocServerException;
+	String getDestroyReason()
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * @return The list of connections, where each connection says what the
@@ -134,9 +155,11 @@ public interface SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws IllegalStateException
 	 *             If the spalloc job is not Ready.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	List<Connection> getConnections()
-			throws IOException, SpallocServerException, IllegalStateException;
+	List<Connection> getConnections() throws IOException,
+			SpallocServerException, IllegalStateException, InterruptedException;
 
 	/**
 	 * @return The name of the host that is the root chip of the whole
@@ -145,8 +168,11 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	String getHostname() throws IOException, SpallocServerException;
+	String getHostname()
+			throws IOException, SpallocServerException, InterruptedException;
 
 	/**
 	 * @return The dimensions of the machine in chips, e.g., for booting.
@@ -156,9 +182,11 @@ public interface SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws IllegalStateException
 	 *             If the spalloc job is not Ready.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	MachineDimensions getDimensions()
-			throws IOException, SpallocServerException, IllegalStateException;
+	MachineDimensions getDimensions() throws IOException,
+			SpallocServerException, IllegalStateException, InterruptedException;
 
 	/**
 	 * @return The name of the machine the job is allocated on.
@@ -168,9 +196,11 @@ public interface SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws IllegalStateException
 	 *             If the spalloc job is not Ready.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	String getMachineName()
-			throws IOException, SpallocServerException, IllegalStateException;
+	String getMachineName() throws IOException, SpallocServerException,
+			IllegalStateException, InterruptedException;
 
 	/**
 	 * @return All the boards allocated to the job.
@@ -180,9 +210,11 @@ public interface SpallocJobAPI {
 	 *             If the spalloc server rejects the operation request.
 	 * @throws IllegalStateException
 	 *             If the spalloc job is not Ready.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
-	List<BoardCoordinates> getBoards()
-			throws IOException, SpallocServerException, IllegalStateException;
+	List<BoardCoordinates> getBoards() throws IOException,
+			SpallocServerException, IllegalStateException, InterruptedException;
 
 	/**
 	 * Block until the job's state changes from the supplied state.
@@ -192,9 +224,11 @@ public interface SpallocJobAPI {
 	 * @return The new state.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	default State waitForStateChange(State oldState)
-			throws SpallocServerException {
+			throws SpallocServerException, InterruptedException {
 		return waitForStateChange(oldState, null);
 	}
 
@@ -209,9 +243,11 @@ public interface SpallocJobAPI {
 	 * @return The new state, or old state if timed out.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	State waitForStateChange(State oldState, Integer timeout)
-			throws SpallocServerException;
+			throws SpallocServerException, InterruptedException;
 
 	/**
 	 * Block until the job is allocated and ready.
@@ -227,10 +263,12 @@ public interface SpallocJobAPI {
 	 *             If the timeout expired before the ready state was entered.
 	 * @throws JobDestroyedException
 	 *             If the job was destroyed before becoming ready.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	void waitUntilReady(Integer timeout)
 			throws JobDestroyedException, IOException, SpallocServerException,
-			SpallocStateChangeTimeoutException;
+			SpallocStateChangeTimeoutException, InterruptedException;
 
 	/**
 	 * Locates and returns the physical coordinates containing a given chip in a
@@ -243,7 +281,9 @@ public interface SpallocJobAPI {
 	 *             If communications fail.
 	 * @throws SpallocServerException
 	 *             If the spalloc server rejects the operation request.
+	 * @throws InterruptedException
+	 *             If interrupted while waiting.
 	 */
 	BoardPhysicalCoordinates whereIs(HasChipLocation chip)
-			throws IOException, SpallocServerException;
+			throws IOException, SpallocServerException, InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ApplicationRunProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ApplicationRunProcess.java
@@ -56,9 +56,11 @@ class ApplicationRunProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void run(AppID appID, CoreSubsets coreSubsets, boolean wait)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		for (var chip : coreSubsets.getChips()) {
 			sendRequest(new ApplicationRun(appID, chip,
 					coreSubsets.pByChip(chip), wait));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
@@ -477,6 +477,8 @@ class BMPCommandProcess<R extends BMPResponse> {
 					// Remove the sequence from the outstanding responses
 					msg.removeRequest(requests);
 				}
+			} catch (InterruptedException e) {
+				throw e;
 			} catch (Exception e) {
 				errorRequest = req.request;
 				exception = e;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
@@ -127,10 +127,12 @@ class BMPCommandProcess<R extends BMPResponse> {
 	 *             If the communications fail
 	 * @throws ProcessException
 	 *             If the other side responds with a failure code
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@SuppressWarnings("unchecked")
 	<T extends R> T execute(BMPRequest<T> request)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var holder = new ValueHolder<R>();
 		/*
 		 * If no pipeline built yet, build one on the connection selected for
@@ -162,10 +164,12 @@ class BMPCommandProcess<R extends BMPResponse> {
 	 *             If the communications fail
 	 * @throws ProcessException
 	 *             If the other side responds with a failure code
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@SuppressWarnings("unchecked")
 	<T extends R> T execute(BMPRequest<T> request, int retries)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var holder = new ValueHolder<R>();
 		/*
 		 * If no pipeline built yet, build one on the connection selected for
@@ -199,10 +203,12 @@ class BMPCommandProcess<R extends BMPResponse> {
 	 *             If the communications fail
 	 * @throws ProcessException
 	 *             If the other side responds with a failure code
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@SuppressWarnings("unchecked")
 	<T extends R> List<T> execute(Iterable<? extends BMPRequest<T>> requests)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var results = new ArrayList<R>();
 		RequestPipeline requestPipeline = null;
 		for (var request : requests) {
@@ -243,10 +249,13 @@ class BMPCommandProcess<R extends BMPResponse> {
 	 *             If the communications fail
 	 * @throws ProcessException
 	 *             If the other side responds with a failure code
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@SuppressWarnings("unchecked")
 	<T extends R> List<T> execute(Iterable<? extends BMPRequest<T>> requests,
-			int retries) throws IOException, ProcessException {
+			int retries)
+			throws IOException, ProcessException, InterruptedException {
 		var results = new ArrayList<R>();
 		RequestPipeline requestPipeline = null;
 		for (var request : requests) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
@@ -438,8 +438,10 @@ class BMPCommandProcess<R extends BMPResponse> {
 		 *
 		 * @throws IOException
 		 *             If anything goes wrong with communications.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
-		private void finish() throws IOException {
+		private void finish() throws IOException, InterruptedException {
 			// While there are still more packets in progress than some
 			// threshold
 			while (!requests.isEmpty()) {
@@ -452,7 +454,7 @@ class BMPCommandProcess<R extends BMPResponse> {
 			}
 		}
 
-		private void retrieve() throws IOException {
+		private void retrieve() throws IOException, InterruptedException {
 			// Receive the next response
 			var msg = connection.receiveSCPResponse(timeout);
 			var req = msg.pickRequest(requests);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadMemoryProcess.java
@@ -66,9 +66,12 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T> T read(BMPBoard board, MemoryLocation address, int size,
-			Accumulator<T> accum) throws ProcessException, IOException {
+			Accumulator<T> accum)
+			throws ProcessException, IOException, InterruptedException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			accum.add(offset, execute(
@@ -91,9 +94,12 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress,
-			ByteBuffer receivingBuffer) throws IOException, ProcessException {
+			ByteBuffer receivingBuffer)
+			throws IOException, ProcessException, InterruptedException {
 		read(board, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 		// Ignore the result; caller already knows it
@@ -113,9 +119,11 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	ByteBuffer read(BMPBoard board, MemoryLocation baseAddress, int size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return read(board, baseAddress, size, new BufferAccumulator(size));
 	}
 
@@ -136,9 +144,12 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress, int size,
-			RandomAccessFile dataFile) throws IOException, ProcessException {
+			RandomAccessFile dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		read(board, baseAddress, size, new FileAccumulator(dataFile));
 	}
 
@@ -158,9 +169,12 @@ class BMPReadMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress, int size,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		try (var s = new RandomAccessFile(dataFile, "rw")) {
 			read(board, baseAddress, size, new FileAccumulator(s));
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadSerialFlashProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPReadSerialFlashProcess.java
@@ -67,9 +67,12 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T> T read(BMPBoard board, MemoryLocation address, int size,
-			Accumulator<T> accum) throws ProcessException, IOException {
+			Accumulator<T> accum)
+			throws ProcessException, IOException, InterruptedException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			accum.add(offset, execute(new ReadSerialFlash(board,
@@ -92,9 +95,12 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress,
-			ByteBuffer receivingBuffer) throws IOException, ProcessException {
+			ByteBuffer receivingBuffer)
+			throws IOException, ProcessException, InterruptedException {
 		read(board, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 		// Ignore the result; caller already knows it
@@ -114,9 +120,11 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	ByteBuffer read(BMPBoard board, MemoryLocation baseAddress, int size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return read(board, baseAddress, size, new BufferAccumulator(size));
 	}
 
@@ -137,9 +145,12 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress, int size,
-			RandomAccessFile dataFile) throws IOException, ProcessException {
+			RandomAccessFile dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		read(board, baseAddress, size, new FileAccumulator(dataFile));
 	}
 
@@ -159,9 +170,12 @@ class BMPReadSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void read(BMPBoard board, MemoryLocation baseAddress, int size,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		try (var s = new RandomAccessFile(dataFile, "rw")) {
 			read(board, baseAddress, size, new FileAccumulator(s));
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
@@ -101,26 +101,30 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	MappableIterable<BMPBoard> availableBoards(@Valid BMPCoords bmp)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
-	 * List which boards are actually available to be manipulated by the default
-	 * BMP.
+	 * List which boards are actually available to be manipulated by the current
+	 * bound BMP.
 	 *
 	 * @return Ordered list of board identifiers.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default MappableIterable<BMPBoard> availableBoards()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return availableBoards(getBoundBMP());
 	}
 
@@ -235,6 +239,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void powerOff(@Valid BMPBoard board)
@@ -261,6 +267,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If SpiNNaker rejects a message.
 	 * @throws InterruptedException
 	 *             If the thread is interrupted while waiting.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void power(@NotNull PowerCommand powerCommand, @Valid BMPCoords bmp,
@@ -283,11 +291,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setLED(Collection<Integer> leds, LEDAction action,
 			@Valid BMPCoords bmp, Collection<@Valid BMPBoard> boards)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the LED state of a board in the machine.
@@ -302,10 +312,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setLED(Collection<Integer> leds, LEDAction action,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		setLED(leds, action, getBoundBMP(), Set.of(board));
 	}
 
@@ -324,11 +337,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGARegister(FPGA fpga, FPGAMainRegisters register,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, register, getBoundBMP(), board);
 	}
 
@@ -349,12 +365,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGARegister(FPGA fpga, FPGAMainRegisters register,
 			@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, register.getAddress(), bmp, board);
 	}
 
@@ -375,12 +393,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGARegister(FPGA fpga, int registerBank,
 			FPGALinkRegisters register, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, registerBank, register, getBoundBMP(),
 				board);
 	}
@@ -404,12 +424,15 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGARegister(FPGA fpga, int registerBank,
 			FPGALinkRegisters register, @Valid BMPCoords bmp,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, register.address(registerBank), bmp,
 				board);
 	}
@@ -431,12 +454,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGALinkCounter(FPGA fpga, int linkNumber,
 			FPGARecevingLinkCounters counter, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGALinkCounter(fpga, linkNumber, counter, getBoundBMP(),
 				board);
 	}
@@ -460,12 +485,15 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGALinkCounter(FPGA fpga, int linkNumber,
 			FPGARecevingLinkCounters counter, @Valid BMPCoords bmp,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, counter.address(linkNumber), bmp, board);
 	}
 
@@ -486,12 +514,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGALinkCounter(FPGA fpga, int linkNumber,
 			FPGASendingLinkCounters counter, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGALinkCounter(fpga, linkNumber, counter, getBoundBMP(),
 				board);
 	}
@@ -515,12 +545,15 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGALinkCounter(FPGA fpga, int linkNumber,
 			FPGASendingLinkCounters counter, @Valid BMPCoords bmp,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, counter.address(linkNumber), bmp, board);
 	}
 
@@ -540,11 +573,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default int readFPGARegister(FPGA fpga, @NotNull MemoryLocation register,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		return readFPGARegister(fpga, register, getBoundBMP(), board);
 	}
 
@@ -566,12 +602,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	int readFPGARegister(FPGA fpga, @NotNull MemoryLocation register,
 			@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write a register on a FPGA of a board, assuming the standard FPGA
@@ -589,11 +627,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeFPGARegister(FPGA fpga, FPGAMainRegisters register,
 			int value, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeFPGARegister(fpga, register, value, getBoundBMP(), board);
 	}
 
@@ -615,11 +655,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeFPGARegister(FPGA fpga, FPGAMainRegisters register,
 			int value, @Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeFPGARegister(fpga, register.getAddress(), value, bmp, board);
 	}
 
@@ -641,11 +683,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeFPGARegister(FPGA fpga, int registerBank,
 			FPGALinkRegisters register, int value, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeFPGARegister(fpga, registerBank, register, value, getBoundBMP(),
 				board);
 	}
@@ -670,11 +714,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeFPGARegister(FPGA fpga, int registerBank,
 			FPGALinkRegisters register, int value, @Valid BMPCoords bmp,
-			@Valid BMPBoard board) throws IOException, ProcessException {
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException {
 		writeFPGARegister(fpga, register.address(registerBank), value, bmp,
 				board);
 	}
@@ -696,11 +743,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeFPGARegister(FPGA fpga, @NotNull MemoryLocation register,
 			int value, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeFPGARegister(fpga, register, value, getBoundBMP(), board);
 	}
 
@@ -723,11 +772,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void writeFPGARegister(FPGA fpga, @NotNull MemoryLocation register,
 			int value, @Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the ADC data.
@@ -739,11 +790,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default ADCInfo readADCData(@Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readADCData(getBoundBMP(), board);
 	}
 
@@ -759,11 +812,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	ADCInfo readADCData(@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the BMP version.
@@ -776,11 +831,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	default VersionInfo readBMPVersion(Iterable<@Valid BMPBoard> boards)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPVersion(getBoundBMP(), boards.iterator().next());
 	}
 
@@ -794,11 +851,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default VersionInfo readBMPVersion(@Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPVersion(getBoundBMP(), board);
 	}
 
@@ -815,12 +874,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	default VersionInfo readBMPVersion(@Valid BMPCoords bmp,
 			Iterable<@Valid BMPBoard> boards)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPVersion(bmp, boards.iterator().next());
 	}
 
@@ -836,11 +897,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	VersionInfo readBMPVersion(@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the BMP firmware descriptor.
@@ -854,12 +917,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default FirmwareDescriptor readBMPFirmwareDescriptor(
 			@Valid BMPBoard board, FirmwareDescriptors type)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPFirmwareDescriptor(getBoundBMP(), board, type);
 	}
 
@@ -877,12 +942,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default FirmwareDescriptor readBMPFirmwareDescriptor(@Valid BMPCoords bmp,
 			@Valid BMPBoard board, FirmwareDescriptors type)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new FirmwareDescriptor(type,
 				readBMPMemory(bmp, board, type.address, type.blockSize));
 	}
@@ -897,11 +964,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default boolean getResetStatus(@Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getResetStatus(getBoundBMP(), board);
 	}
 
@@ -917,11 +986,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	boolean getResetStatus(@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the address of the serial flash buffer.
@@ -933,10 +1004,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default MemoryLocation getSerialFlashBuffer(@Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getSerialFlashBuffer(getBoundBMP(), board);
 	}
 
@@ -952,10 +1025,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	MemoryLocation getSerialFlashBuffer(@Valid BMPCoords bmp,
-			@Valid BMPBoard board) throws IOException, ProcessException;
+			@Valid BMPBoard board)
+			throws IOException, ProcessException, InterruptedException;
 
 	/** The type of reset to perform. */
 	enum FPGAResetType {
@@ -979,10 +1055,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void resetFPGA(@Valid BMPBoard board, FPGAResetType resetType)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		resetFPGA(getBoundBMP(), board, resetType);
 	}
 
@@ -999,10 +1077,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void resetFPGA(@Valid BMPCoords bmp, @Valid BMPBoard board,
-			FPGAResetType resetType) throws IOException, ProcessException;
+			FPGAResetType resetType)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read BMP memory.
@@ -1020,12 +1101,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default ByteBuffer readBMPMemory(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPMemory(getBoundBMP(), board, baseAddress, length);
 	}
 
@@ -1047,12 +1130,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	ByteBuffer readBMPMemory(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read BMP memory.
@@ -1067,12 +1152,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default int readBMPMemoryWord(@Valid BMPBoard board,
 			@NotNull MemoryLocation address)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBMPMemoryWord(getBoundBMP(), board, address);
 	}
 
@@ -1091,12 +1178,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default int readBMPMemoryWord(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation address)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var b = readBMPMemory(bmp, board, address, WORD_SIZE);
 		return b.getInt(0);
 	}
@@ -1117,10 +1206,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeBMPMemory(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, data);
 	}
 
@@ -1142,10 +1233,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeBMPMemory(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write BMP memory.
@@ -1161,10 +1254,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeBMPMemory(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, int dataWord)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, dataWord);
 	}
 
@@ -1184,10 +1279,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeBMPMemory(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, int dataWord)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var data = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		data.putInt(dataWord);
 		data.flip();
@@ -1208,10 +1305,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking or file I/O.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeBMPMemory(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull File file)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeBMPMemory(getBoundBMP(), board, baseAddress, file);
 	}
 
@@ -1231,10 +1330,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking or file I/O.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeBMPMemory(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull File file)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read BMP serial flash memory.
@@ -1252,12 +1353,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default ByteBuffer readSerialFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readSerialFlash(getBoundBMP(), board, baseAddress, length);
 	}
 
@@ -1279,12 +1382,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	ByteBuffer readSerialFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the BMP serial number from a board.
@@ -1299,11 +1404,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	String readBoardSerialNumber(@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the BMP serial number from a board.
@@ -1316,10 +1423,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default String readBoardSerialNumber(@Valid BMPBoard board)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return readBoardSerialNumber(getBoundBMP(), board);
 	}
 
@@ -1335,10 +1444,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default Blacklist readBlacklist(@Valid BMPCoords bmp, @Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new Blacklist(
 				readSerialFlash(bmp, board, SF_BL_ADDR, SF_BL_LEN));
 	}
@@ -1354,10 +1465,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default Blacklist readBlacklist(@Valid BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readBlacklist(getBoundBMP(), board);
 	}
 
@@ -1457,12 +1570,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default int readSerialFlashCRC(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readSerialFlashCRC(getBoundBMP(), board, baseAddress, length);
 	}
 
@@ -1483,12 +1598,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	int readSerialFlashCRC(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write BMP serial flash memory from a file.
@@ -1504,10 +1621,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeSerialFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull File file)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, file);
 	}
 
@@ -1527,10 +1646,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeSerialFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull File file)
-			throws ProcessException, IOException;
+			throws ProcessException, IOException, InterruptedException;
 
 	/**
 	 * Write BMP serial flash memory from a stream.
@@ -1548,10 +1669,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeSerialFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int size,
-			@NotNull InputStream stream) throws ProcessException, IOException {
+			@NotNull InputStream stream)
+			throws ProcessException, IOException, InterruptedException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, size, stream);
 	}
 
@@ -1573,10 +1697,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeSerialFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int size,
-			@NotNull InputStream stream) throws ProcessException, IOException;
+			@NotNull InputStream stream)
+			throws ProcessException, IOException, InterruptedException;
 
 	/**
 	 * Write BMP serial flash memory.
@@ -1592,10 +1719,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeSerialFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeSerialFlash(getBoundBMP(), board, baseAddress, data);
 	}
 
@@ -1615,10 +1744,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeSerialFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws ProcessException, IOException;
+			throws ProcessException, IOException, InterruptedException;
 
 	/**
 	 * Prepare a transfer area for writing to the flash memory of a BMP.
@@ -1638,12 +1769,14 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@Deprecated
 	@CheckReturnValue
 	MemoryLocation eraseBMPFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int size)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Move an uploaded chunk of data into the working buffer for writing to the
@@ -1662,11 +1795,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@Deprecated
 	void chunkBMPFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation address)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Finalise the writing of the flash memory of a BMP.
@@ -1685,11 +1820,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@Deprecated
 	void copyBMPFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @Positive int size)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write a {@linkplain WriteFlashBuffer#FLASH_CHUNK_SIZE fixed size} chunk
@@ -1705,10 +1842,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeBMPFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeBMPFlash(getBoundBMP(), board, baseAddress);
 	}
 
@@ -1728,10 +1867,12 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeBMPFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write a buffer to flash memory on the BMP. This is a composite operation.
@@ -1748,10 +1889,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeFlash(@Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data,
-			boolean update) throws ProcessException, IOException {
+			boolean update)
+			throws ProcessException, IOException, InterruptedException {
 		writeFlash(getBoundBMP(), board, baseAddress, data, update);
 	}
 
@@ -1772,10 +1916,13 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data,
-			boolean update) throws ProcessException, IOException {
+			boolean update)
+			throws ProcessException, IOException, InterruptedException {
 		int size = data.remaining();
 		var workingBuffer = eraseBMPFlash(bmp, board, baseAddress, size);
 		var targetAddr = baseAddress;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteMemoryProcess.java
@@ -71,9 +71,12 @@ class BMPWriteMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(BMPBoard board, MemoryLocation baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+			ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException {
 		execute(new BMPWriteIterator(board, baseAddress, data.remaining()) {
 			private int offset = data.position();
 
@@ -103,10 +106,12 @@ class BMPWriteMemoryProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(BMPBoard board, MemoryLocation baseAddress,
 			InputStream data, int bytesToWrite)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var exn = new ValueHolder<IOException>();
 		var workingBuffer = allocate(UDP_MESSAGE_MAX_SIZE);
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteSerialFlashProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPWriteSerialFlashProcess.java
@@ -72,9 +72,11 @@ class BMPWriteSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void write(BMPBoard board, MemoryLocation baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		execute(new BMPWriteSFIterable(board, baseAddress, data.remaining()) {
 			private int offset = data.position();
 
@@ -104,9 +106,12 @@ class BMPWriteSerialFlashProcess extends BMPCommandProcess<BMPResponse> {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void write(BMPBoard board, MemoryLocation baseAddress, InputStream data,
-			int bytesToWrite) throws IOException, ProcessException {
+			int bytesToWrite)
+			throws IOException, ProcessException, InterruptedException {
 		var exn = new ValueHolder<IOException>();
 		var workingBuffer = allocate(UDP_MESSAGE_MAX_SIZE);
 		execute(new BMPWriteSFIterable(board, baseAddress, bytesToWrite) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
@@ -117,7 +117,7 @@ class FillProcess extends TxrxProcess {
 
 	private void generateWriteMessages(HasChipLocation chip,
 			MemoryLocation base, int size, ByteBuffer buffer)
-			throws IOException {
+			throws IOException, InterruptedException {
 		int toWrite = size;
 		var address = base;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FillProcess.java
@@ -74,12 +74,14 @@ class FillProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 * @throws IllegalArgumentException
 	 *             If the size doesn't match the alignment of the data type.
 	 */
 	void fillMemory(HasChipLocation chip, MemoryLocation baseAddress, int data,
 			int size, FillDataType dataType)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		// Don't do anything if there is nothing to do!
 		if (size == 0) {
 			return;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FixedRouteControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/FixedRouteControlProcess.java
@@ -56,9 +56,11 @@ class FixedRouteControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		loadFixedRoute(chip, fixedRoute, DEFAULT);
 	}
 
@@ -75,9 +77,12 @@ class FixedRouteControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute,
-			AppID appID) throws IOException, ProcessException {
+			AppID appID)
+			throws IOException, ProcessException, InterruptedException {
 		int entry = fixedRoute.encode();
 		synchronousCall(new FixedRouteInitialise(chip, entry, appID));
 	}
@@ -92,9 +97,11 @@ class FixedRouteControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	RoutingEntry readFixedRoute(HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFixedRoute(chip, DEFAULT);
 	}
 
@@ -110,9 +117,11 @@ class FixedRouteControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	RoutingEntry readFixedRoute(HasChipLocation chip, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return synchronousCall(new FixedRouteRead(chip, appID)).getRoute();
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetCPUInfoProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetCPUInfoProcess.java
@@ -58,9 +58,11 @@ class GetCPUInfoProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	MappableIterable<CPUInfo> getCPUInfo(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var cpuInfo = new ArrayList<CPUInfo>();
 		for (var core : requireNonNull(coreSubsets,
 				"must have actual core subset to iterate over")) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetHeapProcess.java
@@ -37,7 +37,7 @@ import uk.ac.manchester.spinnaker.messages.scp.ReadMemory;
 /**
  * Get a description of the heap.
  */
-class GetHeapProcess extends TxrxProcess {
+final class GetHeapProcess extends TxrxProcess {
 	private static final int HEAP_HEADER_SIZE = 16;
 
 	private static final int HEAP_BLOCK_HEADER_SIZE = 8;
@@ -68,10 +68,12 @@ class GetHeapProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	List<HeapElement> getBlocks(HasChipLocation chip,
 			SystemVariableDefinition heap)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var header = getHeapHeader(chip, heap);
 		var nextBlock = header.first;
 
@@ -103,10 +105,12 @@ class GetHeapProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	List<HeapElement> getFreeBlocks(HasChipLocation chip,
 			SystemVariableDefinition heap)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var header = getHeapHeader(chip, heap);
 		var nextBlock = header.free;
 
@@ -136,31 +140,81 @@ class GetHeapProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	int getFreeSpace(HasChipLocation chip, SystemVariableDefinition heap)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getHeapHeader(chip, heap).freeBytes;
 	}
 
+	/**
+	 * Read a heap header.
+	 *
+	 * @param chip
+	 *            What chip to read from.
+	 * @param heap
+	 *            Which heap to get the header of.
+	 * @return The heap header.
+	 * @throws IOException
+	 *             If anything goes wrong with networking
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
+	 */
 	private HeapHeader getHeapHeader(HasChipLocation chip,
 			SystemVariableDefinition heap)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var heapBase = new MemoryLocation(readFromAddress(chip,
 				SYS_VARS.add(heap.offset), heap.type.value).get());
 		return new HeapHeader(
 				readFromAddress(chip, heapBase, HEAP_HEADER_SIZE));
 	}
 
+	/**
+	 * Read a memory block header.
+	 *
+	 * @param chip
+	 *            What chip to read from.
+	 * @param address
+	 *            What address to read from.
+	 * @return The memory block header.
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
+	 */
 	private BlockHeader getBlockHeader(HasChipLocation chip,
-			MemoryLocation address) throws IOException, ProcessException {
+			MemoryLocation address)
+			throws IOException, ProcessException, InterruptedException {
 		return new BlockHeader(
 				readFromAddress(chip, address, HEAP_BLOCK_HEADER_SIZE));
 	}
 
-	// NB: assumes that size is small
+	/**
+	 * Simplified read. <em>Assumes</em> that the amount of data being read can
+	 * fit in a single response message.
+	 *
+	 * @param chip
+	 *            What chip to read from.
+	 * @param address
+	 *            What address to read from.
+	 * @param size
+	 *            How much to read.
+	 * @return Data read, wrapped as little-endian integer buffer.
+	 * @throws IOException
+	 *             If anything goes wrong with networking.
+	 * @throws ProcessException
+	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
+	 */
 	private IntBuffer readFromAddress(HasChipLocation chip,
 			MemoryLocation address, long size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return synchronousCall(
 				new ReadMemory(chip, address, (int) size)).data
 						.asIntBuffer();

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetMachineProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetMachineProcess.java
@@ -131,9 +131,11 @@ class GetMachineProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	Machine getMachineDetails(HasChipLocation bootChip, MachineDimensions size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Get the P2P table; 8 entries are packed into each 32-bit word
 		var p2pColumnData = new ArrayList<ByteBuffer>();
 		for (int column = 0; column < size.width; column++) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetTagsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetTagsProcess.java
@@ -58,9 +58,11 @@ class GetTagsProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	Collection<Tag> getTags(SCPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var tags = new TreeMap<Integer, Tag>();
 		for (var tag : range(0, getTagCount(connection)).toArray()) {
 			sendRequest(new IPTagGet(connection.getChip(), tag), response -> {
@@ -75,7 +77,7 @@ class GetTagsProcess extends TxrxProcess {
 	}
 
 	private int getTagCount(SCPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var tagInfo = synchronousCall(new IPTagGetInfo(connection.getChip()));
 		return tagInfo.poolSize + tagInfo.fixedSize;
 	}
@@ -102,9 +104,11 @@ class GetTagsProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	Map<Tag, Integer> getTagUsage(SCPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var tagUsages = new TreeMap<Tag, Integer>();
 		for (var tag : range(0, getTagCount(connection)).toArray()) {
 			sendRequest(new IPTagGet(connection.getChip(), tag), response -> {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/MulticastRoutesControlProcess.java
@@ -136,6 +136,8 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 * @throws IllegalArgumentException
 	 *             If there are more routes to apply than can fit in a router.
 	 * @throws RuntimeException
@@ -143,7 +145,7 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 */
 	void setRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (routes.size() > MAX_ROUTER_ENTRIES) {
 			throw new IllegalArgumentException(
 					"too many router entries: " + routes.size());
@@ -178,10 +180,12 @@ class MulticastRoutesControlProcess extends WriteMemoryProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	List<MulticastRoutingEntry> getRoutes(HasChipLocation chip,
 			MemoryLocation baseAddress, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var routes = new TreeMap<Integer, MulticastRoutingEntry>();
 		for (int i = 0; i < NUM_READS; i++) {
 			int offset = i * ENTRIES_PER_READ;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ProcessException.java
@@ -66,9 +66,11 @@ public class ProcessException extends SpinnmanException {
 	 * @param cause
 	 *            What exception caused problems.
 	 * @return A process exception, or a subclass of it.
+	 * @throws InterruptedException
+	 *             If the cause was an interrupt, it is immediately rethrown.
 	 */
 	static ProcessException makeInstance(HasCoreLocation core,
-			Throwable cause) {
+			Throwable cause) throws InterruptedException {
 		if (requireNonNull(cause) instanceof UnexpectedResponseCodeException) {
 			var urc = (UnexpectedResponseCodeException) cause;
 			if (urc.response == null) {
@@ -108,6 +110,9 @@ public class ProcessException extends SpinnmanException {
 			default:
 				// Fall through
 			}
+		}
+		if (cause instanceof InterruptedException) {
+			throw (InterruptedException) cause;
 		}
 		return new ProcessException(core, cause, null);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
@@ -70,9 +70,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T> T readMemory(HasChipLocation chip, MemoryLocation baseAddress,
-			int size, Accumulator<T> a) throws IOException, ProcessException {
+			int size, Accumulator<T> a)
+			throws IOException, ProcessException, InterruptedException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			final int thisOffset = offset;
@@ -103,10 +106,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T> T readLink(HasChipLocation chip, Direction linkDirection,
 			MemoryLocation baseAddress, int size, Accumulator<T> a)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (int offset = 0, chunk; offset < size; offset += chunk) {
 			chunk = min(size - offset, UDP_MESSAGE_MAX_SIZE);
 			int thisOffset = offset;
@@ -135,10 +140,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
 			MemoryLocation baseAddress, ByteBuffer receivingBuffer)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		readLink(chip, linkDirection, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 	}
@@ -157,9 +164,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readMemory(HasChipLocation chip, MemoryLocation baseAddress,
-			ByteBuffer receivingBuffer) throws IOException, ProcessException {
+			ByteBuffer receivingBuffer)
+			throws IOException, ProcessException, InterruptedException {
 		readMemory(chip, baseAddress, receivingBuffer.remaining(),
 				new BufferAccumulator(receivingBuffer));
 	}
@@ -180,10 +190,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	ByteBuffer readLink(HasChipLocation chip, Direction linkDirection,
 			MemoryLocation baseAddress, int size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readLink(chip, linkDirection, baseAddress, size,
 				new BufferAccumulator(size));
 	}
@@ -202,9 +214,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	ByteBuffer readMemory(HasChipLocation chip, MemoryLocation baseAddress,
-			int size) throws IOException, ProcessException {
+			int size)
+			throws IOException, ProcessException, InterruptedException {
 		return readMemory(chip, baseAddress, size, new BufferAccumulator(size));
 	}
 
@@ -227,10 +242,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
 			MemoryLocation baseAddress, int size, RandomAccessFile dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		readLink(chip, linkDirection, baseAddress, size,
 				new FileAccumulator(dataFile));
 	}
@@ -252,9 +269,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readMemory(HasChipLocation chip, MemoryLocation baseAddress, int size,
-			RandomAccessFile dataFile) throws IOException, ProcessException {
+			RandomAccessFile dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		readMemory(chip, baseAddress, size, new FileAccumulator(dataFile));
 	}
 
@@ -276,10 +296,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readLink(HasChipLocation chip, Direction linkDirection,
 			MemoryLocation baseAddress, int size, File dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		try (var s = new RandomAccessFile(dataFile, "rw")) {
 			readLink(chip, linkDirection, baseAddress, size,
 					new FileAccumulator(s));
@@ -302,9 +324,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readMemory(HasChipLocation chip, MemoryLocation baseAddress, int size,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		try (var s = new RandomAccessFile(dataFile, "rw")) {
 			readMemory(chip, baseAddress, size, s);
 		}
@@ -326,10 +351,12 @@ class ReadMemoryProcess extends TxrxProcess {
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If anything goes wrong with access to the database.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void readMemory(BufferManagerStorage.Region region,
-			BufferManagerStorage storage)
-			throws IOException, ProcessException, StorageException {
+			BufferManagerStorage storage) throws IOException, ProcessException,
+			StorageException, InterruptedException {
 		var buffer = new byte[region.size];
 		readMemory(region.core.asChipLocation(), region.startAddress,
 				region.size, new BufferAccumulator(buffer));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RouterControlProcess.java
@@ -76,9 +76,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void clearQueue(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new ClearReinjectionQueue(monitorCore));
 	}
 
@@ -91,9 +93,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void clearQueue(CoreSubsets monitorCoreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new ClearReinjectionQueue(core));
 		}
@@ -109,9 +113,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void resetCounters(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new ResetReinjectionCounters(monitorCore));
 	}
 
@@ -124,9 +130,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void resetCounters(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : coreSubsets) {
 			sendRequest(new ResetReinjectionCounters(core));
 		}
@@ -150,10 +158,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setPacketTypes(CoreLocation monitorCore, boolean multicast,
 			boolean pointToPoint, boolean fixedRoute, boolean nearestNeighbour)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new SetReinjectionPacketTypes(monitorCore, multicast,
 				pointToPoint, fixedRoute, nearestNeighbour));
 	}
@@ -175,10 +185,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setPacketTypes(CoreSubsets monitorCoreSubsets, boolean multicast,
 			boolean pointToPoint, boolean fixedRoute, boolean nearestNeighbour)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new SetReinjectionPacketTypes(core, multicast,
 					pointToPoint, fixedRoute, nearestNeighbour));
@@ -199,9 +211,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setTimeout(CoreLocation monitorCore, int timeoutMantissa,
-			int timeoutExponent) throws IOException, ProcessException {
+			int timeoutExponent)
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new SetRouterTimeout(monitorCore, timeoutMantissa,
 				timeoutExponent));
 	}
@@ -219,9 +234,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setTimeout(CoreSubsets monitorCoreSubsets, int timeoutMantissa,
-			int timeoutExponent) throws IOException, ProcessException {
+			int timeoutExponent)
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new SetRouterTimeout(core, timeoutMantissa,
 					timeoutExponent));
@@ -242,9 +260,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setEmergencyTimeout(CoreLocation monitorCore, int timeoutMantissa,
-			int timeoutExponent) throws IOException, ProcessException {
+			int timeoutExponent)
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new SetRouterEmergencyTimeout(monitorCore,
 				timeoutMantissa, timeoutExponent));
 	}
@@ -262,10 +283,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void setEmergencyTimeout(CoreSubsets monitorCoreSubsets,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new SetRouterEmergencyTimeout(core, timeoutMantissa,
 					timeoutExponent));
@@ -282,9 +305,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void saveApplicationRouterTable(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new RouterTableSaveApplicationRoutes(monitorCore));
 	}
 
@@ -298,9 +323,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void saveApplicationRouterTable(CoreSubsets monitorCoreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new RouterTableSaveApplicationRoutes(core));
 		}
@@ -317,9 +344,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadSystemRouterTable(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new RouterTableLoadSystemRoutes(monitorCore));
 	}
 
@@ -333,9 +362,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadSystemRouterTable(CoreSubsets monitorCoreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new RouterTableLoadSystemRoutes(core));
 		}
@@ -352,9 +383,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadApplicationRouterTable(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new RouterTableLoadApplicationRoutes(monitorCore));
 	}
 
@@ -368,9 +401,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void loadApplicationRouterTable(CoreSubsets monitorCoreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new RouterTableLoadApplicationRoutes(core));
 		}
@@ -387,9 +422,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	ReinjectionStatus getReinjectionStatus(CoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return synchronousCall(
 				new GetReinjectionStatus(monitorCore)).reinjectionStatus;
 	}
@@ -404,10 +441,12 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	Map<CoreLocation, ReinjectionStatus> getReinjectionStatus(
 			CoreSubsets monitorCoreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var status = new HashMap<CoreLocation, ReinjectionStatus>();
 		for (var core : monitorCoreSubsets) {
 			sendRequest(new GetReinjectionStatus(core),
@@ -427,9 +466,11 @@ class RouterControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var cr = new ValueHolder<Integer>();
 		var es = new ValueHolder<Integer>();
 		var reg = new int[NUM_REGISTERS];

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
@@ -90,8 +90,11 @@ class RuntimeControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	void clearIOBUF(CoreLocation core) throws IOException, ProcessException {
+	void clearIOBUF(CoreLocation core)
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(new ClearIOBUF(core));
 	}
 
@@ -104,9 +107,11 @@ class RuntimeControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void clearIOBUF(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var core : requireNonNull(coreSubsets,
 				"must have actual core subset to iterate over")) {
 			sendRequest(new ClearIOBUF(core));
@@ -126,9 +131,11 @@ class RuntimeControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void updateRuntime(Integer runTimesteps, CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		int runTime = (runTimesteps == null ? 0 : runTimesteps);
 		boolean infiniteRun = runTimesteps == null;
 		for (var core : requireNonNull(coreSubsets,
@@ -172,9 +179,11 @@ class RuntimeControlProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	MappableIterable<IOBuffer> readIOBuf(int size, CoreSubsets cores)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		// Get the IOBuf address for each core
 		for (var core : requireNonNull(cores,
 				"must have actual core subset to iterate over")) {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/RuntimeControlProcess.java
@@ -154,8 +154,11 @@ class RuntimeControlProcess extends TxrxProcess {
 	 *            the cores to update the provenance of.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	void updateProvenanceAndExit(CoreSubsets coreSubsets) throws IOException {
+	void updateProvenanceAndExit(CoreSubsets coreSubsets)
+			throws IOException, InterruptedException {
 		for (var core : requireNonNull(coreSubsets,
 				"must have actual core subset to iterate over")) {
 			sendOneWayRequest(new UpdateProvenanceAndExit(core));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -398,6 +398,8 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
 	public Transceiver(InetAddress host, MachineVersion version,
@@ -407,7 +409,7 @@ public class Transceiver extends UDPTransceiver
 			Map<ChipLocation, Set<Direction>> ignoredLinks,
 			boolean autodetectBMP, List<ConnectionDescriptor> scampConnections,
 			Integer bootPortNumber, Integer maxSDRAMSize)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		log.info("Creating transceiver for {}", requireNonNull(host,
 				"SpiNNaker machine host name must be not null"));
 		var connections = new ArrayList<Connection>();
@@ -488,10 +490,12 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
 	public Transceiver(InetAddress hostname, MachineVersion version)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		this(hostname, version, null, 0, Set.of(), Map.of(), Map.of(), false,
 				null, null, null);
 	}
@@ -505,10 +509,12 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
 	public Transceiver(MachineVersion version)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		this(version, null, null, null, null, null, null);
 	}
 
@@ -526,11 +532,13 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
 	public Transceiver(MachineVersion version,
 			Collection<Connection> connections)
-			throws IOException, SpinnmanException {
+			throws IOException, SpinnmanException, InterruptedException {
 		this(version, connections, null, null, null, null, null);
 	}
 
@@ -544,9 +552,12 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
-	public Transceiver(Machine machine) throws IOException, SpinnmanException {
+	public Transceiver(Machine machine)
+			throws IOException, SpinnmanException, InterruptedException {
 		this(requireNonNull(machine, "need a real machine")
 				.getBootEthernetAddress(), machine.version, null, null, null,
 				null, null, false, generateScampConnections(machine), null,
@@ -593,6 +604,8 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws SpinnmanException
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	public Transceiver(MachineVersion version,
 			Collection<Connection> connections,
@@ -600,7 +613,8 @@ public class Transceiver extends UDPTransceiver
 			Map<ChipLocation, Set<Integer>> ignoredCores,
 			Map<ChipLocation, Set<Direction>> ignoredLinks,
 			Collection<ConnectionDescriptor> scampConnections,
-			Integer maxSDRAMSize) throws IOException, SpinnmanException {
+			Integer maxSDRAMSize)
+			throws IOException, SpinnmanException, InterruptedException {
 		this.version = version;
 		if (ignoredChips != null) {
 			ignoreChips.addAll(ignoredChips);
@@ -731,7 +745,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	private Object getSystemVariable(HasChipLocation chip,
 			SystemVariableDefinition dataItem)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var buffer = readMemory(chip, SYS_VARS.add(dataItem.offset),
 				dataItem.type.value);
 		switch (dataItem.type) {
@@ -795,7 +809,8 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	/** Check that the BMP connections are actually connected to valid BMPs. */
-	private void checkBMPConnections() throws IOException, SpinnmanException {
+	private void checkBMPConnections()
+			throws IOException, SpinnmanException, InterruptedException {
 		/*
 		 * Check that the UDP BMP conn is actually connected to a BMP via the
 		 * SVER command
@@ -897,8 +912,11 @@ public class Transceiver extends UDPTransceiver
 	 *             if the OS has networking troubles
 	 * @throws ProcessException
 	 *             if SpiNNaker rejects a message
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	void updateMachine() throws IOException, ProcessException {
+	void updateMachine()
+			throws IOException, ProcessException, InterruptedException {
 		// Get the width and height of the machine
 		getMachineDimensions();
 
@@ -955,10 +973,12 @@ public class Transceiver extends UDPTransceiver
 	 *             if networking fails
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	public List<SCPConnection> discoverScampConnections()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		/*
 		 * Currently, this only finds other UDP connections given a connection
 		 * that supports SCP - this is done via the machine
@@ -1037,7 +1057,7 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public MachineDimensions getMachineDimensions()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (dimensions == null) {
 			var data = readMemory(BOOT_CHIP, SYS_VARS.add(y_size.offset), 2);
 			int height = toUnsignedInt(data.get());
@@ -1048,7 +1068,8 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	@Override
-	public Machine getMachineDetails() throws IOException, ProcessException {
+	public Machine getMachineDetails()
+			throws IOException, ProcessException, InterruptedException {
 		if (machine == null) {
 			updateMachine();
 		}
@@ -1061,8 +1082,11 @@ public class Transceiver extends UDPTransceiver
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
-	public AppIdTracker getAppIdTracker() throws IOException, ProcessException {
+	public AppIdTracker getAppIdTracker()
+			throws IOException, ProcessException, InterruptedException {
 		if (appIDTracker == null) {
 			updateMachine();
 		}
@@ -1089,7 +1113,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	public VersionInfo getScampVersion(HasChipLocation chip,
 			ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (connectionSelector == null) {
 			connectionSelector = scpSelector;
 		}
@@ -1207,9 +1231,11 @@ public class Transceiver extends UDPTransceiver
 	 *             If SpiNNaker rejects a request.
 	 * @throws IOException
 	 *             If anything fails with networking.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T extends CheckOKResponse> T simpleProcess(SCPRequest<T> request)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return new TxrxProcess(scpSelector, this).synchronousCall(request);
 	}
 
@@ -1333,7 +1359,8 @@ public class Transceiver extends UDPTransceiver
 		return versionInfo;
 	}
 
-	private CoreSubsets getAllCores() throws IOException, ProcessException {
+	private CoreSubsets getAllCores()
+			throws IOException, ProcessException, InterruptedException {
 		if (machine == null) {
 			updateMachine();
 		}
@@ -1351,7 +1378,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafeWithCare
 	public MappableIterable<CPUInfo> getCPUInformation(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Get all the cores if the subsets are not given
 		if (coreSubsets == null) {
 			coreSubsets = getAllCores();
@@ -1364,7 +1391,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafeWithCare
 	public MappableIterable<IOBuffer> getIobuf(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// making the assumption that all chips have the same iobuf size.
 		if (iobufSize == null) {
 			iobufSize = (Integer) getSystemVariable(BOOT_CHIP, iobuf_size);
@@ -1383,7 +1410,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void clearIobuf(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Get all the cores if the subsets are not given
 		if (coreSubsets == null) {
 			coreSubsets = getAllCores();
@@ -1396,7 +1423,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void updateRuntime(Integer runTimesteps, CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Get all the cores if the subsets are not given
 		if (coreSubsets == null) {
 			coreSubsets = getAllCores();
@@ -1410,7 +1437,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void updateProvenanceAndExit(CoreSubsets coreSubsets)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Get all the cores if the subsets are not given
 		if (coreSubsets == null) {
 			coreSubsets = getAllCores();
@@ -1430,7 +1457,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void setWatchDogTimeoutOnChip(HasChipLocation chip, int watchdog)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// write data
 		writeMemory(chip, SYS_VARS.add(software_watchdog_count.offset),
 				oneByte(watchdog));
@@ -1439,7 +1466,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void enableWatchDogTimerOnChip(HasChipLocation chip,
-			boolean watchdog) throws IOException, ProcessException {
+			boolean watchdog)
+			throws IOException, ProcessException, InterruptedException {
 		// write data
 		writeMemory(chip, SYS_VARS.add(software_watchdog_count.offset), oneByte(
 				watchdog ? (Integer) software_watchdog_count.getDefault() : 0));
@@ -1449,7 +1477,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelUnsafe
 	public int getCoreStateCount(AppID appID, CPUState state)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return simpleProcess(new CountState(appID, state)).count;
 	}
 
@@ -1638,14 +1666,15 @@ public class Transceiver extends UDPTransceiver
 	}
 
 	private <T extends BMPRequest.BMPResponse> T bmpCall(BMPCoords bmp,
-			BMPRequest<T> request) throws IOException, ProcessException {
+			BMPRequest<T> request)
+			throws IOException, ProcessException, InterruptedException {
 		return new BMPCommandProcess<T>(bmpConnection(bmp), this)
 				.execute(request);
 	}
 
 	private <T extends BMPRequest.BMPResponse> T bmpCall(BMPCoords bmp,
 			int timeout, int retries, BMPRequest<T> request)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new BMPCommandProcess<T>(bmpConnection(bmp), timeout, this)
 				.execute(request, retries);
 	}
@@ -1696,7 +1725,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void setLED(Collection<Integer> leds, LEDAction action,
 			BMPCoords bmp, Collection<BMPBoard> board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		bmpCall(bmp, new BMPSetLED(leds, action, board));
 	}
 
@@ -1705,7 +1734,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public int readFPGARegister(FPGA fpga, MemoryLocation register,
 			BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp,
 				new ReadFPGARegister(fpga, register, board)).fpgaRegister;
 	}
@@ -1714,7 +1743,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void writeFPGARegister(FPGA fpga, MemoryLocation register, int value,
 			BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		bmpCall(bmp, new WriteFPGARegister(fpga, register, value, board));
 	}
 
@@ -1722,7 +1751,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelUnsafe
 	public ADCInfo readADCData(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new ReadADC(board)).adcInfo;
 	}
 
@@ -1730,7 +1759,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelUnsafe
 	public VersionInfo readBMPVersion(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new GetBMPVersion(board)).versionInfo;
 	}
 
@@ -1739,7 +1768,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafeWithCare
 	public ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, int length)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		return new BMPReadMemoryProcess(bmpConnection(bmp), this).read(board,
 				baseAddress, length);
 	}
@@ -1747,7 +1776,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new BMPWriteMemoryProcess(bmpConnection(bmp), this).writeMemory(board,
 				baseAddress, data);
 	}
@@ -1755,7 +1784,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeBMPMemory(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, File file)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var wmp = new BMPWriteMemoryProcess(bmpConnection(bmp), this);
 		try (var f = buffer(new FileInputStream(file))) {
 			// The file had better fit...
@@ -1765,14 +1794,14 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public MemoryLocation getSerialFlashBuffer(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new ReadSerialVector(board)).vector
 				.getFlashBuffer();
 	}
 
 	@Override
 	public String readBoardSerialNumber(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var serialNumber = new int[SERIAL_LENGTH];
 		bmpCall(bmp, new ReadSerialVector(board)).vector.getSerialNumber()
 				.get(serialNumber);
@@ -1784,7 +1813,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	public ByteBuffer readSerialFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new BMPReadSerialFlashProcess(bmpConnection(bmp), this)
 				.read(board, baseAddress, length);
 	}
@@ -1796,7 +1825,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	public int readSerialFlashCRC(BMPCoords bmp, BMPBoard board,
 			MemoryLocation address, int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, CRC_TIMEOUT, BMP_RETRIES /* =default */,
 				new ReadSerialFlashCRC(board, address, length)).crc;
 	}
@@ -1804,7 +1833,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, ByteBuffer data)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		new BMPWriteSerialFlashProcess(bmpConnection(bmp), this).write(board,
 				baseAddress, data);
 	}
@@ -1812,7 +1841,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, int size, InputStream stream)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		new BMPWriteSerialFlashProcess(bmpConnection(bmp), this).write(board,
 				baseAddress, stream, size);
 	}
@@ -1820,7 +1849,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void writeSerialFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, File file)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		try (var f = buffer(new FileInputStream(file))) {
 			// The file had better fit...
 			new BMPWriteSerialFlashProcess(bmpConnection(bmp), this)
@@ -1830,7 +1859,8 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	public void writeBMPFlash(BMPCoords bmp, BMPBoard board,
-			MemoryLocation address) throws IOException, ProcessException {
+			MemoryLocation address)
+			throws IOException, ProcessException, InterruptedException {
 		bmpCall(bmp, new WriteFlashBuffer(board, address, true));
 	}
 
@@ -1838,14 +1868,15 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public MemoryLocation eraseBMPFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, int size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new EraseFlash(board, baseAddress, size)).address;
 	}
 
 	@Deprecated
 	@Override
 	public void chunkBMPFlash(BMPCoords bmp, BMPBoard board,
-			MemoryLocation address) throws IOException, ProcessException {
+			MemoryLocation address)
+			throws IOException, ProcessException, InterruptedException {
 		bmpCall(bmp, new WriteFlashBuffer(board, address, false));
 	}
 
@@ -1853,7 +1884,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public void copyBMPFlash(BMPCoords bmp, BMPBoard board,
 			MemoryLocation baseAddress, int size)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// NB: no retries of this! Not idempotent!
 		bmpCall(bmp, (int) (MSEC_PER_SEC * BMP_TIMEOUT), 0,
 				new UpdateFlash(board, baseAddress, size));
@@ -1862,21 +1893,22 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public boolean getResetStatus(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new GetFPGAResetStatus(board)).isReset();
 	}
 
 	@Override
 	@ParallelSafe
 	public void resetFPGA(BMPCoords bmp, BMPBoard board,
-			FPGAResetType resetType) throws IOException, ProcessException {
+			FPGAResetType resetType)
+			throws IOException, ProcessException, InterruptedException {
 		bmpCall(bmp, new ResetFPGA(board, resetType));
 	}
 
 	@Override
 	@CheckReturnValue
 	public MappableIterable<BMPBoard> availableBoards(BMPCoords bmp)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return bmpCall(bmp, new ReadCANStatus()).availableBoards()
 				.map(BMPBoard::new);
 	}
@@ -1899,7 +1931,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(numBytes).writeMemory(core, baseAddress, dataStream,
 				numBytes);
 	}
@@ -1907,7 +1939,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(dataFile.length()).writeMemory(core, baseAddress,
 				dataFile);
 	}
@@ -1915,7 +1948,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+			ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(data.remaining()).writeMemory(core, baseAddress, data);
 	}
 
@@ -1923,7 +1957,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
 			MemoryLocation baseAddress, InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(numBytes).writeLink(core, link, baseAddress, dataStream,
 				numBytes);
 	}
@@ -1932,7 +1966,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
 			MemoryLocation baseAddress, File dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(dataFile.length()).writeLink(core, link, baseAddress,
 				dataFile);
 	}
@@ -1941,7 +1975,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void writeNeighbourMemory(HasCoreLocation core, Direction link,
 			MemoryLocation baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeProcess(data.remaining()).writeLink(core, link, baseAddress, data);
 	}
 
@@ -1949,7 +1983,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public void writeMemoryFlood(MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var process = new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
 		synchronized (floodWriteLock) {
@@ -1962,7 +1996,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void writeMemoryFlood(MemoryLocation baseAddress, File dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var process = new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
 		synchronized (floodWriteLock) {
@@ -1975,7 +2009,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void writeMemoryFlood(MemoryLocation baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var process = new WriteMemoryFloodProcess(scpSelector, this);
 		// Ensure only one flood fill occurs at any one time
 		synchronized (floodWriteLock) {
@@ -1989,7 +2023,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public ByteBuffer readMemory(HasCoreLocation core,
 			MemoryLocation baseAddress, int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new ReadMemoryProcess(scpSelector, this).readMemory(core,
 				baseAddress, length);
 	}
@@ -1997,8 +2031,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void readRegion(BufferManagerStorage.Region region,
-			BufferManagerStorage storage)
-			throws IOException, ProcessException, StorageException {
+			BufferManagerStorage storage) throws IOException, ProcessException,
+			StorageException, InterruptedException {
 		new ReadMemoryProcess(scpSelector, this).readMemory(region, storage);
 	}
 
@@ -2007,7 +2041,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelUnsafe
 	public ByteBuffer readNeighbourMemory(HasCoreLocation core, Direction link,
 			MemoryLocation baseAddress, int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new ReadMemoryProcess(scpSelector, this).readLink(core, link,
 				baseAddress, length);
 	}
@@ -2015,7 +2049,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void stopApplication(AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (machineOff) {
 			log.warn("You are calling a app stop on a turned off machine. "
 					+ "Please fix and try again");
@@ -2026,7 +2060,7 @@ public class Transceiver extends UDPTransceiver
 
 	@CheckReturnValue
 	private boolean inErrorStates(AppID appID, Set<CPUState> errorStates)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var state : errorStates) {
 			if (getCoreStateCount(appID, state) > 0) {
 				return true;
@@ -2103,14 +2137,14 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelUnsafe
 	public void sendSignal(AppID appID, Signal signal)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		simpleProcess(new SendSignal(appID, signal));
 	}
 
 	@Override
 	@ParallelSafe
 	public void setLEDs(HasCoreLocation core, Map<Integer, LEDAction> ledStates)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		simpleProcess(new SetLED(core, ledStates));
 	}
 
@@ -2122,7 +2156,8 @@ public class Transceiver extends UDPTransceiver
 
 	@Override
 	@ParallelSafeWithCare
-	public void setIPTag(IPTag tag) throws IOException, ProcessException {
+	public void setIPTag(IPTag tag)
+			throws IOException, ProcessException, InterruptedException {
 		// Check that the tag has a port assigned
 		if (tag.getPort() == null) {
 			throw new IllegalArgumentException(
@@ -2156,7 +2191,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void setIPTag(IPTag tag, SDPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		/*
 		 * Check that the connection is actually pointing to somewhere we know.
 		 */
@@ -2174,7 +2209,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void setReverseIPTag(ReverseIPTag tag)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (requireNonNull(tag).getPort() == SCP_SCAMP_PORT
 				|| tag.getPort() == UDP_BOOT_CONNECTION_DEFAULT_PORT) {
 			throw new IllegalArgumentException(format(
@@ -2204,7 +2239,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void clearIPTag(int tag, InetAddress boardAddress)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var process = simpleProcess();
 		for (var conn : getConnectionList(boardAddress)) {
 			process.synchronousCall(new IPTagClear(conn.getChip(), tag));
@@ -2215,7 +2250,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafeWithCare
 	public List<Tag> getTags(SCPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var allTags = new ArrayList<Tag>();
 		var process = new GetTagsProcess(scpSelector, this);
 		for (var conn : getConnectionList(connection)) {
@@ -2228,7 +2263,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafeWithCare
 	public Map<Tag, Integer> getTagUsage(SCPConnection connection)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var allUsage = new HashMap<Tag, Integer>();
 		var process = new GetTagsProcess(scpSelector, this);
 		for (var conn : getConnectionList(connection)) {
@@ -2241,7 +2276,8 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafe
 	public MemoryLocation mallocSDRAM(HasChipLocation chip, int size,
-			AppID appID, int tag) throws IOException, ProcessException {
+			AppID appID, int tag)
+			throws IOException, ProcessException, InterruptedException {
 		return simpleProcess(
 				new SDRAMAlloc(chip, appID, size, tag)).baseAddress;
 	}
@@ -2249,14 +2285,14 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void freeSDRAM(HasChipLocation chip, MemoryLocation baseAddress)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		simpleProcess(new SDRAMDeAlloc(chip, baseAddress));
 	}
 
 	@Override
 	@ParallelSafe
 	public int freeSDRAM(HasChipLocation chip, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return simpleProcess(new SDRAMDeAlloc(chip, appID)).numFreedBlocks;
 	}
 
@@ -2264,7 +2300,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void loadMulticastRoutes(HasChipLocation chip,
 			Collection<MulticastRoutingEntry> routes, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new MulticastRoutesControlProcess(scpSelector, this).setRoutes(chip,
 				routes, appID);
 	}
@@ -2272,7 +2308,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void loadFixedRoute(HasChipLocation chip, RoutingEntry fixedRoute,
-			AppID appID) throws IOException, ProcessException {
+			AppID appID)
+			throws IOException, ProcessException, InterruptedException {
 		new FixedRouteControlProcess(scpSelector, this).loadFixedRoute(chip,
 				fixedRoute, appID);
 	}
@@ -2281,7 +2318,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafe
 	public RoutingEntry readFixedRoute(HasChipLocation chip, AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new FixedRouteControlProcess(scpSelector, this)
 				.readFixedRoute(chip, appID);
 	}
@@ -2290,7 +2327,8 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafe
 	public List<MulticastRoutingEntry> getMulticastRoutes(HasChipLocation chip,
-			AppID appID) throws IOException, ProcessException {
+			AppID appID)
+			throws IOException, ProcessException, InterruptedException {
 		var address = (MemoryLocation) getSystemVariable(chip,
 				router_table_copy_address);
 		return new MulticastRoutesControlProcess(scpSelector, this)
@@ -2300,7 +2338,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void clearMulticastRoutes(HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		simpleProcess(new RouterClear(chip));
 	}
 
@@ -2308,7 +2346,7 @@ public class Transceiver extends UDPTransceiver
 	@CheckReturnValue
 	@ParallelSafe
 	public RouterDiagnostics getRouterDiagnostics(HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new RouterControlProcess(scpSelector, this)
 				.getRouterDiagnostics(chip);
 	}
@@ -2317,7 +2355,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void setRouterDiagnosticFilter(HasChipLocation chip, int position,
 			DiagnosticFilter diagnosticFilter)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		if (position < 0 || position > NO_ROUTER_DIAGNOSTIC_FILTERS) {
 			throw new IllegalArgumentException(
 					"router filter positions must be between 0 and "
@@ -2341,7 +2379,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public DiagnosticFilter getRouterDiagnosticFilter(HasChipLocation chip,
-			int position) throws IOException, ProcessException {
+			int position)
+			throws IOException, ProcessException, InterruptedException {
 		if (position < 0 || position > NO_ROUTER_DIAGNOSTIC_FILTERS) {
 			throw new IllegalArgumentException(
 					"router filter positions must be between 0 and "
@@ -2357,7 +2396,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void clearRouterDiagnosticCounters(HasChipLocation chip,
 			boolean enable, Iterable<Integer> counterIDs)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		int clearData = 0;
 		for (int counterID : requireNonNull(counterIDs)) {
 			if (counterID < 0 || counterID >= NUM_ROUTER_DIAGNOSTIC_COUNTERS) {
@@ -2377,7 +2416,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void clearReinjectionQueues(HasCoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this)
 				.clearQueue(monitorCore.asCoreLocation());
 	}
@@ -2385,14 +2424,14 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void clearReinjectionQueues(CoreSubsets monitorCores)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).clearQueue(monitorCores);
 	}
 
 	@Override
 	@ParallelSafe
 	public ReinjectionStatus getReinjectionStatus(HasCoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new RouterControlProcess(scpSelector, this)
 				.getReinjectionStatus(monitorCore.asCoreLocation());
 	}
@@ -2400,7 +2439,8 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public Map<CoreLocation, ReinjectionStatus> getReinjectionStatus(
-			CoreSubsets monitorCores) throws IOException, ProcessException {
+			CoreSubsets monitorCores)
+			throws IOException, ProcessException, InterruptedException {
 		return new RouterControlProcess(scpSelector, this)
 				.getReinjectionStatus(monitorCores);
 	}
@@ -2408,7 +2448,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafe
 	public void resetReinjectionCounters(HasCoreLocation monitorCore)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this)
 				.resetCounters(monitorCore.asCoreLocation());
 	}
@@ -2416,7 +2456,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void resetReinjectionCounters(CoreSubsets monitorCores)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).resetCounters(monitorCores);
 	}
 
@@ -2424,7 +2464,8 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void setReinjectionTypes(HasCoreLocation monitorCore,
 			boolean multicast, boolean pointToPoint, boolean fixedRoute,
-			boolean nearestNeighbour) throws IOException, ProcessException {
+			boolean nearestNeighbour)
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setPacketTypes(
 				monitorCore.asCoreLocation(), multicast, pointToPoint,
 				fixedRoute, nearestNeighbour);
@@ -2434,7 +2475,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafeWithCare
 	public void setReinjectionTypes(CoreSubsets monitorCores, boolean multicast,
 			boolean pointToPoint, boolean fixedRoute, boolean nearestNeighbour)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setPacketTypes(monitorCores,
 				multicast, pointToPoint, fixedRoute, nearestNeighbour);
 	}
@@ -2443,7 +2484,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void setReinjectionEmergencyTimeout(HasCoreLocation monitorCore,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setEmergencyTimeout(
 				monitorCore.asCoreLocation(), timeoutMantissa, timeoutExponent);
 	}
@@ -2452,7 +2493,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafeWithCare
 	public void setReinjectionEmergencyTimeout(CoreSubsets monitorCores,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setEmergencyTimeout(
 				monitorCores, timeoutMantissa, timeoutExponent);
 	}
@@ -2461,7 +2502,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void setReinjectionTimeout(HasCoreLocation monitorCore,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setTimeout(
 				monitorCore.asCoreLocation(), timeoutMantissa, timeoutExponent);
 	}
@@ -2470,7 +2511,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafeWithCare
 	public void setReinjectionTimeout(CoreSubsets monitorCores,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this).setTimeout(monitorCores,
 				timeoutMantissa, timeoutExponent);
 	}
@@ -2480,7 +2521,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public List<HeapElement> getHeap(HasChipLocation chip,
 			SystemVariableDefinition heap)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new GetHeapProcess(scpSelector, this).getBlocks(chip, heap);
 	}
 
@@ -2488,7 +2529,7 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void fillMemory(HasChipLocation chip, MemoryLocation baseAddress,
 			int repeatValue, int size, FillDataType dataType)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		if (repeatValue < 1) {
 			throw new IllegalArgumentException("the repeat must be at least 1");
 		}
@@ -2499,7 +2540,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void saveApplicationRouterTables(CoreSubsets monitorCores)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this)
 				.saveApplicationRouterTable(monitorCores);
 	}
@@ -2507,7 +2548,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void loadApplicationRouterTables(CoreSubsets monitorCores)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this)
 				.loadApplicationRouterTable(monitorCores);
 	}
@@ -2515,7 +2556,7 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	@ParallelSafeWithCare
 	public void loadSystemRouterTables(CoreSubsets monitorCores)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		new RouterControlProcess(scpSelector, this)
 				.loadSystemRouterTable(monitorCores);
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -197,11 +197,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	MachineDimensions getMachineDimensions()
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the details of the machine made up of chips on a board and how they
@@ -216,10 +218,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
-	Machine getMachineDetails() throws IOException, ProcessException;
+	Machine getMachineDetails()
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Determines if the board can be contacted.
@@ -251,10 +256,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
-	default VersionInfo getScampVersion() throws IOException, ProcessException {
+	default VersionInfo getScampVersion()
+			throws IOException, ProcessException, InterruptedException {
 		return getScampVersion(BOOT_CHIP, getScampConnectionSelector());
 	}
 
@@ -269,12 +277,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default VersionInfo getScampVersion(
 			@NotNull ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getScampVersion(BOOT_CHIP, connectionSelector);
 	}
 
@@ -288,11 +298,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default VersionInfo getScampVersion(@Valid HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getScampVersion(chip, getScampConnectionSelector());
 	}
 
@@ -309,12 +321,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	VersionInfo getScampVersion(@Valid HasChipLocation chip,
 			@NotNull ConnectionSelector<SCPConnection> connectionSelector)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Attempt to boot the board. No check is performed to see if the board is
@@ -460,11 +474,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	default MappableIterable<CPUInfo> getCPUInformation()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getCPUInformation((CoreSubsets) null);
 	}
 
@@ -478,11 +494,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default CPUInfo getCPUInformation(@Valid HasCoreLocation core)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getCPUInformation(new CoreSubsets(core)).first().orElseThrow();
 	}
 
@@ -503,11 +521,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	MappableIterable<CPUInfo> getCPUInformation(@Valid CoreSubsets coreSubsets)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the address of user<sub>0</sub> for a given processor on the board.
@@ -649,11 +669,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	default MappableIterable<IOBuffer> getIobuf()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getIobuf((CoreSubsets) null);
 	}
 
@@ -667,11 +689,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default IOBuffer getIobuf(@Valid HasCoreLocation core)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getIobuf(new CoreSubsets(core)).first().orElseThrow();
 	}
 
@@ -686,11 +710,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	MappableIterable<IOBuffer> getIobuf(@Valid CoreSubsets coreSubsets)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Clear the contents of the IOBUF buffer for all processors.
@@ -699,9 +725,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
-	default void clearIobuf() throws IOException, ProcessException {
+	default void clearIobuf()
+			throws IOException, ProcessException, InterruptedException {
 		clearIobuf((CoreSubsets) null);
 	}
 
@@ -714,10 +743,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void clearIobuf(@Valid HasCoreLocation core)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		clearIobuf(new CoreSubsets(core));
 	}
 
@@ -730,10 +761,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void clearIobuf(@Valid CoreSubsets coreSubsets)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the value of the watch dog timer on a specific chip.
@@ -746,10 +779,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setWatchDogTimeoutOnChip(@Valid HasChipLocation chip, int watchdog)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Enable or disable the watch dog timer on a specific chip.
@@ -762,10 +797,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void enableWatchDogTimerOnChip(@Valid HasChipLocation chip,
-			boolean watchdog) throws IOException, ProcessException;
+			boolean watchdog)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the value of the watch dog timer.
@@ -776,10 +814,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void setWatchDogTimeout(int watchdog)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var chip : getMachineDetails().chipCoordinates()) {
 			setWatchDogTimeoutOnChip(chip, watchdog);
 		}
@@ -795,10 +835,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void enableWatchDogTimer(boolean watchdog)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var chip : getMachineDetails().chipCoordinates()) {
 			enableWatchDogTimerOnChip(chip, watchdog);
 		}
@@ -819,11 +861,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	int getCoreStateCount(@NotNull AppID appID, @NotNull CPUState state)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Start an executable running on a single core.
@@ -1408,10 +1452,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void updateRuntime(@PositiveOrZero Integer runTimesteps)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		updateRuntime(runTimesteps, (CoreSubsets) null);
 	}
 
@@ -1428,10 +1474,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void updateRuntime(@PositiveOrZero Integer runTimesteps,
-			@Valid HasCoreLocation core) throws IOException, ProcessException {
+			@Valid HasCoreLocation core)
+			throws IOException, ProcessException, InterruptedException {
 		updateRuntime(runTimesteps, new CoreSubsets(core));
 	}
 
@@ -1448,11 +1497,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void updateRuntime(@PositiveOrZero Integer runTimesteps,
 			@Valid CoreSubsets coreSubsets)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Tell all running application cores to write their provenance data to a
@@ -1463,10 +1514,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void updateProvenanceAndExit()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		updateProvenanceAndExit((CoreSubsets) null);
 	}
 
@@ -1481,10 +1534,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void updateProvenanceAndExit(@Valid HasCoreLocation core)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		updateProvenanceAndExit(new CoreSubsets(core));
 	}
 
@@ -1499,10 +1554,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void updateProvenanceAndExit(@Valid CoreSubsets coreSubsets)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1522,12 +1579,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress,
 			@NotNull InputStream dataStream, @Positive int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(chip.getScampCore(), baseAddress, dataStream, numBytes);
 	}
 
@@ -1549,12 +1608,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void writeMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress,
 			@NotNull InputStream dataStream, @Positive int numBytes)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1572,11 +1633,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, @NotNull File dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(chip.getScampCore(), baseAddress, dataFile);
 	}
 
@@ -1596,11 +1659,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void writeMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress, @NotNull File dataFile)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM on the board.
@@ -1617,11 +1682,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, int dataWord)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(chip.getScampCore(), baseAddress, dataWord);
 	}
 
@@ -1640,11 +1707,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress, int dataWord)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeMemory(core, baseAddress, b);
@@ -1665,11 +1734,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, @NotEmpty byte[] data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(chip.getScampCore(), baseAddress, wrap(data));
 	}
 
@@ -1688,11 +1759,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress, @NotEmpty byte[] data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(core, baseAddress, wrap(data));
 	}
 
@@ -1712,11 +1785,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void writeMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemory(chip.getScampCore(), baseAddress, data);
 	}
 
@@ -1736,11 +1811,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void writeMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the user<sub>0</sub> register of a core.
@@ -1754,9 +1831,11 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser0(@Valid HasCoreLocation core, int value)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser0RegisterAddress(core), value);
 	}
 
@@ -1772,10 +1851,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser0(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation pointer)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser0RegisterAddress(core),
 				pointer.address);
 	}
@@ -1792,9 +1873,11 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser1(@Valid HasCoreLocation core, int value)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser1RegisterAddress(core), value);
 	}
 
@@ -1809,10 +1892,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser1(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation pointer)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser1RegisterAddress(core),
 				pointer.address);
 	}
@@ -1829,9 +1914,11 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser2(@Valid HasCoreLocation core, int value)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser2RegisterAddress(core), value);
 	}
 
@@ -1846,10 +1933,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	default void writeUser2(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation pointer)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		writeMemory(core.getScampCore(), getUser2RegisterAddress(core),
 				pointer.address);
 	}
@@ -1880,12 +1969,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
 			@NotNull InputStream dataStream, @Positive int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataStream,
 				numBytes);
 	}
@@ -1917,12 +2008,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void writeNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
 			@NotNull InputStream dataStream, @Positive int numBytes)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
@@ -1948,11 +2041,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotNull File dataFile) throws IOException, ProcessException {
+			@NotNull File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataFile);
 	}
 
@@ -1981,11 +2077,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void writeNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotNull File dataFile) throws IOException, ProcessException;
+			@NotNull File dataFile)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the memory of a neighbouring chip using a LINK_WRITE SCP
@@ -2010,11 +2109,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			int dataWord) throws IOException, ProcessException {
+			int dataWord)
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, dataWord);
 	}
 
@@ -2042,11 +2144,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			int dataWord) throws IOException, ProcessException {
+			int dataWord)
+			throws IOException, ProcessException, InterruptedException {
 		var b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeNeighbourMemory(core, link, baseAddress, b);
@@ -2075,11 +2180,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotEmpty byte[] data) throws IOException, ProcessException {
+			@NotEmpty byte[] data)
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
 
@@ -2107,11 +2215,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotEmpty byte[] data) throws IOException, ProcessException {
+			@NotEmpty byte[] data)
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(core, link, baseAddress, wrap(data));
 	}
 
@@ -2139,11 +2250,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void writeNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotNull ByteBuffer data) throws IOException, ProcessException {
+			@NotNull ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException {
 		writeNeighbourMemory(chip.getScampCore(), link, baseAddress, data);
 	}
 
@@ -2172,11 +2286,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void writeNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@NotNull ByteBuffer data) throws IOException, ProcessException;
+			@NotNull ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2197,11 +2314,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void writeMemoryFlood(@NotNull MemoryLocation baseAddress,
 			@NotNull InputStream dataStream, @Positive int numBytes)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2220,10 +2339,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void writeMemoryFlood(@NotNull MemoryLocation baseAddress,
-			@NotNull File dataFile) throws IOException, ProcessException;
+			@NotNull File dataFile)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Write to the SDRAM of all chips.
@@ -2241,10 +2363,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void writeMemoryFlood(@NotNull MemoryLocation baseAddress,
-			int dataWord) throws IOException, ProcessException {
+			int dataWord)
+			throws IOException, ProcessException, InterruptedException {
 		var b = allocate(WORD_SIZE).order(LITTLE_ENDIAN);
 		b.putInt(dataWord).flip();
 		writeMemoryFlood(baseAddress, b);
@@ -2266,10 +2391,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void writeMemoryFlood(@NotNull MemoryLocation baseAddress,
-			@NotEmpty byte[] data) throws IOException, ProcessException {
+			@NotEmpty byte[] data)
+			throws IOException, ProcessException, InterruptedException {
 		writeMemoryFlood(baseAddress, wrap(data));
 	}
 
@@ -2290,10 +2418,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void writeMemoryFlood(@NotNull MemoryLocation baseAddress,
-			@NotNull ByteBuffer data) throws IOException, ProcessException;
+			@NotNull ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read some areas of SDRAM from the board.
@@ -2312,12 +2443,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default ByteBuffer readMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readMemory(chip.getScampCore(), baseAddress, length);
 	}
 
@@ -2338,12 +2471,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	ByteBuffer readMemory(@Valid HasCoreLocation core,
 			@NotNull MemoryLocation baseAddress, @Positive int length)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Read the contents of an allocated block on the heap from the board. The
@@ -2361,11 +2496,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default ByteBuffer readMemory(@Valid HasCoreLocation core,
-			@NotNull HeapElement element) throws IOException, ProcessException {
+			@NotNull HeapElement element)
+			throws IOException, ProcessException, InterruptedException {
 		if (element.isFree) {
 			return null;
 		}
@@ -2388,11 +2526,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If anything goes wrong with access to the database.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void readRegion(@Valid BufferManagerStorage.Region region,
-			@NotNull BufferManagerStorage storage)
-			throws IOException, ProcessException, StorageException;
+			@NotNull BufferManagerStorage storage) throws IOException,
+			ProcessException, StorageException, InterruptedException;
 
 	/**
 	 * Read the user<sub>0</sub> register of a core.
@@ -2404,10 +2544,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default int readUser0(@Valid HasCoreLocation core)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		var user0 = getUser0RegisterAddress(core);
 		return readMemory(core.getScampCore(), user0, WORD_SIZE).getInt();
 	}
@@ -2422,10 +2564,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default int readUser1(@Valid HasCoreLocation core)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		var user1 = getUser1RegisterAddress(core);
 		return readMemory(core.getScampCore(), user1, WORD_SIZE).getInt();
 	}
@@ -2440,10 +2584,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
 	default int readUser2(@Valid HasCoreLocation core)
-			throws ProcessException, IOException {
+			throws ProcessException, IOException, InterruptedException {
 		var user2 = getUser2RegisterAddress(core);
 		return readMemory(core.getScampCore(), user2, WORD_SIZE).getInt();
 	}
@@ -2472,11 +2618,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default ByteBuffer readNeighbourMemory(@Valid HasChipLocation chip,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@Positive int length) throws IOException, ProcessException {
+			@Positive int length)
+			throws IOException, ProcessException, InterruptedException {
 		return readNeighbourMemory(chip.getScampCore(), link, baseAddress,
 				length);
 	}
@@ -2507,11 +2656,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	ByteBuffer readNeighbourMemory(@Valid HasCoreLocation core,
 			@NotNull Direction link, @NotNull MemoryLocation baseAddress,
-			@Positive int length) throws IOException, ProcessException;
+			@Positive int length)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Sends a stop request for an application ID.
@@ -2525,10 +2677,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void stopApplication(@NotNull AppID appID)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Waits for the specified cores running the given application to be in some
@@ -2619,11 +2773,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default CoreSubsets getCoresInState(@Valid CoreSubsets allCoreSubsets,
-			@NotNull CPUState state) throws IOException, ProcessException {
+			@NotNull CPUState state)
+			throws IOException, ProcessException, InterruptedException {
 		return getCoresInState(allCoreSubsets, Set.of(state));
 	}
 
@@ -2643,12 +2800,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default CoreSubsets getCoresInState(@Valid CoreSubsets allCoreSubsets,
 			Set<@NotNull CPUState> states)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return new CoreSubsets(getCPUInformation(allCoreSubsets)
 				.filter(info -> states.contains(info.getState()))
 				.map(CPUInfo::asCoreLocation));
@@ -2670,12 +2829,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default Map<CoreLocation, CPUInfo> getCoresNotInState(
 			@Valid CoreSubsets allCoreSubsets, @NotNull CPUState state)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getCoresNotInState(allCoreSubsets, Set.of(state));
 	}
 
@@ -2695,12 +2856,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	@CheckReturnValue
 	default Map<CoreLocation, CPUInfo> getCoresNotInState(
 			@Valid CoreSubsets allCoreSubsets, Set<@NotNull CPUState> states)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getCPUInformation(allCoreSubsets)
 				.filter(info -> !states.contains(info.getState()))
 				.toMap(TreeMap::new, CPUInfo::asCoreLocation, identity());
@@ -2720,10 +2883,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	void sendSignal(@NotNull AppID appID, @NotNull Signal signal)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set LED states.
@@ -2737,11 +2902,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setLEDs(@Valid HasChipLocation chip,
 			Map<Integer, LEDAction> ledStates)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setLEDs(chip.getScampCore(), ledStates);
 	}
 
@@ -2757,10 +2924,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setLEDs(@Valid HasCoreLocation core, Map<Integer, LEDAction> ledStates)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Find a connection that matches the given board IP address.
@@ -2783,9 +2952,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
-	void setIPTag(@Valid IPTag tag) throws IOException, ProcessException;
+	void setIPTag(@Valid IPTag tag)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set up an IP tag to deliver messages to a particular connection.
@@ -2799,10 +2971,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void setIPTag(@Valid IPTag tag, @NotNull SDPConnection connection)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set up a reverse IP tag.
@@ -2815,10 +2989,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setReverseIPTag(@Valid ReverseIPTag tag)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Clear the setting of an IP tag.
@@ -2829,10 +3005,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void clearIPTag(@Valid Tag tag)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		clearIPTag(tag.getTag(), tag.getBoardAddress());
 	}
 
@@ -2848,10 +3026,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	default void clearIPTag(@TagID int tag)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		clearIPTag(tag, null);
 	}
 
@@ -2868,10 +3048,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void clearIPTag(@TagID int tag, InetAddress boardAddress)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the current set of tags that have been set on the board using all
@@ -2885,10 +3067,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
-	default List<Tag> getTags() throws IOException, ProcessException {
+	default List<Tag> getTags()
+			throws IOException, ProcessException, InterruptedException {
 		return getTags(null);
 	}
 
@@ -2902,11 +3087,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	List<Tag> getTags(SCPConnection connection)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the number of times each tag has had a message sent via it using all
@@ -2920,11 +3107,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelUnsafe
 	@CheckReturnValue
 	default Map<Tag, Integer> getTagUsage()
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getTagUsage(null);
 	}
 
@@ -2939,11 +3128,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	Map<Tag, Integer> getTagUsage(@NotNull SCPConnection connection)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Allocates a chunk of SDRAM on a chip on the machine.
@@ -2957,11 +3148,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default MemoryLocation mallocSDRAM(@Valid HasChipLocation chip,
-			@Positive int size) throws IOException, ProcessException {
+			@Positive int size)
+			throws IOException, ProcessException, InterruptedException {
 		return mallocSDRAM(chip, size, DEFAULT, 0);
 	}
 
@@ -2979,12 +3173,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default MemoryLocation mallocSDRAM(@Valid HasChipLocation chip,
 			@Positive int size, @NotNull AppID appID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return mallocSDRAM(chip, size, appID, 0);
 	}
 
@@ -3006,10 +3202,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	MemoryLocation mallocSDRAM(@Valid HasChipLocation chip, @Positive int size,
-			@NotNull AppID appID, int tag) throws IOException, ProcessException;
+			@NotNull AppID appID, int tag)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Free allocated SDRAM.
@@ -3022,11 +3221,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void freeSDRAM(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Free all SDRAM allocated to a given application ID.
@@ -3040,10 +3241,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	int freeSDRAM(@Valid HasChipLocation chip, @NotNull AppID appID)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Load a set of multicast routes on to a chip associated with the default
@@ -3057,11 +3260,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void loadMulticastRoutes(@Valid HasChipLocation chip,
 			Collection<@NotNull MulticastRoutingEntry> routes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		loadMulticastRoutes(chip, routes, DEFAULT);
 	}
 
@@ -3078,11 +3283,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void loadMulticastRoutes(@Valid HasChipLocation chip,
 			Collection<@NotNull MulticastRoutingEntry> routes,
-			@NotNull AppID appID) throws IOException, ProcessException;
+			@NotNull AppID appID)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Loads a fixed route routing table entry onto a chip's router.
@@ -3095,11 +3303,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void loadFixedRoute(@Valid HasChipLocation chip,
 			@Valid RoutingEntry fixedRoute)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		loadFixedRoute(chip, fixedRoute, DEFAULT);
 	}
 
@@ -3116,11 +3326,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void loadFixedRoute(@Valid HasChipLocation chip,
 			@Valid RoutingEntry fixedRoute, @NotNull AppID appID)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Reads a fixed route routing table entry from a chip's router.
@@ -3132,11 +3344,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default RoutingEntry readFixedRoute(@Valid HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return readFixedRoute(chip, DEFAULT);
 	}
 
@@ -3152,11 +3366,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	RoutingEntry readFixedRoute(@Valid HasChipLocation chip,
-			@NotNull AppID appID) throws IOException, ProcessException;
+			@NotNull AppID appID)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the current multicast routes set up on a chip.
@@ -3168,11 +3385,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default List<MulticastRoutingEntry> getMulticastRoutes(
-			@Valid HasChipLocation chip) throws IOException, ProcessException {
+			@Valid HasChipLocation chip)
+			throws IOException, ProcessException, InterruptedException {
 		return getMulticastRoutes(chip, null);
 	}
 
@@ -3189,11 +3409,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	List<MulticastRoutingEntry> getMulticastRoutes(@Valid HasChipLocation chip,
-			AppID appID) throws IOException, ProcessException;
+			AppID appID)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Remove all the multicast routes on a chip.
@@ -3204,10 +3427,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void clearMulticastRoutes(@Valid HasChipLocation chip)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get router diagnostic information from a chip.
@@ -3219,11 +3444,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	RouterDiagnostics getRouterDiagnostics(@Valid HasChipLocation chip)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Sets a router diagnostic filter in a router.
@@ -3241,11 +3468,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setRouterDiagnosticFilter(@Valid HasChipLocation chip, int position,
 			@NotNull DiagnosticFilter diagnosticFilter)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Gets a router diagnostic filter from a router.
@@ -3261,11 +3490,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	DiagnosticFilter getRouterDiagnosticFilter(@Valid HasChipLocation chip,
-			@PositiveOrZero int position) throws IOException, ProcessException;
+			@PositiveOrZero int position)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Clear router diagnostic information on a chip. Resets and enables all
@@ -3277,10 +3509,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void clearRouterDiagnosticCounters(@Valid HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		clearRouterDiagnosticCounters(chip, false,
 				range(0, NO_ROUTER_DIAGNOSTIC_FILTERS).boxed()
 						.collect(toList()));
@@ -3298,10 +3532,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void clearRouterDiagnosticCounters(@Valid HasChipLocation chip,
-			boolean enable) throws IOException, ProcessException {
+			boolean enable)
+			throws IOException, ProcessException, InterruptedException {
 		clearRouterDiagnosticCounters(chip, enable,
 				range(0, NO_ROUTER_DIAGNOSTIC_FILTERS).boxed()
 						.collect(toList()));
@@ -3320,11 +3557,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void clearRouterDiagnosticCounters(@Valid HasChipLocation chip,
 			Iterable<@NotNull Integer> counterIDs)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		clearRouterDiagnosticCounters(chip, false, counterIDs);
 	}
 
@@ -3342,11 +3581,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void clearRouterDiagnosticCounters(@Valid HasChipLocation chip,
 			boolean enable, Iterable<@NotNull Integer> counterIDs)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the contents of the SDRAM heap on a given chip.
@@ -3358,11 +3599,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	default List<HeapElement> getHeap(@Valid HasChipLocation chip)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return getHeap(chip, sdram_heap_address);
 	}
 
@@ -3378,12 +3621,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	List<HeapElement> getHeap(@Valid HasChipLocation chip,
 			@NotNull SystemVariableDefinition heap)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Fill some memory with repeated data.
@@ -3402,11 +3647,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void fillMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, int repeatValue,
-			@Positive int size) throws ProcessException, IOException {
+			@Positive int size)
+			throws ProcessException, IOException, InterruptedException {
 		fillMemory(chip, baseAddress, repeatValue, size, WORD);
 	}
 
@@ -3429,12 +3677,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void fillMemory(@Valid HasChipLocation chip,
 			@NotNull MemoryLocation baseAddress, int repeatValue,
 			@Positive int size, @NotNull FillDataType dataType)
-			throws ProcessException, IOException;
+			throws ProcessException, IOException, InterruptedException;
 
 	/**
 	 * Clear the packet reinjection queues in a monitor process.
@@ -3445,10 +3695,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void clearReinjectionQueues(@Valid HasCoreLocation monitorCore)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Clear the packet reinjection queues in some monitor processes.
@@ -3459,10 +3711,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void clearReinjectionQueues(@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the packet reinjection status of a monitor process.
@@ -3474,11 +3728,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	ReinjectionStatus getReinjectionStatus(@Valid HasCoreLocation monitorCore)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Get the packet reinjection status of some monitor processes.
@@ -3490,12 +3746,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	@CheckReturnValue
 	Map<CoreLocation, ReinjectionStatus> getReinjectionStatus(
 			@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Reset the packet reinjection counters of a monitor process.
@@ -3506,10 +3764,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void resetReinjectionCounters(@Valid HasCoreLocation monitorCore)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Reset the packet reinjection counters of some monitor processes.
@@ -3520,10 +3780,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void resetReinjectionCounters(@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set whether packets (of all types) are to be reinjected.
@@ -3536,10 +3798,15 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjection(@Valid HasCoreLocation monitorCore,
-			boolean reinject) throws IOException, ProcessException {
+			boolean reinject)
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTypes(monitorCore, reinject, reinject, reinject,
 				reinject);
 	}
@@ -3555,10 +3822,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjection(@Valid CoreSubsets monitorCores,
-			boolean reinject) throws IOException, ProcessException {
+			boolean reinject)
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTypes(monitorCores, reinject, reinject, reinject,
 				reinject);
 	}
@@ -3574,11 +3844,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjection(@Valid HasCoreLocation monitorCore,
 			@NotNull ReinjectionStatus status)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTypes(monitorCore, status.isReinjectingMulticast(),
 				status.isReinjectingPointToPoint(),
 				status.isReinjectingFixedRoute(),
@@ -3596,11 +3868,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjection(@Valid CoreSubsets monitorCores,
 			@NotNull ReinjectionStatus status)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTypes(monitorCores, status.isReinjectingMulticast(),
 				status.isReinjectingPointToPoint(),
 				status.isReinjectingFixedRoute(),
@@ -3624,11 +3898,14 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setReinjectionTypes(@Valid HasCoreLocation monitorCore,
 			boolean multicast, boolean pointToPoint, boolean fixedRoute,
-			boolean nearestNeighbour) throws IOException, ProcessException;
+			boolean nearestNeighbour)
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set what types of packets are to be reinjected.
@@ -3647,11 +3924,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void setReinjectionTypes(@Valid CoreSubsets monitorCores, boolean multicast,
 			boolean pointToPoint, boolean fixedRoute, boolean nearestNeighbour)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the emergency packet reinjection timeout.
@@ -3666,11 +3945,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setReinjectionEmergencyTimeout(@Valid HasCoreLocation monitorCore,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the emergency packet reinjection timeout.
@@ -3683,11 +3964,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjectionEmergencyTimeout(
 			@Valid HasCoreLocation monitorCore, @NotNull RouterTimeout timeout)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionEmergencyTimeout(monitorCore, timeout.mantissa,
 				timeout.exponent);
 	}
@@ -3705,11 +3988,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void setReinjectionEmergencyTimeout(@Valid CoreSubsets monitorCores,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the emergency packet reinjection timeout.
@@ -3722,11 +4007,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void setReinjectionEmergencyTimeout(@Valid CoreSubsets monitorCores,
 			@NotNull RouterTimeout timeout)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionEmergencyTimeout(monitorCores, timeout.mantissa,
 				timeout.exponent);
 	}
@@ -3742,11 +4029,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void setReinjectionEmergencyTimeout(@Valid CoreSubsets monitorCores,
 			@NotNull ReinjectionStatus status)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionEmergencyTimeout(monitorCores,
 				status.getEmergencyTimeout());
 	}
@@ -3764,11 +4053,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	void setReinjectionTimeout(@Valid HasCoreLocation monitorCore,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the packet reinjection timeout.
@@ -3781,11 +4072,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafe
 	default void setReinjectionTimeout(@Valid HasCoreLocation monitorCore,
 			@NotNull RouterTimeout timeout)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTimeout(monitorCore, timeout.mantissa, timeout.exponent);
 	}
 
@@ -3802,11 +4095,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void setReinjectionTimeout(@Valid CoreSubsets monitorCores,
 			int timeoutMantissa, int timeoutExponent)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Set the packet reinjection timeout.
@@ -3819,11 +4114,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void setReinjectionTimeout(@Valid CoreSubsets monitorCores,
 			@NotNull RouterTimeout timeout)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTimeout(monitorCores, timeout.mantissa, timeout.exponent);
 	}
 
@@ -3838,11 +4135,13 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	default void setReinjectionTimeout(@Valid CoreSubsets monitorCores,
 			@NotNull ReinjectionStatus status)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		setReinjectionTimeout(monitorCores, status.getTimeout());
 	}
 
@@ -3856,10 +4155,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void saveApplicationRouterTables(@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Load the (previously saved) application's multicast router tables. The
@@ -3873,10 +4174,12 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void loadApplicationRouterTables(@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 
 	/**
 	 * Load the (previously configured) system multicast router tables. The
@@ -3890,8 +4193,10 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	@ParallelSafeWithCare
 	void loadSystemRouterTables(@Valid CoreSubsets monitorCores)
-			throws IOException, ProcessException;
+			throws IOException, ProcessException, InterruptedException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TxrxProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TxrxProcess.java
@@ -186,9 +186,11 @@ class TxrxProcess {
 	 *            The request to send.
 	 * @throws IOException
 	 *             If sending fails.
+	 * @throws InterruptedException
+	 *             If communications are interrupted while preparing to send.
 	 */
 	protected final <Resp extends CheckOKResponse> void sendRequest(
-			SCPRequest<Resp> request) throws IOException {
+			SCPRequest<Resp> request) throws IOException, InterruptedException {
 		sendRequest(request, null);
 	}
 
@@ -205,10 +207,12 @@ class TxrxProcess {
 	 *            (i.e., checked for any failures) and then discarded.
 	 * @throws IOException
 	 *             If sending fails.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	protected final <Resp extends CheckOKResponse> void sendRequest(
 			SCPRequest<Resp> request, Consumer<Resp> callback)
-			throws IOException {
+			throws IOException, InterruptedException {
 		getPipeline(request).sendRequest(request, callback, this::receiveError);
 	}
 
@@ -245,9 +249,11 @@ class TxrxProcess {
 	 *            The request to send. <em>Must</em> be a one-way request!
 	 * @throws IOException
 	 *             If sending fails.
+	 * @throws InterruptedException
+	 *             If communications are interrupted while preparing to send.
 	 */
-	protected final void sendOneWayRequest(
-			SCPRequest<NoResponse> request) throws IOException {
+	protected final void sendOneWayRequest(SCPRequest<NoResponse> request)
+			throws IOException, InterruptedException {
 		getPipeline(request).sendOneWayRequest(request);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryFloodProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryFloodProcess.java
@@ -70,9 +70,12 @@ class WriteMemoryFloodProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+			ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException {
 		data = data.asReadOnlyBuffer();
 		int numBytes = data.remaining();
 		synchronousCall(
@@ -113,10 +116,12 @@ class WriteMemoryFloodProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
 			InputStream dataStream, int numBytes)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		synchronousCall(
 				new FloodFillStart(nearestNeighbourID, numBlocks(numBytes)));
 
@@ -153,9 +158,12 @@ class WriteMemoryFloodProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or access to the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(byte nearestNeighbourID, MemoryLocation baseAddress,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		try (var s = buffer(new FileInputStream(dataFile))) {
 			writeMemory(nearestNeighbourID, baseAddress, s,
 					(int) dataFile.length());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
@@ -113,10 +113,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
 			MemoryLocation baseAddress, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemoryFlow(baseAddress, data, (addr, bytes) -> new WriteLink(core,
 				linkDirection, addr, bytes));
 	}
@@ -139,10 +141,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
 			MemoryLocation baseAddress, InputStream data, int bytesToWrite)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemoryFlow(baseAddress, data, bytesToWrite, (addr,
 				bytes) -> new WriteLink(core, linkDirection, addr, bytes));
 	}
@@ -164,10 +168,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or access to the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeLink(HasCoreLocation core, Direction linkDirection,
 			MemoryLocation baseAddress, File dataFile)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		try (var data = buffer(new FileInputStream(dataFile))) {
 			writeMemoryFlow(baseAddress, data, (int) dataFile.length(), (addr,
 					bytes) -> new WriteLink(core, linkDirection, addr, bytes));
@@ -190,9 +196,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
-			ByteBuffer data) throws IOException, ProcessException {
+			ByteBuffer data)
+			throws IOException, ProcessException, InterruptedException {
 		writeMemoryFlow(baseAddress, data,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -213,10 +222,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
 			InputStream data, int bytesToWrite)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		writeMemoryFlow(baseAddress, data, bytesToWrite,
 				(addr, bytes) -> new WriteMemory(core, addr, bytes));
 	}
@@ -236,9 +247,12 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or access to the file.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	void writeMemory(HasCoreLocation core, MemoryLocation baseAddress,
-			File dataFile) throws IOException, ProcessException {
+			File dataFile)
+			throws IOException, ProcessException, InterruptedException {
 		try (var data = buffer(new FileInputStream(dataFile))) {
 			writeMemoryFlow(baseAddress, data, (int) dataFile.length(),
 					(addr, bytes) -> new WriteMemory(core, addr, bytes));
@@ -260,11 +274,13 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
 			MemoryLocation baseAddress, ByteBuffer data,
 			MessageProvider<T> msgProvider)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		int offset = data.position();
 		int bytesToWrite = data.remaining();
 		var writePosition = baseAddress;
@@ -298,11 +314,13 @@ class WriteMemoryProcess extends TxrxProcess {
 	 *             If anything goes wrong with networking or the input stream.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If the communications were interrupted.
 	 */
 	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
 			MemoryLocation baseAddress, InputStream data, int bytesToWrite,
 			MessageProvider<T> msgProvider)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var writePosition = baseAddress;
 		var workingBuffer = allocate(UDP_MESSAGE_MAX_SIZE);
 		while (bytesToWrite > 0) {

--- a/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
+++ b/SpiNNaker-comms/src/test/java/testconfig/BoardTestConfiguration.java
@@ -148,7 +148,7 @@ public class BoardTestConfiguration {
 	@MustBeClosed
 	public SpallocJob setUpSpallocedBoard()
 			throws IOException, SpallocServerException, JobDestroyedException,
-			SpallocStateChangeTimeoutException {
+			SpallocStateChangeTimeoutException, InterruptedException {
 		var spalloc = config.get(SPSEC, "hostname");
 		assumeTrue(spalloc != null, "no spalloc server defined");
 		assumeTrue(hostIsReachable(spalloc),

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -275,7 +275,8 @@ class MockWriteTransceiver extends Transceiver {
 	MockWriteTransceiver(MachineVersion version,
 			Collection<Connection> connections)
 			throws IOException, SpinnmanException,
-			uk.ac.manchester.spinnaker.transceiver.ProcessException {
+			uk.ac.manchester.spinnaker.transceiver.ProcessException,
+			InterruptedException {
 		super(version, connections, null, null, null, null, null);
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -340,10 +340,12 @@ public final class CommandLineInterface {
 	 *             If a BMP is uncontactable or SpiNNaker rejects a message
 	 * @throws StorageException
 	 *             If the database is in an illegal state
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public static void downloadRun(String placementsJsonFile,
 			String machineJsonFile, String runFolder) throws IOException,
-			SpinnmanException, StorageException {
+			SpinnmanException, StorageException, InterruptedException {
 		var placements = getPlacements(placementsJsonFile);
 		var machine = getMachine(machineJsonFile);
 		var db = getDatabase(runFolder);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/NoDropPacketContext.java
@@ -88,11 +88,13 @@ public class NoDropPacketContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public NoDropPacketContext(TransceiverInterface txrx,
 			CoreSubsets monitorCores, CoreSubsets gatherers)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		this.txrx = txrx;
 		this.monitorCores = monitorCores;
 		// Store the last reinjection status for resetting
@@ -136,11 +138,13 @@ public class NoDropPacketContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public NoDropPacketContext(TransceiverInterface txrx,
 			CoreSubsets monitorCoreLocations, Gather gatherer)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		this(txrx, monitorCoreLocations, convertToCoreSubset(gatherer));
 	}
 
@@ -160,11 +164,14 @@ public class NoDropPacketContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public NoDropPacketContext(TransceiverInterface txrx,
 			List<? extends HasCoreLocation> monitorCoreLocations,
-			Gather gatherer) throws IOException, ProcessException {
+			Gather gatherer)
+			throws IOException, ProcessException, InterruptedException {
 		this(txrx, convertToCoreSubset(monitorCoreLocations),
 				convertToCoreSubset(gatherer));
 	}
@@ -185,11 +192,14 @@ public class NoDropPacketContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public NoDropPacketContext(TransceiverInterface txrx,
 			Stream<? extends HasCoreLocation> monitorCoreLocations,
-			Stream<Gather> gatherers) throws IOException, ProcessException {
+			Stream<Gather> gatherers)
+			throws IOException, ProcessException, InterruptedException {
 		this(txrx, convertToCoreSubset(monitorCoreLocations),
 				convertToCoreSubset(gatherers));
 	}
@@ -224,9 +234,12 @@ public class NoDropPacketContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@Override
-	public void close() throws IOException, ProcessException {
+	public void close()
+			throws IOException, ProcessException, InterruptedException {
 		log.info("switching board at {} to standard mode", firstChip);
 		quietlySetTemporaryTimeouts();
 
@@ -237,6 +250,10 @@ public class NoDropPacketContext implements AutoCloseable {
 			txrx.setReinjection(monitorCores, lastStatus);
 			log.debug("switched board at {} to standard mode", firstChip);
 			return;
+		} catch (IOException | ProcessException | InterruptedException
+				| RuntimeException e) {
+			log.error("error resetting router timeouts", e);
+			throw e;
 		} catch (Exception e) {
 			log.error("error resetting router timeouts", e);
 		}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -184,9 +184,11 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If DB access goes wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	public int gather(List<Gather> gatherers)
-			throws IOException, ProcessException, StorageException {
+	public int gather(List<Gather> gatherers) throws IOException,
+			ProcessException, StorageException, InterruptedException {
 		sanityCheck(gatherers);
 		var workSize = new ValueHolder<>(0);
 		Map<ChipLocation, List<WorkItems>> work;
@@ -267,10 +269,13 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If DB access goes wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	private Map<ChipLocation, List<WorkItems>> discoverActualWork(
 			List<Gather> gatherers, ValueHolder<Integer> workSize, Progress bar)
-			throws IOException, ProcessException, StorageException {
+			throws IOException, ProcessException, StorageException,
+			InterruptedException {
 		log.info("discovering regions to download");
 		var work = new HashMap<ChipLocation, List<WorkItems>>();
 		int count = 0;
@@ -320,10 +325,12 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If IO fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	private Map<ChipLocation, GatherDownloadConnection> createConnections(
 			List<Gather> gatherers, Map<ChipLocation, ?> work)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		log.info("building high-speed data connections and configuring IPtags");
 		var connections = new HashMap<ChipLocation, GatherDownloadConnection>();
 		for (var g : gatherers) {
@@ -350,13 +357,15 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If DB access goes wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	private void parallel(Stream<SimpleCallable> tasks)
-			throws IOException, ProcessException, StorageException {
+	private void parallel(Stream<SimpleCallable> tasks) throws IOException,
+			ProcessException, StorageException, InterruptedException {
 		try {
 			pool.submitTasks(tasks).awaitAndCombineExceptions();
 		} catch (IOException | StorageException | ProcessException
-				| RuntimeException e) {
+				| InterruptedException | RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new RuntimeException("unexpected exception", e);
@@ -380,10 +389,13 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If a download times out unrecoverably.
 	 * @throws ProcessException
 	 *             If anything unexpected goes wrong.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	private void fastDownload(List<WorkItems> work,
-			GatherDownloadConnection conn, Progress bar) throws IOException,
-			StorageException, TimeoutException, ProcessException {
+			GatherDownloadConnection conn, Progress bar)
+			throws IOException, StorageException, TimeoutException,
+			ProcessException, InterruptedException {
 		try (var c = new BoardLocal(conn.getChip())) {
 			log.info("processing fast downloads for {}", conn.getChip());
 			var dl = new Downloader(conn);
@@ -430,7 +442,7 @@ public abstract class DataGatherer extends BoardLocalSupport
 	}
 
 	private void compareDownloadWithSCP(Region r, ByteBuffer data)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var data2 = txrx.readMemory(r.core.asChipLocation(), r.startAddress,
 				r.size);
 		if (data.remaining() != data2.remaining()) {
@@ -494,9 +506,11 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If message sending or reception fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	private void reconfigureIPtag(IPTag iptag, GatherDownloadConnection conn)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		txrx.setIPTag(iptag, conn);
 		if (log.isDebugEnabled()) {
 			log.debug("all tags for board: {}", txrx.getTags(
@@ -526,11 +540,14 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 *             If SpiNNaker rejects a message.
 	 * @throws StorageException
 	 *             If the database doesn't like something.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@UsedInJavadocOnly(BufferManagerStorage.class)
 	@ForOverride
 	protected abstract List<Region> getRegion(Placement placement, int regionID)
-			throws IOException, ProcessException, StorageException;
+			throws IOException, ProcessException, StorageException,
+			InterruptedException;
 
 	/**
 	 * Store the data retrieved from a region. Called (at most) once for each

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -639,9 +639,12 @@ public abstract class DataGatherer extends BoardLocalSupport
 		 *             If a download times out unrecoverably.
 		 * @throws ProcessException
 		 *             If anything unexpected goes wrong.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		ByteBuffer doDownload(Monitor extraMonitor, Region region)
-				throws IOException, TimeoutException, ProcessException {
+				throws IOException, TimeoutException, ProcessException,
+				InterruptedException {
 			monitorCore = extraMonitor;
 			dataReceiver = allocate(region.size);
 			/*
@@ -711,9 +714,11 @@ public abstract class DataGatherer extends BoardLocalSupport
 		 * @throws TimeoutException
 		 *             If we have a full timeout, or if we are flailing around,
 		 *             making no progress.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		private boolean processOnePacket(int timeout, int transactionId)
-				throws IOException, TimeoutException {
+				throws IOException, TimeoutException, InterruptedException {
 			var p = conn.getNextPacket(timeout + INTERNAL_DELAY);
 			if (p.hasRemaining()) {
 				received = true;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -105,9 +105,11 @@ public class DirectDataGatherer extends DataGatherer {
 	 *             If IO fails
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	private IntBuffer getCoreRegionTable(CoreLocation core, Vertex vertex)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// TODO get this info from the database, if the DB knows it
 		Map<MemoryLocation, ByteBuffer> map;
 		synchronized (coreTableCache) {
@@ -135,7 +137,7 @@ public class DirectDataGatherer extends DataGatherer {
 
 	@Override
 	protected List<Region> getRegion(Placement placement, int regionID)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var b = getCoreRegionTable(placement.asCoreLocation(),
 				placement.getVertex());
 		// TODO This is wrong because of shared regions!

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/GatherDownloadConnection.java
@@ -138,8 +138,11 @@ final class GatherDownloadConnection extends SDPConnection {
 	 *         returned. Never returns {@code null}.
 	 * @throws IOException
 	 *             If a non-recoverable error (e.g., closed channel) happens.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	ByteBuffer getNextPacket(int timeout) throws IOException {
+	ByteBuffer getNextPacket(int timeout)
+			throws IOException, InterruptedException {
 		try {
 			var b = receive(timeout);
 			if (b == null) {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegion.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegion.java
@@ -111,10 +111,12 @@ public final class RecordingRegion {
 	 *             If the reading goes wrong
 	 * @throws ProcessException
 	 *             If the data in the read goes wrong
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public static List<RecordingRegion> getRecordingRegionDescriptors(
 			TransceiverInterface txrx, Placement placement)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var recordingDataAddress = placement.getVertex().getBase();
 		// Get the size of the list of recordings
 		int nRegions = txrx.readMemory(placement.getScampCore(),

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -99,7 +99,7 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	}
 
 	private List<RecordingRegion> getRegions(Placement placement)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		// Cheap check first
 		synchronized (recordingRegions) {
 			var regions = recordingRegions.get(placement);
@@ -118,7 +118,7 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 
 	@Override
 	protected List<Region> getRegion(Placement placement, int index)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		var region = getRegions(placement).get(index);
 		log.debug("got region of {} R:{} as {}", placement.asCoreLocation(),
 				index, region);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Gather.java
@@ -140,9 +140,11 @@ public class Gather implements HasCoreLocation {
 	 *             If SpiNNaker rejects a message.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public void updateTransactionIdFromMachine(TransceiverInterface txrx)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		transactionId = txrx.readUser1(this);
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/request/Monitor.java
@@ -125,9 +125,11 @@ public class Monitor implements HasCoreLocation {
 	 *             If SpiNNaker rejects a message.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	public void updateTransactionIdFromMachine(TransceiverInterface txrx)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		transactionId = txrx.readUser1(this);
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
@@ -58,6 +58,8 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 	 *             If the transceiver can't talk to its sockets.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If something really strange occurs with talking to the BMP;
 	 *             this constructor should not be doing that!
@@ -65,7 +67,7 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 	@MustBeClosed
 	@SuppressWarnings("MustBeClosed")
 	protected ExecuteDataSpecification(Machine machine)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		super(machine);
 		this.machine = machine;
 		executor = new BasicExecutor(PARALLEL_SIZE);
@@ -101,17 +103,21 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 	 *             If SpiNNaker rejects a message.
 	 * @throws DataSpecificationException
 	 *             If a data specification in the database is invalid.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If an unexpected exception occurs in any of the parallel
 	 *             tasks.
 	 */
 	protected final void processTasksInParallel(List<Ethernet> tasks,
 			Function<Ethernet, SimpleCallable> mapper) throws StorageException,
-			IOException, ProcessException, DataSpecificationException {
+			IOException, ProcessException, DataSpecificationException,
+			InterruptedException {
 		try {
 			executor.submitTasks(tasks, mapper).awaitAndCombineExceptions();
 		} catch (StorageException | IOException | ProcessException
-				| DataSpecificationException | RuntimeException e) {
+				| DataSpecificationException | InterruptedException
+				| RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new IllegalStateException("unexpected exception", e);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecutionContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecutionContext.java
@@ -76,9 +76,12 @@ class ExecutionContext implements AutoCloseable {
 	 *             If something goes wrong SpiNNaker-side with the write.
 	 * @throws IOException
 	 *             If there's a problem with I/O.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	void execute(Executor executor, CoreLocation core, MemoryLocation start)
-			throws DataSpecificationException, ProcessException, IOException {
+			throws DataSpecificationException, ProcessException, IOException,
+			InterruptedException {
 		executor.execute();
 		executor.setBaseAddress(start);
 
@@ -124,7 +127,8 @@ class ExecutionContext implements AutoCloseable {
 	}
 
 	private void writeHeader(HasCoreLocation core, Executor executor,
-			MemoryLocation startAddress) throws IOException, ProcessException {
+			MemoryLocation startAddress)
+			throws IOException, ProcessException, InterruptedException {
 		var b = allocate(APP_PTR_TABLE_BYTE_SIZE).order(LITTLE_ENDIAN);
 
 		executor.addHeader(b);
@@ -136,7 +140,7 @@ class ExecutionContext implements AutoCloseable {
 
 	@Override
 	public void close() throws DataSpecificationException, ProcessException,
-			IOException {
+			IOException, InterruptedException {
 		// Check for missing
 		var errors = new ArrayList<String>();
 		for (var toFill : regionsToFill) {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -135,16 +135,20 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If IO goes wrong.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If something really strange occurs with talking to the BMP;
 	 *             this constructor should not be doing that!
 	 */
 	@MustBeClosed
 	public FastExecuteDataSpecification(Machine machine, List<Gather> gatherers,
-			File reportDir) throws IOException, ProcessException {
+			File reportDir)
+			throws IOException, ProcessException, InterruptedException {
 		super(machine);
 		if (SPINNAKER_COMPARE_UPLOAD != null) {
-			log.warn("detailed comparison of uploaded data enabled; "
+			log.warn(
+					"detailed comparison of uploaded data enabled; "
 					+ "this may destabilize the protocol");
 		}
 
@@ -161,7 +165,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	}
 
 	private void buildMaps(List<Gather> gatherers)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		for (var g : gatherers) {
 			g.updateTransactionIdFromMachine(txrx);
 			var gathererChip = g.asChipLocation();
@@ -192,13 +196,15 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If SpiNNaker rejects a message.
 	 * @throws DataSpecificationException
 	 *             If a data specification in the database is invalid.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If an unexpected exception occurs in any of the parallel
 	 *             tasks.
 	 */
 	public void loadCores(ConnectionProvider<DSEStorage> connection)
 			throws StorageException, IOException, ProcessException,
-			DataSpecificationException {
+			DataSpecificationException, InterruptedException {
 		var storage = connection.getStorageInterface();
 		var ethernets = storage.listEthernetsToLoad();
 		int opsToRun = storage.countWorkRequired();
@@ -211,7 +217,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 
 	private void loadBoard(Ethernet board, DSEStorage storage, Progress bar)
 			throws IOException, ProcessException,
-			DataSpecificationException, StorageException {
+			DataSpecificationException, StorageException, InterruptedException {
 		var cores = storage.listCoresToLoad(board, false);
 		if (cores.isEmpty()) {
 			log.info("no cores need loading on board; skipping");
@@ -242,7 +248,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	}
 
 	private MemoryLocation malloc(CoreToLoad ctl, Integer bytesUsed)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed,
 				new AppID(ctl.appID),
 				ctl.core.getP() + CORE_DATA_SDRAM_BASE_TAG);
@@ -394,7 +400,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 		@MustBeClosed
 		@SuppressWarnings("MustBeClosed")
 		BoardWorker(Ethernet board, DSEStorage storage, Progress bar)
-				throws IOException, ProcessException {
+				throws IOException, ProcessException, InterruptedException {
 			this.board = board;
 			this.logContext = new BoardLocal(board.location);
 			this.storage = storage;
@@ -406,7 +412,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 
 		@Override
 		public void close() throws IOException, ProcessException,
-				DataSpecificationException {
+				DataSpecificationException, InterruptedException {
 			execContext.close();
 			logContext.close();
 			connection.close();
@@ -431,10 +437,13 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 		 *             If the instructions to build the data are wrong.
 		 * @throws StorageException
 		 *             If the database access fails.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		protected void loadCore(CoreToLoad ctl, Gather gather,
 				MemoryLocation start) throws IOException, ProcessException,
-				DataSpecificationException, StorageException {
+				DataSpecificationException, StorageException,
+				InterruptedException {
 			ByteBuffer ds;
 			try {
 				ds = ctl.getDataSpec();
@@ -470,14 +479,14 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 
 		private int loadCoreFromExecutor(CoreToLoad ctl, Gather gather,
 				MemoryLocation start, Executor executor,
-				ExecutionContext execContext) throws DataSpecificationException,
-				IOException, ProcessException, StorageException {
+				ExecutionContext execContext)
+				throws DataSpecificationException, IOException,
+				ProcessException, StorageException, InterruptedException {
 			execContext.execute(executor, ctl.core, start);
 			int size = executor.getConstructedDataSize();
 			if (log.isInfoEnabled()) {
-				log.info(
-						"generated {} bytes to load onto {} into memory "
-								+ "starting at {}",
+				log.info("generated {} bytes to load onto {} into memory "
+						+ "starting at {}",
 						size, ctl.core, start);
 			}
 			int written = APP_PTR_TABLE_BYTE_SIZE;
@@ -603,10 +612,12 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 		 *             If anything goes wrong with communication.
 		 * @throws ProcessException
 		 *             If SpiNNaker rejects a message.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		@MustBeClosed
 		NoDropPacketContext dontDropPackets(Gather core)
-				throws IOException, ProcessException {
+				throws IOException, ProcessException, InterruptedException {
 			return new NoDropPacketContext(txrx,
 					monitorsForBoard.get(board.location), core);
 		}
@@ -620,10 +631,12 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 		 *             If anything goes wrong with communication.
 		 * @throws ProcessException
 		 *             If SpiNNaker rejects a message.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		@MustBeClosed
 		SystemRouterTableContext systemRouterTables()
-				throws IOException, ProcessException {
+				throws IOException, ProcessException, InterruptedException {
 			return new SystemRouterTableContext(txrx,
 					monitorsForBoard.get(board.location));
 		}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
@@ -65,13 +65,15 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If the transceiver can't talk to its sockets.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If something really strange occurs with talking to the BMP;
 	 *             this constructor should not be doing that!
 	 */
 	@MustBeClosed
 	public HostExecuteDataSpecification(Machine machine)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		super(machine);
 	}
 
@@ -90,13 +92,15 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If SpiNNaker rejects a message.
 	 * @throws DataSpecificationException
 	 *             If a data specification in the database is invalid.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If an unexpected exception occurs in any of the parallel
 	 *             tasks.
 	 */
 	public void loadAllCores(ConnectionProvider<DSEStorage> connection)
 			throws StorageException, IOException, ProcessException,
-			DataSpecificationException {
+			DataSpecificationException, InterruptedException {
 		var storage = connection.getStorageInterface();
 		var ethernets = storage.listEthernetsToLoad();
 		int opsToRun = storage.countWorkRequired();
@@ -123,13 +127,15 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If SpiNNaker rejects a message.
 	 * @throws DataSpecificationException
 	 *             If a data specification in the database is invalid.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If an unexpected exception occurs in any of the parallel
 	 *             tasks.
 	 */
 	public void loadApplicationCores(ConnectionProvider<DSEStorage> connection)
 			throws StorageException, IOException, ProcessException,
-			DataSpecificationException {
+			DataSpecificationException, InterruptedException {
 		var storage = connection.getStorageInterface();
 		var ethernets = storage.listEthernetsToLoad();
 		int opsToRun = storage.countWorkRequired();
@@ -156,13 +162,15 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             If SpiNNaker rejects a message.
 	 * @throws DataSpecificationException
 	 *             If a data specification in the database is invalid.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws IllegalStateException
 	 *             If an unexpected exception occurs in any of the parallel
 	 *             tasks.
 	 */
 	public void loadSystemCores(ConnectionProvider<DSEStorage> connection)
 			throws StorageException, IOException, ProcessException,
-			DataSpecificationException {
+			DataSpecificationException, InterruptedException {
 		var storage = connection.getStorageInterface();
 		var ethernets = storage.listEthernetsToLoad();
 		int opsToRun = storage.countWorkRequired();
@@ -176,7 +184,7 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 
 	private void loadBoard(Ethernet board, DSEStorage storage, Progress bar,
 			ExecutionContext context) throws IOException, ProcessException,
-			DataSpecificationException, StorageException {
+			DataSpecificationException, StorageException, InterruptedException {
 		try (var c = new BoardLocal(board.location)) {
 			var worker = new BoardWorker(board, storage, bar, context);
 			for (var ctl : storage.listCoresToLoad(board)) {
@@ -186,8 +194,9 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	}
 
 	private void loadBoard(Ethernet board, DSEStorage storage, Progress bar,
-			boolean system, ExecutionContext context) throws IOException,
-			ProcessException, DataSpecificationException, StorageException {
+			boolean system, ExecutionContext context)
+			throws IOException, ProcessException, DataSpecificationException,
+			StorageException, InterruptedException {
 		try (var c = new BoardLocal(board.location)) {
 			var worker = new BoardWorker(board, storage, bar, context);
 			for (var ctl : storage.listCoresToLoad(board, system)) {
@@ -240,9 +249,12 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 		 *             If the instructions to build the data are wrong.
 		 * @throws StorageException
 		 *             If the database access fails.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		void loadCore(CoreToLoad ctl) throws IOException, ProcessException,
-				DataSpecificationException, StorageException {
+				DataSpecificationException, StorageException,
+				InterruptedException {
 			ByteBuffer ds = getDataSpec(ctl);
 			var start = malloc(ctl, ctl.sizeToWrite);
 			var executor = new Executor(ds, machine.getChipAt(ctl.core).sdram);
@@ -273,7 +285,7 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 		}
 
 		private MemoryLocation malloc(CoreToLoad ctl, int bytesUsed)
-				throws IOException, ProcessException {
+				throws IOException, ProcessException, InterruptedException {
 			return txrx.mallocSDRAM(ctl.core.getScampCore(), bytesUsed,
 					new AppID(ctl.appID),
 					ctl.core.getP() + CORE_DATA_SDRAM_BASE_TAG);
@@ -294,10 +306,12 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 		 *             If anything goes wrong with I/O.
 		 * @throws ProcessException
 		 *             If SCAMP rejects the request.
+		 * @throws InterruptedException
+		 *             If communications are interrupted.
 		 */
 		private int writeRegion(HasCoreLocation core, MemoryRegionReal region,
 				MemoryLocation baseAddress)
-				throws IOException, ProcessException {
+				throws IOException, ProcessException, InterruptedException {
 			var data = region.getRegionData().duplicate();
 
 			data.flip();

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/SystemRouterTableContext.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/SystemRouterTableContext.java
@@ -58,10 +58,13 @@ public class SystemRouterTableContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public SystemRouterTableContext(TransceiverInterface txrx,
-			CoreSubsets monitorCores) throws IOException, ProcessException {
+			CoreSubsets monitorCores)
+			throws IOException, ProcessException, InterruptedException {
 		this.txrx = txrx;
 		this.monitorCores = monitorCores;
 		var firstCore = monitorCores.first().orElseThrow();
@@ -73,7 +76,7 @@ public class SystemRouterTableContext implements AutoCloseable {
 		try {
 			txrx.saveApplicationRouterTables(monitorCores);
 			txrx.loadSystemRouterTables(monitorCores);
-		} catch (IOException | ProcessException e) {
+		} catch (IOException | ProcessException | InterruptedException e) {
 			log.error("failed to switch multicast routing on {} to system",
 					firstChip, e);
 			throw e;
@@ -92,11 +95,13 @@ public class SystemRouterTableContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public SystemRouterTableContext(TransceiverInterface txrx,
 			List<? extends HasCoreLocation> monitorCoreLocations)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		this(txrx, convertToCoreSubset(monitorCoreLocations));
 	}
 
@@ -112,11 +117,13 @@ public class SystemRouterTableContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	public SystemRouterTableContext(TransceiverInterface txrx,
 			Stream<? extends HasCoreLocation> monitorCoreLocations)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		this(txrx, convertToCoreSubset(monitorCoreLocations));
 	}
 
@@ -143,15 +150,18 @@ public class SystemRouterTableContext implements AutoCloseable {
 	 *             If communications fail.
 	 * @throws ProcessException
 	 *             If SCAMP or an extra monitor rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@Override
-	public void close() throws IOException, ProcessException {
+	public void close()
+			throws IOException, ProcessException, InterruptedException {
 		log.info("switching multicast routing on board at {} to standard mode",
 				firstChip);
 
 		try {
 			txrx.loadApplicationRouterTables(monitorCores);
-		} catch (IOException | ProcessException e) {
+		} catch (IOException | ProcessException | InterruptedException e) {
 			log.error("error restoring multicast router tables", e);
 			throw e;
 		}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -123,8 +123,11 @@ class ThrottledConnection implements Closeable {
 	 *             If no message is received by the timeout.
 	 * @throws IOException
 	 *             If IO fails.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
-	public IntBuffer receive() throws SocketTimeoutException, IOException {
+	public IntBuffer receive()
+			throws SocketTimeoutException, IOException, InterruptedException {
 		return connection.receive(TIMEOUT_MS).slice().order(LITTLE_ENDIAN)
 				.asIntBuffer();
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -97,10 +97,13 @@ class ThrottledConnection implements Closeable {
 	 *             If IO fails.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects the reprogramming.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 */
 	@MustBeClosed
 	ThrottledConnection(TransceiverInterface transceiver, Ethernet board,
-			IPTag iptag) throws IOException, ProcessException {
+			IPTag iptag)
+			throws IOException, ProcessException, InterruptedException {
 		location = board.location;
 		addr = getByName(board.ethernetAddress);
 		connection = new SCPConnection(location, addr, SCP_SCAMP_PORT);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
@@ -110,11 +110,14 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	 *             If network IO fails or the mapping dictionary is absent.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws RuntimeException
 	 *             If an unexpected exception happens.
 	 */
 	public NotableMessages retrieveIobufContents(IobufRequest request,
-			String provenanceDir) throws IOException, ProcessException {
+			String provenanceDir)
+			throws IOException, ProcessException, InterruptedException {
 		var provDir = new File(provenanceDir);
 		validateProvenanceDirectory(provDir);
 		var errorEntries = new ArrayList<String>();
@@ -131,7 +134,8 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 					})).awaitAndCombineExceptions();
 		} catch (Replacer.WrappedException e) {
 			e.rethrow();
-		} catch (IOException | ProcessException | RuntimeException e) {
+		} catch (IOException | ProcessException | InterruptedException
+				| RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new RuntimeException("unexpected exception", e);
@@ -157,12 +161,14 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	 *             If network IO fails or the mapping dictionary is absent.
 	 * @throws ProcessException
 	 *             If SpiNNaker rejects a message.
+	 * @throws InterruptedException
+	 *             If communications are interrupted.
 	 * @throws RuntimeException
 	 *             If an unexpected exception happens.
 	 */
 	public NotableMessages retrieveIobufContents(CoreSubsets cores,
 			File binaryFile, File provenanceDir)
-			throws IOException, ProcessException {
+			throws IOException, ProcessException, InterruptedException {
 		validateProvenanceDirectory(provenanceDir);
 		var errorEntries = new ArrayList<String>();
 		var warnEntries = new ArrayList<String>();
@@ -174,7 +180,8 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 			}).awaitAndCombineExceptions();
 		} catch (Replacer.WrappedException e) {
 			e.rethrow();
-		} catch (IOException | ProcessException | RuntimeException e) {
+		} catch (IOException | ProcessException | InterruptedException
+				| RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new RuntimeException("unexpected exception", e);
@@ -209,7 +216,8 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 
 	private void retrieveIobufContents(CoreSubsets cores, Replacer replacer,
 			File provenanceDir, List<String> errorEntries,
-			List<String> warnEntries) throws IOException, ProcessException {
+			List<String> warnEntries)
+			throws IOException, ProcessException, InterruptedException {
 		try (var bl = new BoardLocal(cores.first().orElseThrow())) {
 			// extract iobuf, write to file and check for errors for provenance
 			for (var iobuf : txrx.getIobuf(cores)) {
@@ -218,8 +226,8 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 					log.info("storing iobuf from {} (running {}) in {}",
 							iobuf.asCoreLocation(), replacer.origin, file);
 					// ISO 8859-1: bytes are zero-extended to chars
-					for (var originalLine : iobuf
-							.getContentsString(ISO_8859_1).split("\n", -1)) {
+					for (var originalLine : iobuf.getContentsString(ISO_8859_1)
+							.split("\n", -1)) {
 						var line = replacer.replace(originalLine);
 						w.write(line);
 						w.newLine();

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Ping.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/Ping.java
@@ -79,7 +79,9 @@ public abstract class Ping {
 	/**
 	 * Pings to detect if a host or IP address is reachable. May wait for up to
 	 * about five seconds (or longer <i>in extremis</i>). Technically, it only
-	 * detects if a host is reachable by ICMP ECHO requests.
+	 * detects if a host is reachable by ICMP ECHO requests; there are
+	 * environments (such as Microsoft Azure) where ICMP ECHO is blocked but it
+	 * is possible to route ordinary UDP packets.
 	 *
 	 * @param address
 	 *            Where should be pinged.
@@ -88,26 +90,26 @@ public abstract class Ping {
 	 */
 	@CheckReturnValue
 	public static int ping(String address) {
-		int result = -1;
 		int i = 0;
 		while (true) {
-			result = ping1(address);
+			int result = ping1(address);
 			if (result == 0 || ++i >= PING_COUNT) {
-				break;
+				return result;
 			}
 			try {
 				sleep(PING_DELAY);
 			} catch (InterruptedException e) {
-				break;
+				return result;
 			}
 		}
-		return result;
 	}
 
 	/**
 	 * Pings to detect if a host or IP address is reachable. May wait for up to
 	 * about five seconds (or longer <i>in extremis</i>). Technically, it only
-	 * detects if a host is reachable by ICMP ECHO requests.
+	 * detects if a host is reachable by ICMP ECHO requests; there are
+	 * environments (such as Microsoft Azure) where ICMP ECHO is blocked but it
+	 * is possible to route ordinary UDP packets.
 	 *
 	 * @param address
 	 *            Where should be pinged.


### PR DESCRIPTION
While tidying up, I noticed that there was interrupts of waiting in the guts of the transceiver that was getting swallowed. Oh dear! Stopping that from vanishing nastily (i.e., letting the `InterruptedException` do what it should) caused the transceiver's public exception profile to change, and that in turn cascades into many places.
