### PR TITLE
More javadoc links

### DIFF
--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -136,7 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						<goals>
 							<goal>minify</goal>
 						</goals>
-						<phase>generate-resources</phase>
+						<phase>process-resources</phase>
 						<configuration>
 							<sourceDir>js</sourceDir>
 							<targetDir>META-INF/public-web-resources</targetDir>

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineDefinitionLoader.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineDefinitionLoader.java
@@ -418,13 +418,14 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 	}
 
 	/**
-	 * A configuration description. JSON-serializable. Largely ignored as it
-	 * represents configuration settings that we handle elsewhere. However, the
+	 * A configuration description. JSON-deserializable (the only supported
+	 * mechanism for generating an instance). Largely ignored as it represents
+	 * configuration settings that we handle elsewhere. However, the
 	 * {@code machines} property <em>is</em> interesting.
 	 *
 	 * @author Donal Fellows
 	 */
-	static final class Configuration {
+	public static final class Configuration {
 		private @NotNull List<@Valid Machine> machines;
 
 		@TCPPort
@@ -447,7 +448,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return machines;
 		}
 
-		public void setMachines(List<Machine> machines) {
+		void setMachines(List<Machine> machines) {
 			this.machines = copy(machines);
 		}
 
@@ -456,7 +457,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return port;
 		}
 
-		public void setPort(int port) {
+		void setPort(int port) {
 			this.port = port;
 		}
 
@@ -468,7 +469,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return ip;
 		}
 
-		public void setIp(String ip) {
+		void setIp(String ip) {
 			this.ip = ip;
 		}
 
@@ -477,7 +478,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return timeoutCheckInterval;
 		}
 
-		public void setTimeoutCheckInterval(double timeoutCheckInterval) {
+		void setTimeoutCheckInterval(double timeoutCheckInterval) {
 			this.timeoutCheckInterval = timeoutCheckInterval;
 		}
 
@@ -495,7 +496,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return secondsBeforeFree;
 		}
 
-		public void setSecondsBeforeFree(int secondsBeforeFree) {
+		void setSecondsBeforeFree(int secondsBeforeFree) {
 			this.secondsBeforeFree = secondsBeforeFree;
 		}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineDefinitionLoader.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineDefinitionLoader.java
@@ -487,7 +487,7 @@ public class MachineDefinitionLoader extends DatabaseAwareBean {
 			return maxRetiredJobs;
 		}
 
-		public void setMaxRetiredJobs(int maxRetiredJobs) {
+		void setMaxRetiredJobs(int maxRetiredJobs) {
 			this.maxRetiredJobs = maxRetiredJobs;
 		}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
@@ -250,6 +250,11 @@ public class MachineStateControl extends DatabaseAwareBean {
 			return format("(%d,%d,%d)", x, y, z);
 		}
 
+		/**
+		 * Convert this active object to a static record.
+		 *
+		 * @return The static (conceptually serialisable) record object.
+		 */
 		public BoardRecord toBoardRecord() {
 			var br = new BoardRecord();
 			br.setId(id);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
@@ -27,7 +27,7 @@
  * followed by some payload data (of length limited by the maximum size of a
  * SpiNNaker SDP or SpiNNaker boot message; the framing does not itself impose a
  * maximum message length):
- * <p>
+ * </p>
  * <table border="1" class="protocol">
  * <caption style="display:none">Protocol inside web socket</caption>
  * <tr>

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/package-info.java
@@ -15,6 +15,188 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * SpiNNaker message proxying support code.
+ * SpiNNaker message proxying support code. The protocol uses binary message
+ * frames within a websocket. That websocket will have been opened within an
+ * HTTPS-encrypted session where the session's user was authorised to access the
+ * particular job that is the context for the websocket. Messages sent via the
+ * protocol can only ever access boards allocated to the job.
+ * <p>
+ * The protocol has five messages that clients can send, three of which have
+ * replies and one of which can also be sent from the server/proxy to the
+ * client. All messages consist of a sequence of little-endian words, possibly
+ * followed by some payload data (of length limited by the maximum size of a
+ * SpiNNaker SDP or SpiNNaker boot message; the framing does not itself impose a
+ * maximum message length):
+ * <p>
+ * <table border="1" class="protocol">
+ * <caption style="display:none">Protocol inside web socket</caption>
+ * <tr>
+ * <th>Name</th>
+ * <th>Request Layout (words)</th>
+ * <th>Response Layout (words)</th>
+ * </tr>
+ * <tr>
+ * <td rowspan=2>{@linkplain ProxyCore#openConnectedChannel(ByteBuffer) Open
+ * Connected Channel}</td>
+ * <td>
+ * <table border="1" class="protocolrequest">
+ * <caption style="display:none">Request</caption>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN 0}
+ * <td>Correlation&nbsp;ID
+ * <td>Chip&nbsp;X
+ * <td>Chip&nbsp;Y
+ * <td>UDP&nbsp;Port on Chip
+ * </tr>
+ * </table>
+ * </td>
+ * <td>
+ * <table border="1" class="protocolresponse">
+ * <caption style="display:none">Response</caption>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN 0}
+ * <td>Correlation&nbsp;ID
+ * <td>Channel&nbsp;ID
+ * </tr>
+ * </table>
+ * </td>
+ * </tr>
+ * <tr>
+ * <td colspan=2>Establish a UDP socket that will talk to the given Ethernet
+ * chip within the allocation. Returns an ID that can be used to refer to that
+ * channel. Note that opening a socket declares that you are prepared to receive
+ * messages from SpiNNaker on it, but does not mean that SpiNNaker will send any
+ * messages that way. The correlation ID is caller-nominated, and just passed
+ * back uninterpreted in the response message.</td>
+ * </tr>
+ * <tr>
+ * <td rowspan=2>{@linkplain ProxyCore#closeChannel(ByteBuffer) Close
+ * Channel}</td>
+ * <td>
+ * <table border="1" class="protocolrequest">
+ * <caption style="display:none">Request</caption>
+ * <tr>
+ * <td>{@link ProxyOp#CLOSE 1}
+ * <td>Correlation&nbsp;ID
+ * <td>Channel&nbsp;ID
+ * </tr>
+ * </table>
+ * </td>
+ * <td>
+ * <table border="1" class="protocolresponse">
+ * <caption style="display:none">Response</caption>
+ * <tr>
+ * <td>{@link ProxyOp#CLOSE 1}
+ * <td>Correlation&nbsp;ID
+ * <td>Channel&nbsp;ID (if closed) or {@code 0} (not closed)
+ * </tr>
+ * </table>
+ * </td>
+ * </tr>
+ * <tr>
+ * <td colspan=2>Close an established UDP socket, given its ID. Returns the ID
+ * on success, and zero on failure (e.g., because the socket is already closed).
+ * The correlation ID is caller-nominated, and just passed back uninterpreted in
+ * the response message. The channel may have been opened with either <em>Open
+ * Connected Channel</em> or <em>Open Unconnected Channel</em>.</td>
+ * </tr>
+ * <tr>
+ * <td rowspan=2>{@linkplain ProxyCore#sendMessage(ByteBuffer) Send
+ * Message}</td>
+ * <td>
+ * <table border="1" class="protocolrequest">
+ * <caption style="display:none">Request</caption>
+ * <tr>
+ * <td>{@link ProxyOp#MESSAGE 2}
+ * <td>Channel&nbsp;ID
+ * <td>Raw&nbsp;message&nbsp;bytes...
+ * </tr>
+ * </table>
+ * </td>
+ * <td>N/A</td>
+ * </tr>
+ * <tr>
+ * <td colspan=2>Send a message to SpiNNaker on a particular established UDP
+ * configuration. This is technically one-way, but messages come back in the
+ * same format (i.e., a 4 byte prefix to say that it is a message, and another 4
+ * bytes to say what socket this is talking about). The raw message bytes
+ * (<em>including</em> the half-word of ethernet frame padding) follow the
+ * header. Messages sent on connections opened with <em>Open Unconnected
+ * Channel</em> will be ignored.</td>
+ * </tr>
+ * <tr>
+ * <td rowspan=2>{@linkplain ProxyCore#openUnconnectedChannel(ByteBuffer) Open
+ * Unconnected Channel}</td>
+ * <td>
+ * <table border="1" class="protocolrequest">
+ * <caption style="display:none">Request</caption>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN_UNCONNECTED 3}
+ * <td>Correlation&nbsp;ID
+ * </tr>
+ * </table>
+ * </td>
+ * <td>
+ * <table border="1" class="protocolresponse">
+ * <caption style="display:none">Response</caption>
+ * <tr>
+ * <td>{@link ProxyOp#OPEN_UNCONNECTED 3}
+ * <td>Correlation&nbsp;ID
+ * <td>Channel&nbsp;ID
+ * <td>IP&nbsp;Address
+ * <td>UDP&nbsp;Port on Server
+ * </tr>
+ * </table>
+ * </td>
+ * </tr>
+ * <tr>
+ * <td colspan=2>Establish a UDP socket that will receive from the allocation.
+ * Returns an ID that can be used to refer to that channel. Note that opening a
+ * socket declares that you are prepared to receive messages from SpiNNaker on
+ * it, but does not mean that SpiNNaker will send any messages that way. The
+ * correlation ID is caller-nominated, and just passed back uninterpreted in the
+ * response message. Also included in the response message is the IPv4 address
+ * (big-endian binary encoding; one word) and server UDP port for the
+ * connection, allowing the client to instruct SpiNNaker to send messages to the
+ * socket on the server side of the channel (which is not necessarily accessible
+ * from anything other than SpiNNaker). No guarantee is made about whether any
+ * message from anything other than a board in the job will be passed on.
+ * Sending on the channel will only be possible with the <em>Send Message
+ * To</em> operation.</td>
+ * </tr>
+ * <tr>
+ * <td rowspan=2>{@linkplain ProxyCore#sendMessageTo(ByteBuffer) Send Message
+ * To}</td>
+ * <td>
+ * <table border="1" class="protocolrequest">
+ * <caption style="display:none">Request</caption>
+ * <tr>
+ * <td>{@link ProxyOp#MESSAGE_TO 4}
+ * <td>Channel&nbsp;ID
+ * <td>Chip&nbsp;X
+ * <td>Chip&nbsp;Y
+ * <td>UDP&nbsp;Port on Chip
+ * <td>Raw&nbsp;message&nbsp;bytes...
+ * </tr>
+ * </table>
+ * </td>
+ * <td>N/A</td>
+ * </tr>
+ * <tr>
+ * <td colspan=2>Send a message to a SpiNNaker board (identified by coordinates
+ * of its ethernet chip) to a given UDP port. This is one-way. The raw message
+ * bytes (<em>including</em> the half-word of ethernet frame padding) follow the
+ * header. The channel must have been opened with <em>Open Unconnected
+ * Channel</em>. Any responses come back as standard messages; if doing calls
+ * with this, it is advised to only have one in flight at a time.</td>
+ * </tr>
+ * </table>
+ * <p>
+ * <em>Protocol-level errors</em> (such as not following the protocol!) may be
+ * responded to by the server arbitrarily closing the websocket, in which case
+ * any proxied connections it has open through the websocket will also be
+ * closed.
  */
 package uk.ac.manchester.spinnaker.alloc.proxy;
+
+import java.nio.ByteBuffer;

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/compat/JsonTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/compat/JsonTest.java
@@ -68,9 +68,7 @@ class JsonTest {
 		@Test
 		void testBoardPhysicalCoordinates() throws IOException, JSONException {
 			var r = new BoardPhysicalCoordinates(0, 1, 2);
-			JSONAssert.assertEquals(
-					"[0, 1, 2]",
-					serialize(r), true);
+			JSONAssert.assertEquals("[0, 1, 2]", serialize(r), true);
 		}
 
 		@Test
@@ -78,6 +76,7 @@ class JsonTest {
 			var r = new JobMachineInfo(0, 0,
 					List.of(new Connection(ZERO_ZERO, "2.3.4.5")),
 					"gorp", List.of(new BoardCoordinates(0, 1, 2)));
+
 			JSONAssert.assertEquals(
 					"{ 'boards': [[0,1,2]], "
 							+ "'connections': [[[0,0],'2.3.4.5']], "
@@ -89,14 +88,14 @@ class JsonTest {
 
 		@Test
 		void testJobState() throws IOException, JSONException {
-			var r = new JobState.Builder() //
-					.withState(State.POWER) //
-					.withStartTime(123) //
-					.withPower(false) //
-					.withReason("gorp") //
-					.withKeepalive(321) //
-					.withKeepalivehost("127.0.0.1") //
-					.build();
+			var r = new JobState.Builder();
+			r.setState(State.POWER);
+			r.setStartTime(123);
+			r.setPower(false);
+			r.setReason("gorp");
+			r.setKeepalive(321);
+			r.setKeepalivehost("127.0.0.1");
+
 			JSONAssert.assertEquals(
 					"{ 'state': 2, "
 							+ "'start_time': 123, "
@@ -104,17 +103,23 @@ class JsonTest {
 							+ "'reason': 'gorp', "
 							+ "'keepalive': 321, "
 							+ "'keepalivehost': '127.0.0.1' }",
-					serialize(r), true);
+					serialize(r.build()), true);
 		}
 
 		@Test
 		void testJobDescription() throws IOException, JSONException {
-			var r = new JobDescription[1];
-			r[0] = new JobDescription.Builder().withJobID(1)
-					.withArgs(List.of(0)).withKwargs(Map.of())
-					.withKeepAlive(123).withKeepAliveHost("127.0.0.1")
-					.withMachine("foo").withOwner("bar").withPower(false)
-					.withStartTime(321.).withState(State.POWER).build();
+			var r = new JobDescription.Builder();
+			r.setJobID(1);
+			r.setArgs(List.of(0));
+			r.setKwargs(Map.of());
+			r.setKeepAlive(123);
+			r.setKeepAliveHost("127.0.0.1");
+			r.setMachine("foo");
+			r.setOwner("bar");
+			r.setPower(false);
+			r.setStartTime(321.);
+			r.setState(State.POWER);
+
 			JSONAssert.assertEquals(
 					"[{ 'allocated_machine_name': 'foo', "
 							+ "'args': [0], "
@@ -129,19 +134,19 @@ class JsonTest {
 							+ "'state': 2, "
 							+ "'start_time': 321 "
 							+ "}]",
-					serialize(r), true);
+					serialize(new JobDescription[] {r.build()}), true);
 		}
 
 		@Test
 		void testMachine() throws IOException, JSONException {
-			var r = new Machine[1];
-			r[0] = new Machine("gorp", List.of("foo", "bar"), 0, 0, null, null);
-			JSONAssert
-					.assertEquals(
-							"[{ 'name': 'gorp', 'tags': ['foo', 'bar'], "
-									+ "'dead_boards': [], 'dead_links': [], "
-									+ "'height': 0, 'width': 0 }]",
-							serialize(r), true);
+			var r = new Machine("gorp", List.of("foo", "bar"), 0, 0, null,
+					null);
+
+			JSONAssert.assertEquals(
+					"[{ 'name': 'gorp', 'tags': ['foo', 'bar'], "
+							+ "'dead_boards': [], 'dead_links': [], "
+							+ "'height': 0, 'width': 0 }]",
+					serialize(new Machine[] {r}), true);
 		}
 
 		@Test
@@ -150,11 +155,12 @@ class JsonTest {
 					new ChipLocation(0, 0), new BoardCoordinates(0, 1, 2),
 					"gorp", new ChipLocation(0, 0),
 					new BoardPhysicalCoordinates(0, 1, 2));
+
 			JSONAssert.assertEquals(
 					"{'chip': [0,0], 'board_chip': [0,0],"
-					+ "'job_chip': [0,0], 'job_id': 0,"
-					+ "'logical': [0,1,2], 'physical': [0,1,2],"
-					+ "'machine': 'gorp'}",
+							+ "'job_chip': [0,0], 'job_id': 0,"
+							+ "'logical': [0,1,2], 'physical': [0,1,2],"
+							+ "'machine': 'gorp'}",
 					serialize(r), true);
 		}
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/allocator/AllocatedMachine.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/allocator/AllocatedMachine.java
@@ -135,6 +135,12 @@ public final class AllocatedMachine {
 		@IPAddress
 		private final String hostname;
 
+		/**
+		 * @param chip
+		 *            Which root chip (of a board) is this about?
+		 * @param hostname
+		 *            What's the IP address of the chip?
+		 */
 		public ConnectionInfo(@JsonProperty("chip") ChipLocation chip,
 				@JsonProperty("hostname") String hostname) {
 			this.chip = chip;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobDescription.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobDescription.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * A description of the state of a job.
@@ -195,6 +195,10 @@ public final class JobDescription {
 		return builder.toString();
 	}
 
+	/**
+	 * Builder for {@link JobDescription}.
+	 */
+	@JsonPOJOBuilder(withPrefix = "set")
 	public static class Builder {
 		private int jobID;
 
@@ -220,85 +224,113 @@ public final class JobDescription {
 
 		private String keepAliveHost;
 
-		@CanIgnoreReturnValue
+		/**
+		 * @param jobID The job's identifier.
+		 */
 		@JsonProperty("job_id")
-		public Builder withJobID(int jobID) {
+		public void setJobID(int jobID) {
 			this.jobID = jobID;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withOwner(String owner) {
+		/**
+		 * @param owner
+		 *            The job's owner.
+		 */
+		public void setOwner(String owner) {
 			this.owner = owner;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
+		/**
+		 * @param startTime
+		 *            When the job started, in seconds from the epoch.
+		 */
 		@JsonProperty("start_time")
-		public Builder withStartTime(Double startTime) {
+		public void setStartTime(Double startTime) {
 			this.startTime = startTime;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withState(State state) {
+		/**
+		 * @param state
+		 *            The job state.
+		 */
+		public void setState(State state) {
 			this.state = state;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withPower(Boolean power) {
+		/**
+		 * @param power
+		 *            Whether the job's allocated boards are powered on.
+		 */
+		public void setPower(Boolean power) {
 			this.power = power;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
+		/**
+		 * @param keepAlive
+		 *            The job's maximum keepalive interval, in seconds.
+		 */
 		@JsonProperty("keepalive")
-		public Builder withKeepAlive(double keepAlive) {
+		public void setKeepAlive(double keepAlive) {
 			this.keepAlive = keepAlive;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withReason(String reason) {
+		/**
+		 * @param reason
+		 *            The reason why the job terminated.
+		 */
+		public void setReason(String reason) {
 			this.reason = reason;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
+		/**
+		 * @param machine
+		 *            The name of the machine that the job is allocated to.
+		 */
 		@JsonProperty("allocated_machine_name")
-		public Builder withMachine(String machine) {
+		public void setMachine(String machine) {
 			this.machine = machine;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withArgs(List<Integer> args) {
+		/**
+		 * @param args
+		 *            The positional arguments used to create the job.
+		 */
+		public void setArgs(List<Integer> args) {
 			this.args = isNull(args) ? List.of() : List.copyOf(args);
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withKwargs(Map<String, Object> kwargs) {
+		/**
+		 * @param kwargs
+		 *            The keyword arguments used to create the job.
+		 */
+		public void setKwargs(Map<String, Object> kwargs) {
 			this.kwargs = isNull(args) ? Map.of()
 					// Careful: could be null values in map!
 					: unmodifiableMap(new HashMap<>(kwargs));
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withBoards(List<BoardCoordinates> boards) {
+		/**
+		 * @param boards
+		 *            The boards allocated to the job and their locations.
+		 */
+		public void setBoards(List<BoardCoordinates> boards) {
 			this.boards = isNull(boards) ? List.of() : List.copyOf(boards);
-			return this;
 		}
 
-		@CanIgnoreReturnValue
+		/**
+		 * @param keepAliveHost
+		 *            The host believed to be keeping the job alive.
+		 */
 		@JsonProperty("keepalivehost")
-		public Builder withKeepAliveHost(String keepAliveHost) {
+		public void setKeepAliveHost(String keepAliveHost) {
 			this.keepAliveHost = keepAliveHost;
-			return this;
 		}
 
+		/**
+		 * Build an instance of the immutable {@link JobDescription}.
+		 *
+		 * @return The instance.
+		 */
 		public JobDescription build() {
 			return new JobDescription(jobID, owner, startTime, state, power,
 					keepAlive, reason, machine, args, kwargs, boards,

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/JobState.java
@@ -20,7 +20,6 @@ import javax.validation.constraints.Positive;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 /**
@@ -91,7 +90,10 @@ public final class JobState {
 				+ keepAlive + " reason: " + reason;
 	}
 
-	@JsonPOJOBuilder
+	/**
+	 * Builder for {@link JobState}.
+	 */
+	@JsonPOJOBuilder(withPrefix = "set")
 	public static class Builder {
 		private State state = null;
 
@@ -105,42 +107,59 @@ public final class JobState {
 
 		private String keepalivehost;
 
-		@CanIgnoreReturnValue
-		public Builder withState(State state) {
+		/**
+		 * @param state
+		 *            The state of the job.
+		 */
+		public void setState(State state) {
 			this.state = state;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withPower(Boolean power) {
+		/**
+		 * @param power
+		 *            whether the job's boards are powered.
+		 */
+		public void setPower(Boolean power) {
 			this.power = power;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withKeepalive(double keepAlive) {
+		/**
+		 * @param keepAlive
+		 *            The keepalive interval, in seconds.
+		 */
+		public void setKeepalive(double keepAlive) {
 			this.keepAlive = keepAlive;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withStartTime(double startTime) {
+		/**
+		 * @param startTime
+		 *            The time the job started, in seconds from the epoch.
+		 */
+		public void setStartTime(double startTime) {
 			this.startTime = startTime;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withReason(String reason) {
+		/**
+		 * @param reason
+		 *            The reason why the job was destroyed.
+		 */
+		public void setReason(String reason) {
 			this.reason = reason;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withKeepalivehost(String keepalivehost) {
+		/**
+		 * @param keepalivehost
+		 *            The host keeping the job alive.
+		 */
+		public void setKeepalivehost(String keepalivehost) {
 			this.keepalivehost = keepalivehost;
-			return this;
 		}
 
+		/**
+		 * Build an instance of the immutable {@link JobState}.
+		 *
+		 * @return The instance.
+		 */
 		public JobState build() {
 			return new JobState(state, power, keepAlive, startTime, reason,
 					keepalivehost);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIs.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/spalloc/messages/WhereIs.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
@@ -165,7 +164,10 @@ public final class WhereIs {
 				+ " boardChip: " + boardChip + " physical: " + physical;
 	}
 
-	@JsonPOJOBuilder
+	/**
+	 * Builder for {@link WhereIs}.
+	 */
+	@JsonPOJOBuilder(withPrefix = "set")
 	public static class Builder {
 		private ChipLocation jobChip;
 
@@ -181,48 +183,67 @@ public final class WhereIs {
 
 		private BoardPhysicalCoordinates physical;
 
-		@CanIgnoreReturnValue
-		public Builder withJobChip(ChipLocation jobChip) {
+		/**
+		 * @param jobChip
+		 *            The chip location relative to the job's allocation.
+		 */
+		public void setJobChip(ChipLocation jobChip) {
 			this.jobChip = jobChip;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withJobId(Integer jobId) {
+		/**
+		 * @param jobId
+		 *            The job id.
+		 */
+		public void setJobId(Integer jobId) {
 			this.jobId = jobId;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withChip(ChipLocation chip) {
+		/**
+		 * @param chip
+		 *            The absolute chip location.
+		 */
+		public void setChip(ChipLocation chip) {
 			this.chip = chip;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withLogical(BoardCoordinates logical) {
+		/**
+		 * @param logical
+		 *            The logical coordinates of the board.
+		 */
+		public void setLogical(BoardCoordinates logical) {
 			this.logical = logical;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withMachine(String machine) {
+		/**
+		 * @param machine
+		 *            The name of the machine.
+		 */
+		public void setMachine(String machine) {
 			this.machine = machine;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withBoardChip(ChipLocation boardChip) {
+		/**
+		 * @param boardChip
+		 *            The chip location relative to its board.
+		 */
+		public void setBoardChip(ChipLocation boardChip) {
 			this.boardChip = boardChip;
-			return this;
 		}
 
-		@CanIgnoreReturnValue
-		public Builder withPhysical(BoardPhysicalCoordinates physical) {
+		/**
+		 * @param physical
+		 *            The physical coordinates of the board.
+		 */
+		public void setPhysical(BoardPhysicalCoordinates physical) {
 			this.physical = physical;
-			return this;
 		}
 
+		/**
+		 * Build an instance of the immutable {@link WhereIs}.
+		 *
+		 * @return The instance.
+		 */
 		public WhereIs build() {
 			return new WhereIs(jobChip, jobId, chip, logical, machine,
 					boardChip, physical);

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 							<link>https://javaee.github.io/javaee-spec/javadocs/</link>
 							-->
 							<link>https://errorprone.info/api/latest/</link>
+							<link>https://javadoc.io/doc/javax.validation/validation-api/latest/</link>
+							<link>https://javadoc.io/doc/javax.ws.rs/javax.ws.rs-api/latest/</link>
 						</links>
 						<notimestamp>true</notimestamp>
 						<additionalOptions>
@@ -983,6 +985,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<link>https://javaee.github.io/javaee-spec/javadocs/</link>
 								<link>https://cxf.apache.org/javadoc/latest-3.0.x/</link>
 								<link>https://errorprone.info/api/latest/</link>
+								<link>https://javadoc.io/doc/javax.validation/validation-api/latest/</link>
+								<link>https://javadoc.io/doc/javax.ws.rs/javax.ws.rs-api/latest/</link>
 							</links>
 						</configuration>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 							</group>
 							<group>
 								<title>Communications</title>
-								<packages>uk.ac.manchester.spinnaker.connections*:uk.ac.manchester.spinnaker.io:uk.ac.manchester.spinnaker.messages*:uk.ac.manchester.spinnaker.transceiver*:uk.ac.manchester.spinnaker.spalloc*</packages>
+								<packages>uk.ac.manchester.spinnaker.connections*:uk.ac.manchester.spinnaker.allocator:uk.ac.manchester.spinnaker.io:uk.ac.manchester.spinnaker.messages*:uk.ac.manchester.spinnaker.transceiver*:uk.ac.manchester.spinnaker.spalloc*</packages>
 							</group>
 							<group>
 								<title>Data Management</title>
@@ -476,6 +476,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 							<link>https://javadoc.io/doc/javax.validation/validation-api/latest/</link>
 							<link>https://javadoc.io/doc/javax.ws.rs/javax.ws.rs-api/latest/</link>
 						</links>
+						<doclint>all</doclint>
 						<notimestamp>true</notimestamp>
 						<additionalOptions>
 							<additionalOption>-html5</additionalOption>
@@ -584,8 +585,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 							<exclude>**/.dbeaver/**</exclude>
 							<exclude>**/*.erd</exclude>
 							<exclude>**/node_modules/**</exclude>
+							<exclude>**/.settings/**</exclude>
+							<exclude>**/.checkstyle</exclude>
+							<exclude>**/.classpath</exclude>
+							<exclude>**/.project</exclude>
 						</excludes>
 						<consoleOutput>true</consoleOutput>
+						<parseSCMIgnoresAsExcludes>true</parseSCMIgnoresAsExcludes>
+						<useEclipseDefaultExcludes>true</useEclipseDefaultExcludes>
+						<excludeSubProjects>true</excludeSubProjects>
 					</configuration>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->


### PR DESCRIPTION
This is all about getting better cross-references to classes we use (especially annotation types and JAX-RS bits).

It also turns a few things in builders back into setters; the `withFoo()` fluent style encouraged by Jackson doesn't really do it for me.