### PR TITLE
Rewrite the command line API to use picocli

### DIFF
--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -91,6 +91,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-lambda</artifactId>
+		</dependency>
 	</dependencies>
 	<description>The front-end interface. NB: not a GUI!</description>
 	<name>SpiNNaker Front End Interface</name>

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -110,6 +110,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<parameters>true</parameters>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>info.picocli</groupId>
+							<artifactId>picocli-codegen</artifactId>
+							<version>${picocli.version}</version>
+						</path>
+					</annotationProcessorPaths>
+					<compilerArgs>
+						<arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -87,6 +87,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+		</dependency>
 	</dependencies>
 	<description>The front-end interface. NB: not a GUI!</description>
 	<name>SpiNNaker Front End Interface</name>
@@ -102,6 +106,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		</resources>
 		<finalName>spinnaker-exe</finalName>
 		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<parameters>true</parameters>
+				</configuration>
+			</plugin>
 			<plugin>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -142,8 +142,9 @@ public final class CommandLineInterface {
 		var cmd = new CommandLine(new CommandLineInterface());
 		if (args.length == 0) {
 			cmd.usage(cmd.getErr());
+			System.exit(USAGE);
 		} else {
-			cmd.execute(args);
+			System.exit(cmd.execute(args));
 		}
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -100,7 +100,7 @@ public final class CommandLineInterface {
 
 	private static final String PROPS = "command-line.properties";
 
-	private static class BuildPropsLoader implements IModelTransformer {
+	static class BuildPropsLoader implements IModelTransformer {
 		private Properties loadProps() throws IOException {
 			var prop = new Properties();
 			try (var clp = getClass().getResourceAsStream(PROPS)) {
@@ -399,7 +399,7 @@ public final class CommandLineInterface {
 			return machine;
 		}
 
-		private static class Converter implements ITypeConverter<Machine> {
+		static class Converter implements ITypeConverter<Machine> {
 			@Override
 			public Machine convert(String filename) throws IOException {
 				try (var reader = new FileReader(filename, UTF_8)) {
@@ -431,7 +431,7 @@ public final class CommandLineInterface {
 			return request;
 		}
 
-		private static class Converter implements ITypeConverter<IobufRequest> {
+		static class Converter implements ITypeConverter<IobufRequest> {
 			@Override
 			public IobufRequest convert(String filename) throws IOException {
 				try (var reader = new FileReader(filename, UTF_8)) {
@@ -462,7 +462,7 @@ public final class CommandLineInterface {
 			return gatherers;
 		}
 
-		private static class Converter implements ITypeConverter<List<Gather>> {
+		static class Converter implements ITypeConverter<List<Gather>> {
 			@Override
 			public List<Gather> convert(String filename) throws IOException {
 				try (var reader = new FileReader(filename, UTF_8)) {
@@ -493,7 +493,7 @@ public final class CommandLineInterface {
 			return placements;
 		}
 
-		private static class Converter
+		static class Converter
 				implements ITypeConverter<List<Placement>> {
 			@Override
 			public List<Placement> convert(String filename) throws IOException {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
@@ -197,11 +197,11 @@ public final class LogControl {
 	 * Note that this reads system properties, and probably should only be
 	 * called once.
 	 *
-	 * @param directoryName
+	 * @param directory
 	 *            The directory where the log should written inside.
 	 */
-	public static void setLoggerDir(String directoryName) {
-		var logfile = new File(new File(directoryName), LOG_FILE);
+	public static void setLoggerDir(File directory) {
+		var logfile = new File(directory, LOG_FILE);
 		var level = getProperty(Props.LOGGING_LEVEL_NAME, "info");
 		var lc = new LogControl();
 		reconfigure(lc.configuration(logfile, level));

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
@@ -68,7 +68,6 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 	/** How to run tasks in parallel. */
 	private final BasicExecutor executor;
 
-
 	/**
 	 * @param machine
 	 *            The description of the SpiNNaker machine.

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
@@ -116,10 +116,9 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	 *             If an unexpected exception happens.
 	 */
 	public NotableMessages retrieveIobufContents(IobufRequest request,
-			String provenanceDir)
+			File provenanceDir)
 			throws IOException, ProcessException, InterruptedException {
-		var provDir = new File(provenanceDir);
-		validateProvenanceDirectory(provDir);
+		validateProvenanceDirectory(provenanceDir);
 		var errorEntries = new ArrayList<String>();
 		var warnEntries = new ArrayList<String>();
 		var mapping = request.getRequestDetails();
@@ -128,8 +127,8 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 					.map(this::partitionByBoard).flatMap(entry -> {
 						var r = new Replacer(entry.getKey());
 						return entry.getValue().stream().map(cs -> {
-							return () -> retrieveIobufContents(cs, r, provDir,
-									errorEntries, warnEntries);
+							return () -> retrieveIobufContents(cs, r,
+									provenanceDir, errorEntries, warnEntries);
 						});
 					})).awaitAndCombineExceptions();
 		} catch (Replacer.WrappedException e) {

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -16,17 +16,70 @@
  */
 package uk.ac.manchester.spinnaker.front_end;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.Disabled;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 class TestFrontEnd {
 
+	/**
+	 * Run the command line, trapping its exit and comparing it with an expected
+	 * value.
+	 * <p>
+	 * This produces <em>one non-suppressable warning</em> due to
+	 * deprecation-for-removal in Java 17.
+	 *
+	 * @param expectedCode
+	 *            The expected exit code.
+	 * @param args
+	 *            The arguments to pass to the command line.
+	 * @throws Exception
+	 *             If anything goes wrong.
+	 * @see <a href="https://github.com/stefanbirkner/system-lambda/issues/27">
+	 *      System Lambda Issue #27</a>
+	 * @see <a href="https://bugs.openjdk.org/browse/JDK-8199704">JDK Issue
+	 *      #8199704</a>
+	 */
+	private static void runExpecting(int expectedCode, String... args)
+			throws Exception {
+		int code = catchSystemExit(() -> CommandLineInterface.main(args));
+		assertEquals(expectedCode, code);
+	}
+
 	@Test
-	@Disabled("Not yet implemented")
-	void test() {
-		fail("Not yet implemented");
+	void testHelp() throws Exception {
+		var msg = tapSystemOutNormalized(() -> {
+			runExpecting(0, "help");
+		});
+		var requiredSubcommands = List.of("dse_app_mon", "gather");
+		var requiredArgs = List.of("<machineFile>", "<runFolder>");
+		for (var cmd: requiredSubcommands) {
+			assertTrue(msg.contains(cmd),
+					() -> format("help message does not contain '%s': %s", cmd,
+							msg));
+			var msg2 = tapSystemOutNormalized(() -> {
+				runExpecting(0, "help", cmd);
+			});
+			for (var arg : requiredArgs) {
+				assertTrue(msg2.contains(arg),
+						() -> format("help message does not contain '%s': %s",
+								arg, msg2));
+			}
+		}
+	}
+
+	@Test
+	void testVersion() throws Exception {
+		var msg = tapSystemOutNormalized(() -> {
+			runExpecting(0, "--version");
+		});
+		assertTrue(msg.contains(" version "),
+				() -> format("message '%s' does not contain 'version'", msg));
 	}
 
 }

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/Machine.java
@@ -42,8 +42,6 @@ import java.util.TreeMap;
 
 import javax.validation.Valid;
 
-import org.slf4j.Logger;
-
 import uk.ac.manchester.spinnaker.machine.bean.MachineBean;
 import uk.ac.manchester.spinnaker.machine.datalinks.FPGALinkData;
 import uk.ac.manchester.spinnaker.machine.datalinks.FpgaEnum;
@@ -66,8 +64,6 @@ import uk.ac.manchester.spinnaker.utils.TripleMapIterable;
  * @author Christian-B
  */
 public class Machine implements MappableIterable<Chip> {
-	private static final Logger log = getLogger(Link.class);
-
 	/** Size of the machine along the x and y axes in Chips. */
 	@Valid
 	public final MachineDimensions machineDimensions;
@@ -217,6 +213,7 @@ public class Machine implements MappableIterable<Chip> {
 		if (ignoreLinks.isEmpty() && ignoreChips.isEmpty()) {
 			return this;
 		}
+		var log = getLogger(Link.class);
 		var rebuilt = new Machine(machineDimensions, boot);
 		for (var chip : this) {
 			var location = chip.asChipLocation();

--- a/SpiNNaker-py2json/pom.xml
+++ b/SpiNNaker-py2json/pom.xml
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<main.class>uk.ac.manchester.spinnaker.py2json.MachineDefinitionConverter</main.class>
 		<from.py>nosuchfile.py</from.py>
 		<to.json>config.json</to.json>
+		<program.name>py2json</program.name>
 	</properties>
 
 	<dependencies>
@@ -73,6 +74,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-lambda</artifactId>
 		</dependency>
 	</dependencies>
 	<build>
@@ -126,6 +131,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 									<mainClass>${main.class}</mainClass>
 								</transformer>
 							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.skife.maven</groupId>
+				<artifactId>really-executable-jar-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>really-executable-jar</goal>
+						</goals>
+						<configuration>
+							<programFile>${program.name}</programFile>
+							<attachProgramFile>true</attachProgramFile>
 						</configuration>
 					</execution>
 				</executions>

--- a/SpiNNaker-py2json/src/test/java/uk/ac/manchester/spinnaker/py2json/TestConvert.java
+++ b/SpiNNaker-py2json/src/test/java/uk/ac/manchester/spinnaker/py2json/TestConvert.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.spinnaker.py2json;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static java.io.File.createTempFile;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
@@ -158,9 +159,8 @@ class TestConvert {
 		var src = getFile(SINGLE_BOARD);
 		var dst = createTempFile("dst", ".json");
 		try {
-			// Can't test command line parse errors; System.exit() is called
-			// TODO check out https://stefanbirkner.github.io/system-rules/
-			main(src.getAbsolutePath(), dst.getAbsolutePath());
+			catchSystemExit(
+					() -> main(src.getAbsolutePath(), dst.getAbsolutePath()));
 
 			assertTrue(dst.exists());
 			try (var r = new BufferedReader(new FileReader(dst, UTF_8))) {

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<artifactId>javax.el</artifactId>
 				<version>3.0.0</version>
 			</dependency>
+			<dependency>
+				<groupId>com.github.stefanbirkner</groupId>
+				<artifactId>system-lambda</artifactId>
+				<version>1.2.1</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -678,6 +678,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.skife.maven</groupId>
+					<artifactId>really-executable-jar-maven-plugin</artifactId>
+					<version>2.0.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<jsontaglib.version>1.0.5</jsontaglib.version>
 		<jython.version>2.7.3</jython.version>
 		<error-prone.version>2.17.0</error-prone.version>
+		<picocli.version>4.7.0</picocli.version>
 	</properties>
 
 	<dependencyManagement>
@@ -301,7 +302,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<dependency>
 				<groupId>info.picocli</groupId>
 				<artifactId>picocli</artifactId>
-				<version>4.7.0</version>
+				<version>${picocli.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.keycloak</groupId>


### PR DESCRIPTION
This is actually significantly clearer than before (goodbye big `switch`!) and uses a library that we were already making use of elsewhere.