### PR TITLE
Workaround for weird reordering with @Mixin

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
@@ -97,6 +97,12 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 		this.db = db;
 		executor = new BasicExecutor(PARALLEL_SIZE);
 		try {
+			if (db == null) {
+				// For testing only
+				job = null;
+				txrx = null;
+				return;
+			}
 			var proxy = db.getStorageInterface().getProxyInformation();
 			if (proxy == null) {
 				log.debug("Using direct machine access for transceiver");
@@ -118,7 +124,9 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 
 	@Override
 	public final void close() throws IOException, InterruptedException {
-		txrx.close();
+		if (txrx != null) {
+			txrx.close();
+		}
 		executor.close();
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -172,7 +172,19 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 		buildMaps(gatherers);
 	}
 
-	private void buildMaps(List<Gather> gatherers)
+	/**
+	 * Construct the internal mappings for gatherers and monitors.
+	 *
+	 * @param gatherers
+	 *            The descriptions of whether the gatherers are located.
+	 * @throws IOException
+	 *             If IDs can't be read from the machine for network reasons.
+	 * @throws ProcessException
+	 *             If IDs can't be read from the machine for machine reasons.
+	 * @throws InterruptedException
+	 *             If we are interrupted.
+	 */
+	protected void buildMaps(List<Gather> gatherers)
 			throws IOException, ProcessException, InterruptedException {
 		for (var g : gatherers) {
 			g.updateTransactionIdFromMachine(txrx);

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -17,13 +17,24 @@
 package uk.ac.manchester.spinnaker.front_end;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErrNormalized;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.AssertionFailedError;
+
+import uk.ac.manchester.spinnaker.front_end.download.request.Gather;
+import uk.ac.manchester.spinnaker.front_end.dse.FastExecuteDataSpecification;
+import uk.ac.manchester.spinnaker.front_end.dse.HostExecuteDataSpecification;
+import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 class TestFrontEnd {
 
@@ -45,30 +56,34 @@ class TestFrontEnd {
 	 * @see <a href="https://bugs.openjdk.org/browse/JDK-8199704">JDK Issue
 	 *      #8199704</a>
 	 */
-	private static void runExpecting(int expectedCode, String... args)
+	private static void runMainExpecting(int expectedCode, String... args)
 			throws Exception {
 		int code = catchSystemExit(() -> CommandLineInterface.main(args));
 		assertEquals(expectedCode, code);
 	}
 
+	private static void assertContains(String message, String substring) {
+		if (!requireNonNull(message).contains(requireNonNull(substring))) {
+			throw new AssertionFailedError(
+					format("message ‘%s’ does not contain ‘%s’", message,
+							substring));
+		}
+	}
+
 	@Test
 	void testHelp() throws Exception {
 		var msg = tapSystemOutNormalized(() -> {
-			runExpecting(0, "help");
+			runMainExpecting(0, "help");
 		});
 		var requiredSubcommands = List.of("dse_app_mon", "gather");
 		var requiredArgs = List.of("<machineFile>", "<runFolder>");
 		for (var cmd: requiredSubcommands) {
-			assertTrue(msg.contains(cmd),
-					() -> format("help message does not contain '%s': %s", cmd,
-							msg));
+			assertContains(msg, cmd);
 			var msg2 = tapSystemOutNormalized(() -> {
-				runExpecting(0, "help", cmd);
+				runMainExpecting(0, "help", cmd);
 			});
 			for (var arg : requiredArgs) {
-				assertTrue(msg2.contains(arg),
-						() -> format("help message does not contain '%s': %s",
-								arg, msg2));
+				assertContains(msg2, arg);
 			}
 		}
 	}
@@ -76,10 +91,100 @@ class TestFrontEnd {
 	@Test
 	void testVersion() throws Exception {
 		var msg = tapSystemOutNormalized(() -> {
-			runExpecting(0, "--version");
+			runMainExpecting(0, "--version");
 		});
-		assertTrue(msg.contains(" version "),
-				() -> format("message '%s' does not contain 'version'", msg));
+		assertContains(msg, " version ");
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = {"dse", "dse_sys", "dse_app"})
+	void testSimpleDSE(String cmd) throws Exception {
+		var machineFile = getClass().getResource("/machine.json").getFile();
+		var runFolder = "target/test/SimpleDSE";
+		new File(runFolder).mkdirs();
+
+		var saved = CommandLineInterface.hostFactory;
+		var called = new ValueHolder<>("none");
+		try {
+			CommandLineInterface.hostFactory =
+					(m, db) -> new HostExecuteDataSpecification(m, null) {
+						@Override
+						public void loadSystemCores() {
+							called.setValue("dse_sys");
+						}
+
+						@Override
+						public void loadApplicationCores() {
+							called.setValue("dse_app");
+						}
+
+						@Override
+						public void loadAllCores() {
+							called.setValue("dse");
+						}
+					};
+
+			var msg0 = tapSystemErrNormalized(() -> {
+				runMainExpecting(2, cmd);
+			});
+			assertContains(msg0, cmd + " <machineFile> <runFolder>");
+
+			var msg1 = tapSystemErrNormalized(() -> {
+				runMainExpecting(2, cmd, machineFile);
+			});
+			assertContains(msg1, cmd + " <machineFile> <runFolder>");
+
+			var msg3 = tapSystemErrNormalized(() -> {
+				runMainExpecting(2, cmd, machineFile, runFolder, "gorp");
+			});
+			assertContains(msg3, cmd + " <machineFile> <runFolder>");
+
+			assertEquals("none", called.getValue());
+			runMainExpecting(0, cmd, machineFile, runFolder);
+			assertEquals(cmd, called.getValue());
+		} finally {
+			CommandLineInterface.hostFactory = saved;
+		}
+	}
+
+	@Test
+	void testAdvancedDSE() throws Exception {
+		var cls = getClass();
+		var gatherFile = cls.getResource("/gather.json").getFile();
+		var machineFile = cls.getResource("/machine.json").getFile();
+		var runFolder = "target/test/AdvancedDSE";
+		new File(runFolder).mkdirs();
+
+		var saved = CommandLineInterface.hostFactory;
+		var called = new ValueHolder<>("none");
+		try {
+			CommandLineInterface.fastFactory = (m, g, r,
+					db) -> new FastExecuteDataSpecification(m, g, r, null) {
+						@Override
+						public void loadCores() {
+							called.setValue("mon");
+						}
+
+						@Override
+						protected void buildMaps(List<Gather> gatherers) {
+							assertEquals(g, gatherers);
+						}
+					};
+
+			var msg = tapSystemErrNormalized(() -> {
+				runMainExpecting(2, "dse_app_mon");
+			});
+			assertContains(msg, "<gatherFile>");
+			assertContains(msg, "<machineFile>");
+			assertContains(msg, "<runFolder>");
+			assertContains(msg, "[<reportFolder>]");
+
+			assertEquals("none", called.getValue());
+			runMainExpecting(0, "dse_app_mon", gatherFile, machineFile,
+					runFolder);
+			assertEquals("mon", called.getValue());
+		} finally {
+			CommandLineInterface.hostFactory = saved;
+		}
+	}
 }

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -122,6 +122,7 @@ class TestFrontEnd {
 
 	@ParameterizedTest
 	@ValueSource(strings = {"dse", "dse_sys", "dse_app"})
+	@SuppressWarnings("MustBeClosed")
 	void testSimpleDSE(String cmd) throws Exception {
 		var machineFile = getClass().getResource("/machine.json").getFile();
 		var runFolder = "target/test/SimpleDSE";
@@ -170,6 +171,7 @@ class TestFrontEnd {
 	}
 
 	@Test
+	@SuppressWarnings("MustBeClosed")
 	void testAdvancedDSE() throws Exception {
 		var cls = getClass();
 		var gatherFile = cls.getResource("/gather.json").getFile();

--- a/SpiNNaker-front-end/src/test/resources/machine.json
+++ b/SpiNNaker-front-end/src/test/resources/machine.json
@@ -1,0 +1,8 @@
+{
+	"width": 1,
+	"height": 1,
+	"root": [0, 0],
+	"ethernetResources": {},
+	"standardResources": {},
+	"chips": []
+}


### PR DESCRIPTION
The picocli `@Mixin` annotation was making things be reordered in a way that was surprising to me! Switching to `@ArgGroup(multiplicity = "1")` stops that, but is a less-than-obvious alternative given how things are documented.

Reported upstream: https://github.com/remkop/picocli/issues/1919
