### PR TITLE
Another thing to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ hs_err_pid*
 .project
 .classpath
 .settings
+.factorypath
 .checkstyle
 .dbeaver
 


### PR DESCRIPTION
Thanks, Eclipse, for introducing `.factorypath`! I know not what it does, but I know I don't need it in my commits.
