### PR TITLE
Fixes to BMP mocking

### DIFF
--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
@@ -27,6 +27,7 @@ import static uk.ac.manchester.spinnaker.alloc.model.JobState.READY;
 import java.io.IOException;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,17 @@ class AllocatorTest extends TestSupport {
 		MockTransceiver.installIntoFactory(txrxFactory);
 		setupDB3();
 		this.bmpCtrl = bmpCtrl.getTestAPI();
+		this.bmpCtrl.clearBmpException();
+	}
+
+	@AfterEach
+	void checkBMPWasFine() {
+		var exn = bmpCtrl.getBmpException();
+		assertDoesNotThrow(() -> {
+			if (exn != null) {
+				throw exn;
+			}
+		}, "BMP controller must not have thrown, but did");
 	}
 
 	private void assertState(int jobId, JobState state, int requestCount,

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
@@ -24,6 +24,7 @@ import static uk.ac.manchester.spinnaker.alloc.model.JobState.READY;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,17 @@ class FirmwareLoaderTest extends TestSupport {
 		assumeTrue(db != null, "spring-configured DB engine absent");
 		setupDB1();
 		this.bmpCtrl = bmpCtrl.getTestAPI();
+		this.bmpCtrl.clearBmpException();
+	}
+
+	@AfterEach
+	void checkBMPDidNotThrow() {
+		var exn = bmpCtrl.getBmpException();
+		assertDoesNotThrow(() -> {
+			if (exn != null) {
+				throw exn;
+			}
+		}, "BMP controller must not have thrown, but did");
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
@@ -94,11 +94,18 @@ class BlacklistCommsTest extends TestSupport {
 		MockTransceiver.installIntoFactory(txrxFactory);
 		this.txrxFactory = txrxFactory.getTestAPI();
 		exec = newSingleThreadExecutor();
+		this.bmpCtrl.clearBmpException();
 	}
 
 	@AfterEach
 	void stopExecutor() {
 		exec.shutdown();
+		var exn = bmpCtrl.getBmpException();
+		assertDoesNotThrow(() -> {
+			if (exn != null) {
+				throw new Exception(exn);
+			}
+		}, "BMP controller must not have thrown, but did");
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
@@ -60,6 +60,9 @@ import uk.ac.manchester.spinnaker.utils.ValueHolder;
 public final class MockTransceiver extends UnimplementedBMPTransceiver {
 	private static final Logger log = getLogger(MockTransceiver.class);
 
+	private static final MemoryLocation FLASH_DATA_ADDRESS =
+			new MemoryLocation(0x1000);
+
 	/**
 	 * Install this mock transceiver as the thing to be manufactured by the
 	 * given transceiver factory.
@@ -178,8 +181,7 @@ public final class MockTransceiver extends UnimplementedBMPTransceiver {
 	}
 
 	@Override
-	public String readBoardSerialNumber(BMPCoords bmp, BMPBoard board)
-			throws IOException, ProcessException {
+	public String readBoardSerialNumber(BMPCoords bmp, BMPBoard board) {
 		log.info("readBoardSerialNumber({},{})", bmp, board);
 		return SERIAL_NUMBER;
 	}
@@ -212,11 +214,16 @@ public final class MockTransceiver extends UnimplementedBMPTransceiver {
 
 	@Override
 	public ByteBuffer readBMPMemory(BMPCoords bmp, BMPBoard board,
-			MemoryLocation baseAddress, int length)
-			throws IOException, ProcessException {
+			MemoryLocation baseAddress, int length) {
 		log.info("readBMPMemory({},{},{},{})", bmp, board, baseAddress, length);
 		// TODO use ByteBuffer.slice(int,int) from Java 14 onwards
 		return slice(memory, baseAddress.address, length);
+	}
+
+	@Override
+	public MemoryLocation getSerialFlashBuffer(BMPCoords bmp, BMPBoard board) {
+		log.info("getSerialFlashBuffer({},{})", bmp, board);
+		return FLASH_DATA_ADDRESS;
 	}
 
 	@Override
@@ -230,8 +237,7 @@ public final class MockTransceiver extends UnimplementedBMPTransceiver {
 	@Override
 	public void writeFlash(@Valid BMPCoords bmp, @Valid BMPBoard board,
 			@NotNull MemoryLocation baseAddress, @NotNull ByteBuffer data,
-			boolean update)
-			throws ProcessException, IOException, InterruptedException {
+			boolean update) {
 		log.info("writeFlash({},{},{},{})", bmp, board, baseAddress,
 				data.remaining());
 		var blData = data.duplicate().position(BMP_FLASH_BLACKLIST_OFFSET);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
@@ -1094,7 +1094,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 * @param length
 	 *            The length of the data to be read in bytes
 	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
+	 *         the data. The buffer will be writable, but writes will not be
+	 *         automatically reflected anywhere.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
@@ -1123,7 +1124,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 * @param length
 	 *            The length of the data to be read in bytes
 	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
+	 *         the data. The buffer will be writable, but writes will not be
+	 *         automatically reflected anywhere.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
@@ -1346,7 +1348,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 * @param length
 	 *            The length of the data to be read in bytes
 	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
+	 *         the data. The buffer will be writable, but writes will not be
+	 *         automatically reflected anywhere.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException
@@ -1375,7 +1378,8 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 	 * @param length
 	 *            The length of the data to be read in bytes
 	 * @return A little-endian buffer of data read, positioned at the start of
-	 *         the data
+	 *         the data. The buffer will be writable, but writes will not be
+	 *         automatically reflected anywhere.
 	 * @throws IOException
 	 *             If anything goes wrong with networking.
 	 * @throws ProcessException


### PR DESCRIPTION
This is particularly about ensuring that failures in the BMP level get detected by tests, and that there are in fact no such failures. (This included enhancing the mock used, and updating the docs so I don't mess some "obvious" things up again in the future.)