### PR TITLE
Enhance the OAuth2 bearer token we get 

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/LocalAuthenticationProvider.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/LocalAuthenticationProvider.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.spinnaker.alloc.security;
 import static uk.ac.manchester.spinnaker.alloc.security.SecurityConfig.IS_ADMIN;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -94,6 +95,17 @@ public interface LocalAuthenticationProvider<TestAPI>
 	 */
 	void mapAuthorities(Jwt token,
 			Collection<GrantedAuthority> resultCollection);
+
+	/**
+	 * Map the attributes taken from introspecting an opaque token to
+	 * authorities.
+	 *
+	 * @param attributes
+	 *            The attributes from the introspection. Read-only.
+	 * @return The authorities to add.
+	 */
+	Collection<GrantedAuthority> mapOpaqueTokenAttributes(
+			Map<String, Object> attributes);
 
 	/**
 	 * @return The test interface.

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -271,5 +271,6 @@ spring:
         jwt:
           issuer-uri: ${spalloc.auth.openid.domain}
         opaquetoken:
+          introspection-uri: ${spalloc.auth.openid.domain}/protocol/openid-connect/token/introspect
           client-id: ${spalloc.auth.openid.id}
           client-secret: ${spalloc.auth.openid.secret}


### PR DESCRIPTION
The JWT doesn't always include all the claims we need. Specifically, it sometimes misses the `roles/team` sub-claim. To fix this, we need to query Keycloak to get the extra claims info we need.

Try to do auth using the (opaque) token introspection scheme, which apparently works just fine with JWT too. If this doesn't work (it depends on *exactly* what the server sends back and it's all extremely soft coded), we'll need to poke the `userinfo` endpoint.
