### PR TITLE
Reduce number of warnings from shade plugin

### DIFF
--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	</parent>
 	<artifactId>SpiNNaker-front-end</artifactId>
 	<properties>
-		<mainClass>uk.ac.manchester.spinnaker.front_end.CommandLineInterface</mainClass>
+		<main.class>uk.ac.manchester.spinnaker.front_end.CommandLineInterface</main.class>
 		<exeJar>${project.build.finalName}.jar</exeJar>
 	</properties>
 	<dependencies>
@@ -103,6 +103,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<finalName>spinnaker-exe</finalName>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-jar</id>
+						<configuration>
+							<forceCreation>true</forceCreation>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
@@ -111,16 +123,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						<goals>
 							<goal>shade</goal>
 						</goals>
-						<configuration>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>${mainClass}</mainClass>
-									<manifestEntries>
-										<Multi-Release>true</Multi-Release>
-									</manifestEntries>
-								</transformer>
-							</transformers>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/SpiNNaker-py2json/pom.xml
+++ b/SpiNNaker-py2json/pom.xml
@@ -121,11 +121,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						</goals>
 						<configuration>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>${main.class}</mainClass>
-								</transformer>
-							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
 									<addHeader>false</addHeader>
 								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
+									<resource>META-INF/io.netty.versions.properties</resource>
+									<ordinalKey>ordinal</ordinalKey>
+								</transformer>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<manifestEntries>
 										<Main-Class>${main.class}</Main-Class>

--- a/pom.xml
+++ b/pom.xml
@@ -387,12 +387,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<artifact>*:*</artifact>
 								<excludes>
 									<!-- Strip unwanted junk -->
-									<exclude>module-info.class</exclude>
-									<exclude>META-INF/MANIFEST.MF</exclude>
-									<exclude>META-INF/LICENSE</exclude>
-									<exclude>META-INF/LICENSE.txt</exclude>
-									<exclude>META-INF/NOTICE</exclude>
-									<exclude>META-INF/NOTICE.txt</exclude>
+									<exclude>**/*module-info.class</exclude>
+									<exclude>META-INF/*.MF</exclude>
 									<exclude>META-INF/DEPENDENCIES</exclude>
 									<exclude>META-INF/*.SF</exclude>
 									<exclude>META-INF/*.DSA</exclude>
@@ -400,6 +396,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								</excludes>
 							</filter>
 						</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+									<resource>.md</resource>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+									<addHeader>false</addHeader>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>${main.class}</Main-Class>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
This is an attempt to reduce the number of warnings from the build. I don't yet know how successful the result is, as this is a part of the build process *after tests!* I'd rather have a working build than a warning-free build.