### PR TITLE
Remove code that forced buffer copying

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPRequestPipeline.java
@@ -221,7 +221,7 @@ public class SCPRequestPipeline implements AsyncCommsTask {
 				throw new InterruptedIOException(
 						"interrupted while waiting to send");
 			}
-			connection.send(requestData.asReadOnlyBuffer());
+			connection.send(requestData);
 			nextSendTime = nanoTime() + INTER_SEND_INTERVAL_NS;
 		}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPCommandProcess.java
@@ -332,7 +332,7 @@ class BMPCommandProcess<R extends BMPResponse> {
 			}
 
 			private void send() throws IOException {
-				connection.send(requestData.asReadOnlyBuffer());
+				connection.send(requestData);
 			}
 
 			private void resend(String reason) throws IOException {


### PR DESCRIPTION
It wasn't a problem when we were using the channel-based NIO API, but as we stopped using that in #488, we should take care to not set things in a way that forces copying. The copies might still happen, but passing in read-only buffers was forcing it.
