### PR TITLE
Add extension point for SCPConnection making to TransceiverInterface

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedSCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedSCPConnection.java
@@ -104,4 +104,13 @@ final class ProxiedSCPConnection extends SCPConnection {
 		throw new UnsupportedOperationException(
 				"receiveWithAddress() not supported by this connection type");
 	}
+
+	/**
+	 * Close this connection eventually. Actually processes it immediately
+	 * because the other end of the proxy makes it eventual.
+	 */
+	@Override
+	public void closeEventually() {
+		closeAndLogNoExcept();
+	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedTransceiver.java
@@ -19,9 +19,12 @@ package uk.ac.manchester.spinnaker.alloc.client;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.TRIAD_NO_WRAPAROUND;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.Map;
 
+import uk.ac.manchester.spinnaker.connections.EIEIOConnection;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.model.Connection;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
@@ -32,9 +35,14 @@ import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 final class ProxiedTransceiver extends Transceiver {
 	private final ProxyProtocolClient websocket;
 
+	private final Map<Inet4Address, ChipLocation> hostToChip;
+
 	/**
 	 * @param connections
 	 *            The proxied connections we will use.
+	 * @param hostToChip
+	 *            The mapping from addresses to chip locations, to enable
+	 *            manufacturing of proxied {@link EIEIOConnection}s.
 	 * @param websocket
 	 *            The proxy handle.
 	 * @throws IOException
@@ -45,11 +53,13 @@ final class ProxiedTransceiver extends Transceiver {
 	 *             If SpiNNaker rejects a message.
 	 */
 	ProxiedTransceiver(Collection<Connection> connections,
+			Map<Inet4Address, ChipLocation> hostToChip,
 			ProxyProtocolClient websocket)
 			throws IOException, SpinnmanException, InterruptedException {
 		// Assume unwrapped
 		super(TRIAD_NO_WRAPAROUND, connections, null, null, null, null,
 				null);
+		this.hostToChip = hostToChip;
 		this.websocket = websocket;
 	}
 
@@ -65,6 +75,16 @@ final class ProxiedTransceiver extends Transceiver {
 			InetAddress addr) throws IOException {
 		try {
 			return new ProxiedSCPConnection(chip, websocket);
+		} catch (InterruptedException e) {
+			throw new IOException("failed to proxy connection", e);
+		}
+	}
+
+	@Override
+	protected EIEIOConnection newEieioConnection(InetAddress localHost,
+			Integer localPort) throws IOException {
+		try {
+			return new ProxiedEIEIOListenerConnection(hostToChip, websocket);
 		} catch (InterruptedException e) {
 			throw new IOException("failed to proxy connection", e);
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/ProxiedTransceiver.java
@@ -19,9 +19,12 @@ package uk.ac.manchester.spinnaker.alloc.client;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.TRIAD_NO_WRAPAROUND;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Collection;
 
+import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.model.Connection;
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.transceiver.SpinnmanException;
 import uk.ac.manchester.spinnaker.transceiver.Transceiver;
 
@@ -55,5 +58,15 @@ final class ProxiedTransceiver extends Transceiver {
 	public void close() throws IOException {
 		super.close();
 		websocket.close();
+	}
+
+	@Override
+	public SCPConnection createScpConnection(ChipLocation chip,
+			InetAddress addr) throws IOException {
+		try {
+			return new ProxiedSCPConnection(chip, websocket);
+		} catch (InterruptedException e) {
+			throw new IOException("failed to proxy connection", e);
+		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/SpallocClientFactory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/alloc/client/SpallocClientFactory.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.Inet4Address;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,6 +65,7 @@ import uk.ac.manchester.spinnaker.alloc.client.SpallocClient.SpallocException;
 import uk.ac.manchester.spinnaker.connections.EIEIOConnection;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.model.Connection;
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.board.PhysicalCoords;
 import uk.ac.manchester.spinnaker.machine.board.TriadCoords;
@@ -706,12 +708,15 @@ public class SpallocClientFactory {
 			var ws = getProxy();
 			var am = machine();
 			var conns = new ArrayList<Connection>();
+			var hostToChip = new HashMap<Inet4Address, ChipLocation>();
 			for (var bc : am.getConnections()) {
 				conns.add(new ProxiedSCPConnection(
 						bc.getChip().asChipLocation(), ws));
+				hostToChip.put(getByNameQuietly(bc.getHostname()),
+						bc.getChip());
 			}
 			conns.add(new ProxiedBootConnection(ws));
-			return new ProxiedTransceiver(conns, ws);
+			return new ProxiedTransceiver(conns, hostToChip, ws);
 		}
 
 		@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/EIEIOConnection.java
@@ -34,22 +34,6 @@ import uk.ac.manchester.spinnaker.messages.eieio.EIEIOMessage;
 public class EIEIOConnection
 		extends UDPConnection<EIEIOMessage<? extends EIEIOHeader>> {
 	/**
-	 * Create an EIEIO connection only available for listening, using default
-	 * local port.
-	 *
-	 * @param localHost
-	 *            The local IP address to bind to. If not specified, it defaults
-	 *            to binding to all interfaces, unless remoteHost is specified,
-	 *            in which case binding is done to the IP address that will be
-	 *            used to send packets.
-	 * @throws IOException
-	 *             If there is an error setting up the communication channel
-	 */
-	public EIEIOConnection(InetAddress localHost) throws IOException {
-		super(localHost, null, null, null, null);
-	}
-
-	/**
 	 * Create an EIEIO connection only available for listening.
 	 *
 	 * @param localHost
@@ -64,34 +48,7 @@ public class EIEIOConnection
 	 */
 	public EIEIOConnection(InetAddress localHost, Integer localPort)
 			throws IOException {
-		super(localHost, localPort, null, null, null);
-	}
-
-	/**
-	 * Create an EIEIO connection.
-	 *
-	 * @param localHost
-	 *            The local host to bind to. If not specified, it defaults to
-	 *            binding to all interfaces, unless remoteHost is specified, in
-	 *            which case binding is done to the IP address that will be used
-	 *            to send packets.
-	 * @param localPort
-	 *            The local port to bind to, 0 or between 1025 and 65535.
-	 * @param remoteHost
-	 *            The remote host to send packets to. If not specified, the
-	 *            socket will be available for listening only, and will throw
-	 *            and exception if used for sending.
-	 * @param remotePort
-	 *            The remote port to send packets to. If remoteHost is
-	 *            {@code null}, this is ignored. If remoteHost is specified,
-	 *            this must also be specified as non-zero for the connection to
-	 *            allow sending.
-	 * @throws IOException
-	 *             If there is an error setting up the communication channel
-	 */
-	public EIEIOConnection(InetAddress localHost, Integer localPort,
-			InetAddress remoteHost, Integer remotePort) throws IOException {
-		super(localHost, localPort, remoteHost, remotePort, IPTOS_THROUGHPUT);
+		super(localHost, localPort, null, null, IPTOS_THROUGHPUT);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/connections/SCPConnection.java
@@ -17,53 +17,32 @@
 package uk.ac.manchester.spinnaker.connections;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
-import static uk.ac.manchester.spinnaker.messages.scp.SCPRequest.BOOT_CHIP;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.connections.model.SCPSenderReceiver;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
+import uk.ac.manchester.spinnaker.utils.Daemon;
 
 /** A UDP connection to SC&amp;MP on the board. */
-public class SCPConnection extends SDPConnection
-		implements SCPSenderReceiver {
-	/**
-	 * Create a connection to a particular instance of SCAMP.
-	 *
-	 * @param remoteHost
-	 *            The remote host to send messages to.
-	 * @throws IOException
-	 *             If anything goes wrong with socket setup.
-	 */
-	public SCPConnection(InetAddress remoteHost) throws IOException {
-		this(BOOT_CHIP, null, null, remoteHost, SCP_SCAMP_PORT);
-	}
+public class SCPConnection extends SDPConnection implements SCPSenderReceiver {
+	private static final Logger log = getLogger(SCPConnection.class);
 
-	/**
-	 * Create a connection to a particular instance of SCAMP.
-	 *
-	 * @param localHost
-	 *            The optional host of the local interface to
-	 *            listen on; use {@code null} to listen on all local
-	 *            interfaces.
-	 * @param localPort
-	 *            The optional local port to listen on; use {@code null} to
-	 *            pick a random port.
-	 * @param remoteHost
-	 *            The remote host to send messages to.
-	 * @param remotePort
-	 *            The optional remote port number to send messages to. If
-	 *            {@code null}, the default remote port is used.
-	 * @throws IOException
-	 *             If anything goes wrong with socket setup.
-	 */
-	public SCPConnection(InetAddress localHost, Integer localPort,
-			InetAddress remoteHost, Integer remotePort) throws IOException {
-		this(BOOT_CHIP, localHost, localPort, remoteHost, remotePort);
+	private static final ScheduledExecutorService CLOSER;
+
+	static {
+		CLOSER = newSingleThreadScheduledExecutor(
+				r -> new Daemon(r, "SCPConnection.Closer"));
 	}
 
 	/**
@@ -82,35 +61,17 @@ public class SCPConnection extends SDPConnection
 	}
 
 	/**
-	 * Create a connection to a particular instance of SCAMP.
-	 *
-	 * @param chip
-	 *            The location of the chip on the board with this remoteHost
-	 * @param remoteHost
-	 *            The remote host to send messages to.
-	 * @param remotePort
-	 *            The optional remote port number to send messages to. If
-	 *            {@code null}, the default remote port is used.
-	 * @throws IOException
-	 *             If anything goes wrong with socket setup.
-	 */
-	public SCPConnection(HasChipLocation chip, InetAddress remoteHost,
-			Integer remotePort) throws IOException {
-		this(chip, null, null, remoteHost, remotePort);
-	}
-
-	/**
-	 * Create a connection to a particular instance of SCAMP.
+	 * Create a connection to a particular instance of SCAMP. Can use a
+	 * specified local network interface.
 	 *
 	 * @param chip
 	 *            The location of the chip on the board with this remoteHost
 	 * @param localHost
-	 *            The optional host of the local interface to
-	 *            listen on; use {@code null} to listen on all local
-	 *            interfaces.
+	 *            The optional host of the local interface to listen on; use
+	 *            {@code null} to listen on all local interfaces.
 	 * @param localPort
-	 *            The optional local port to listen on; use {@code null} to
-	 *            pick a random port.
+	 *            The optional local port to listen on; use {@code null} to pick
+	 *            a random port.
 	 * @param remoteHost
 	 *            The remote host to send messages to.
 	 * @param remotePort
@@ -119,12 +80,12 @@ public class SCPConnection extends SDPConnection
 	 * @throws IOException
 	 *             If anything goes wrong with socket setup.
 	 */
-	public SCPConnection(HasChipLocation chip, InetAddress localHost,
-			Integer localPort, InetAddress remoteHost, Integer remotePort)
+	protected SCPConnection(HasChipLocation chip, InetAddress localHost,
+			Integer localPort, InetAddress remoteHost, int remotePort)
 			throws IOException {
 		super(chip, localHost, localPort, requireNonNull(remoteHost,
 				"SCPConnection only meaningful with a real remote host"),
-				(remotePort == null) ? SCP_SCAMP_PORT : remotePort);
+				remotePort);
 	}
 
 	/**
@@ -149,5 +110,31 @@ public class SCPConnection extends SDPConnection
 	@Override
 	public void send(SCPRequest<?> scpRequest) throws IOException {
 		send(getSCPData(scpRequest));
+	}
+
+	/**
+	 * Close this connection eventually. The close might not happen immediately.
+	 */
+	@SuppressWarnings("FutureReturnValueIgnored")
+	public void closeEventually() {
+		CLOSER.schedule(this::closeAndLogNoExcept, 1, SECONDS);
+	}
+
+	/**
+	 * Close this connection, logging failures instead of throwing.
+	 * <p>
+	 * Core of implementation of {@link #closeEventually()}.
+	 */
+	protected final void closeAndLogNoExcept() {
+		try {
+			var name = "";
+			if (log.isInfoEnabled()) {
+				name = toString();
+			}
+			close();
+			log.info("closed {}", name);
+		} catch (IOException e) {
+			log.warn("failed to close connection", e);
+		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -393,6 +393,7 @@ public class Transceiver extends UDPTransceiver
 	 *             If the communications were interrupted.
 	 */
 	@MustBeClosed
+	@SuppressWarnings("MustBeClosed")
 	public Transceiver(InetAddress host, MachineVersion version,
 			Collection<BMPConnectionData> bmpConnectionData,
 			Integer numberOfBoards, Set<ChipLocation> ignoredChips,
@@ -432,7 +433,7 @@ public class Transceiver extends UDPTransceiver
 			scampConnections = List.of();
 		}
 		if (scampConnections.isEmpty()) {
-			connections.add(new SCPConnection(host));
+			connections.add(createScpConnection(BOOT_CHIP, host));
 		}
 
 		// handle the boot connection
@@ -454,8 +455,12 @@ public class Transceiver extends UDPTransceiver
 		allConnections.addAll(connections);
 		// if there has been SCAMP connections given, build them
 		for (var desc : scampConnections) {
-			connections.add(new SCPConnection(desc.chip, desc.hostname,
-					desc.portNumber));
+			if (desc.portNumber != null
+					&& desc.portNumber != SCP_SCAMP_PORT) {
+				log.warn("ignoring unexpected SCAMP port: {}",
+						desc.portNumber);
+			}
+			connections.add(createScpConnection(desc.chip, desc.hostname));
 		}
 		for (Connection conn : connections) {
 			identifyConnection(conn);
@@ -598,6 +603,7 @@ public class Transceiver extends UDPTransceiver
 	 * @throws InterruptedException
 	 *             If the communications were interrupted.
 	 */
+	@SuppressWarnings("MustBeClosed")
 	public Transceiver(MachineVersion version,
 			Collection<Connection> connections,
 			Collection<ChipLocation> ignoredChips,
@@ -627,8 +633,12 @@ public class Transceiver extends UDPTransceiver
 		// if there has been SCAMP connections given, build them
 		if (scampConnections != null) {
 			for (ConnectionDescriptor desc : scampConnections) {
-				connections.add(new SCPConnection(desc.chip, desc.hostname,
-						desc.portNumber));
+				if (desc.portNumber != null
+						&& desc.portNumber != SCP_SCAMP_PORT) {
+					log.warn("ignoring unexpected SCAMP port: {}",
+							desc.portNumber);
+				}
+				connections.add(createScpConnection(desc.chip, desc.hostname));
 			}
 		}
 		for (Connection conn : connections) {
@@ -636,6 +646,12 @@ public class Transceiver extends UDPTransceiver
 		}
 		scpSelector = makeConnectionSelector();
 		checkBMPConnections();
+	}
+
+	@Override
+	public SCPConnection createScpConnection(ChipLocation chip,
+			InetAddress addr) throws IOException {
+		return new SCPConnection(chip, addr);
 	}
 
 	private ConnectionSelector<SCPConnection> makeConnectionSelector() {
@@ -953,6 +969,7 @@ public class Transceiver extends UDPTransceiver
 	 *             If the communications were interrupted.
 	 */
 	@CheckReturnValue
+	@SuppressWarnings("MustBeClosed")
 	public List<SCPConnection> discoverScampConnections()
 			throws IOException, ProcessException, InterruptedException {
 		/*
@@ -978,7 +995,7 @@ public class Transceiver extends UDPTransceiver
 
 			// if no data, no proxy
 			if (conn == null) {
-				conn = new SCPConnection(chip, ipAddress);
+				conn = createScpConnection(chip, ipAddress);
 			} else {
 				// proxy, needs an adjustment
 				udpScpConnections.remove(conn.getRemoteIPAddress());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TransceiverInterface.java
@@ -57,11 +57,13 @@ import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.MustBeClosed;
 
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.connections.SDPConnection;
 import uk.ac.manchester.spinnaker.connections.model.Connection;
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.CoreSubsets;
 import uk.ac.manchester.spinnaker.machine.Direction;
@@ -78,6 +80,7 @@ import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
 import uk.ac.manchester.spinnaker.machine.tags.Tag;
 import uk.ac.manchester.spinnaker.machine.tags.TagID;
+import uk.ac.manchester.spinnaker.messages.Constants;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.CPUInfo;
 import uk.ac.manchester.spinnaker.messages.model.CPUState;
@@ -97,6 +100,7 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
 import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.utils.MappableIterable;
+import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
 
 /**
  * The interface supported by the {@link Transceiver}. Emulates a lot of default
@@ -4199,4 +4203,24 @@ public interface TransceiverInterface extends BMPTransceiverInterface {
 	@ParallelSafeWithCare
 	void loadSystemRouterTables(@Valid CoreSubsets monitorCores)
 			throws IOException, ProcessException, InterruptedException;
+
+	/**
+	 * Create a connection to a particular instance of SCAMP. Note that this
+	 * connection is a new connection; it is not a previously existing
+	 * connection.
+	 *
+	 * @param chip
+	 *            The location of the chip on the board with this remoteHost
+	 * @param addr
+	 *            The IP address of the SpiNNaker board to send messages to.
+	 * @return The SCP connection to use. It is up to the caller to arrange for
+	 *         this to be closed at the right time.
+	 * @throws IOException
+	 *             If anything goes wrong with socket setup.
+	 */
+	@ParallelSafe
+	@MustBeClosed
+	@UsedInJavadocOnly(Constants.class)
+	SCPConnection createScpConnection(ChipLocation chip, InetAddress addr)
+			throws IOException;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UDPTransceiver.java
@@ -256,13 +256,32 @@ public abstract class UDPTransceiver implements Closeable {
 		log.info("finding/creating connection listening on {}:{}",
 				addr.getHostAddress(), localPort);
 		var pair = unwrap(() -> lookup(addr, localPort).orElseGet(
-				() -> new Pair<>(wrap(() -> new EIEIOConnection(addr, port)),
+				() -> new Pair<>(wrap(() -> newEieioConnection(addr, port)),
 						true)));
 
 		// Launch a listener if one is required
 		pair.initListener(addr, callback);
 		eieioListeners.add(pair);
 		return (EIEIOConnection) pair.connection;
+	}
+
+	/**
+	 * Create an EIEIO connection only available for listening (or directed
+	 * sending towards a SpiNNaker board).
+	 *
+	 * @param localHost
+	 *            The local IP address to bind to. If {@code null}, it defaults
+	 *            to binding to all interfaces or a system-specified interface.
+	 * @param localPort
+	 *            The local port to bind to, {@code null} or between 1025 and
+	 *            65535.
+	 * @return The listen-only EIEIO connection.
+	 * @throws IOException
+	 *             If there is an error setting up the communication channel
+	 */
+	protected EIEIOConnection newEieioConnection(InetAddress localHost,
+			Integer localPort) throws IOException {
+		return new EIEIOConnection(localHost, localPort);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/connections/TestUDPConnection.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static uk.ac.manchester.spinnaker.machine.Direction.EAST;
 import static uk.ac.manchester.spinnaker.machine.MemoryLocation.NULL;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
+import static uk.ac.manchester.spinnaker.messages.scp.SCPRequest.BOOT_CHIP;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPResult.RC_OK;
 import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.BUFFERED_SDRAM_START;
 
@@ -60,7 +61,8 @@ public class TestUDPConnection {
 		var scpReq = new GetVersion(ZERO_CORE);
 		scpReq.scpRequestHeader.issueSequenceNumber(Set.of());
 		SCPResultMessage result;
-		try (var connection = new SCPConnection(boardConfig.remotehost)) {
+		try (var connection =
+				new SCPConnection(BOOT_CHIP, boardConfig.remotehost)) {
 			connection.send(scpReq);
 			result = connection.receiveSCPResponse(TIMEOUT);
 		} catch (SocketTimeoutException e) {
@@ -82,7 +84,8 @@ public class TestUDPConnection {
 				new ReadLink(ZERO_CHIP, EAST, BUFFERED_SDRAM_START, LINK_SIZE);
 		scpReq.scpRequestHeader.issueSequenceNumber(Set.of());
 		SCPResultMessage result;
-		try (var connection = new SCPConnection(boardConfig.remotehost)) {
+		try (var connection =
+				new SCPConnection(BOOT_CHIP, boardConfig.remotehost)) {
 			connection.send(scpReq);
 			result = connection.receiveSCPResponse(TIMEOUT);
 		} catch (SocketTimeoutException e) {
@@ -100,7 +103,8 @@ public class TestUDPConnection {
 				UDP_MESSAGE_MAX_SIZE);
 		scpReq.scpRequestHeader.issueSequenceNumber(Set.of());
 		SCPResultMessage result;
-		try (var connection = new SCPConnection(boardConfig.remotehost)) {
+		try (var connection =
+				new SCPConnection(BOOT_CHIP, boardConfig.remotehost)) {
 			connection.send(scpReq);
 			result = connection.receiveSCPResponse(TIMEOUT);
 		} catch (SocketTimeoutException e) {
@@ -116,7 +120,8 @@ public class TestUDPConnection {
 			throws UnknownHostException {
 		boardConfig.setUpNonexistentBoard();
 		assertThrows(IOException.class, () -> {
-			try (var connection = new SCPConnection(boardConfig.remotehost)) {
+			try (var connection =
+					new SCPConnection(BOOT_CHIP, boardConfig.remotehost)) {
 				var scp = new ReadMemory(ZERO_CHIP, NULL, UDP_MESSAGE_MAX_SIZE);
 				scp.scpRequestHeader.issueSequenceNumber(Set.of());
 				connection.send(scp);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static testconfig.BoardTestConfiguration.NOHOST;
 import static uk.ac.manchester.spinnaker.machine.MachineVersion.FIVE;
 import static uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition.software_watchdog_count;
+import static uk.ac.manchester.spinnaker.messages.scp.SCPRequest.BOOT_CHIP;
 import static uk.ac.manchester.spinnaker.transceiver.CommonMemoryLocations.SYS_VARS;
 import static uk.ac.manchester.spinnaker.utils.Ping.ping;
 
@@ -69,7 +70,7 @@ class TestTransceiver {
 		var connections = new ArrayList<Connection>();
 
 		boardConfig.setUpRemoteBoard();
-		connections.add(new SCPConnection(boardConfig.remotehost));
+		connections.add(new SCPConnection(BOOT_CHIP, boardConfig.remotehost));
 
 		try (var txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
@@ -82,7 +83,7 @@ class TestTransceiver {
 		var connections = new ArrayList<Connection>();
 
 		boardConfig.setUpRemoteBoard();
-		connections.add(new SCPConnection(boardConfig.remotehost));
+		connections.add(new SCPConnection(BOOT_CHIP, boardConfig.remotehost));
 
 		try (var txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
@@ -95,10 +96,10 @@ class TestTransceiver {
 		var connections = new ArrayList<Connection>();
 
 		boardConfig.setUpRemoteBoard();
-		connections.add(new SCPConnection(boardConfig.remotehost));
+		connections.add(new SCPConnection(BOOT_CHIP, boardConfig.remotehost));
 
 		boardConfig.setUpLocalVirtualBoard();
-		connections.add(new SCPConnection(boardConfig.remotehost));
+		connections.add(new SCPConnection(BOOT_CHIP, boardConfig.remotehost));
 
 		try (var txrx = new Transceiver(FIVE, connections, null,
 				null, null, null, null)) {
@@ -114,7 +115,7 @@ class TestTransceiver {
 		var connections = new ArrayList<Connection>();
 
 		boardConfig.setUpRemoteBoard();
-		connections.add(new SCPConnection(boardConfig.remotehost));
+		connections.add(new SCPConnection(BOOT_CHIP, boardConfig.remotehost));
 
 		boardConfig.setUpLocalVirtualBoard();
 		connections.add(
@@ -163,7 +164,7 @@ class TestTransceiver {
 		assumeFalse(ping(noHost) == 0,
 				() -> "unreachable host (" + noHost + ") appears to be up");
 		var connections = new ArrayList<Connection>();
-		connections.add(new SCPConnection(null, (Integer) null, noHost, null));
+		connections.add(new SCPConnection(BOOT_CHIP, noHost));
 		var orig = new EIEIOConnection(null, null, null, null);
 		connections.add(orig);
 
@@ -207,7 +208,7 @@ class TestTransceiver {
 
 		var connections = new ArrayList<Connection>();
 		var noHost = InetFactory.getByName(NOHOST);
-		connections.add(new SCPConnection(noHost));
+		connections.add(new SCPConnection(BOOT_CHIP, noHost));
 		try (var txrx = new MockWriteTransceiver(FIVE, connections)) {
 			// All chips
 			txrx.enableWatchDogTimer(true);

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/transceiver/TestTransceiver.java
@@ -165,7 +165,7 @@ class TestTransceiver {
 				() -> "unreachable host (" + noHost + ") appears to be up");
 		var connections = new ArrayList<Connection>();
 		connections.add(new SCPConnection(BOOT_CHIP, noHost));
-		var orig = new EIEIOConnection(null, null, null, null);
+		var orig = new EIEIOConnection(null, null);
 		connections.add(orig);
 
 		var mh = new EIEIOMessageHandler() {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/BoardLocalSupport.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/BoardLocalSupport.java
@@ -21,6 +21,7 @@ import org.slf4j.MDC.MDCCloseable;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.Machine;
+import uk.ac.manchester.spinnaker.transceiver.TransceiverInterface;
 
 /**
  * A class for making things easier to do on a per-board basis.
@@ -30,10 +31,23 @@ import uk.ac.manchester.spinnaker.machine.Machine;
 public abstract class BoardLocalSupport {
 	private static final String BOARD_ROOT = "boardRoot";
 
-	private final Machine machine;
+	/** The transceiver for talking to the SpiNNaker machine. */
+	protected final TransceiverInterface txrx;
 
-	/** @param machine Which machine is this on? Used for address mapping. */
-	protected BoardLocalSupport(Machine machine) {
+	/** The description of the SpiNNaker machine. */
+	protected final Machine machine;
+
+	/**
+	 * @param transceiver
+	 *            How to talk to the SpiNNaker system via SCP. Where the system
+	 *            is located.
+	 * @param machine
+	 *            Which machine is this on? Used for address mapping and
+	 *            provided as a general service to subclasses.
+	 */
+	protected BoardLocalSupport(TransceiverInterface transceiver,
+			Machine machine) {
+		this.txrx = transceiver;
 		this.machine = machine;
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -610,7 +610,14 @@ public final class CommandLineInterface {
 
 	private static SpallocClient.Job getJob(ProxyAwareStorage storage)
 			throws StorageException, IOException {
-		return getJobFromProxyInfo(storage.getProxyInformation());
+		try {
+			return getJobFromProxyInfo(storage.getProxyInformation());
+		} catch (StorageException e) {
+			if (e.getMessage().contains("no such table: proxy_configuration")) {
+				return null;
+			}
+			throw e;
+		}
 	}
 
 	@MustBeClosed

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -610,14 +610,7 @@ public final class CommandLineInterface {
 
 	private static SpallocClient.Job getJob(ProxyAwareStorage storage)
 			throws StorageException, IOException {
-		try {
-			return getJobFromProxyInfo(storage.getProxyInformation());
-		} catch (StorageException e) {
-			if (e.getMessage().contains("no such table: proxy_configuration")) {
-				return null;
-			}
-			throw e;
-		}
+		return getJobFromProxyInfo(storage.getProxyInformation());
 	}
 
 	@MustBeClosed

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
@@ -51,11 +51,7 @@ import uk.ac.manchester.spinnaker.transceiver.TransceiverInterface;
  * @author Christian-B
  */
 public class DataReceiver extends BoardLocalSupport {
-	private final TransceiverInterface txrx;
-
 	private final BufferedReceivingData receivedData;
-
-	private final Machine machine;
 
 	private static final Logger log = getLogger(DataReceiver.class);
 
@@ -71,11 +67,9 @@ public class DataReceiver extends BoardLocalSupport {
 	 */
 	public DataReceiver(TransceiverInterface tranceiver, Machine machine,
 			BufferManagerStorage storage) {
-		super(machine);
-		txrx = tranceiver;
+		super(tranceiver, machine);
 		// storage area for received data from cores
 		receivedData = new BufferedReceivingData(storage);
-		this.machine = machine;
 	}
 
 	private Stream<List<Placement>> partitionByBoard(

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
-import uk.ac.manchester.spinnaker.alloc.client.SpallocClient;
 import uk.ac.manchester.spinnaker.front_end.download.request.Placement;
 import uk.ac.manchester.spinnaker.front_end.download.request.Vertex;
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
@@ -61,8 +60,6 @@ public class DirectDataGatherer extends DataGatherer {
 	/** Version of the file produced by the DSE. */
 	private static final int DSE_VERSION = 0x00010000;
 
-	private final TransceiverInterface txrx;
-
 	private final BufferManagerStorage database;
 
 	@GuardedBy("itself")
@@ -78,8 +75,6 @@ public class DirectDataGatherer extends DataGatherer {
 	 *            Where to put the retrieved data.
 	 * @param machine
 	 *            The description of the machine being talked to.
-	 * @param job
-	 *            The spalloc job to connect to, or null if none.
 	 * @throws ProcessException
 	 *             If we can't discover the machine details due to SpiNNaker
 	 *             rejecting messages
@@ -88,10 +83,9 @@ public class DirectDataGatherer extends DataGatherer {
 	 */
 	@MustBeClosed
 	public DirectDataGatherer(TransceiverInterface transceiver, Machine machine,
-			BufferManagerStorage database, SpallocClient.Job job)
+			BufferManagerStorage database)
 			throws IOException, ProcessException {
-		super(transceiver, machine, job);
-		this.txrx = transceiver;
+		super(transceiver, machine);
 		this.database = database;
 		coreTableCache = new HashMap<>();
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
-import uk.ac.manchester.spinnaker.alloc.client.SpallocClient;
 import uk.ac.manchester.spinnaker.front_end.download.request.Placement;
 import uk.ac.manchester.spinnaker.machine.Machine;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
@@ -63,8 +62,6 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	private static final Logger log =
 			getLogger(RecordingRegionDataGatherer.class);
 
-	private final TransceiverInterface txrx;
-
 	private final BufferManagerStorage database;
 
 	@GuardedBy("itself")
@@ -84,8 +81,6 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	 *            The description of the machine talked to.
 	 * @param database
 	 *            Where to put the retrieved data.
-	 * @param job
-	 *            The spalloc job to connect to, or null if none.
 	 * @throws ProcessException
 	 *             If we can't discover the machine details due to SpiNNaker
 	 *             rejecting messages
@@ -94,11 +89,9 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	 */
 	@MustBeClosed
 	public RecordingRegionDataGatherer(TransceiverInterface transceiver,
-			Machine machine, BufferManagerStorage database,
-			SpallocClient.Job job)
+			Machine machine, BufferManagerStorage database)
 			throws IOException, ProcessException {
-		super(transceiver, machine, job);
-		this.txrx = transceiver;
+		super(transceiver, machine);
 		this.database = database;
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ExecuteDataSpecification.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.spinnaker.front_end.dse;
 
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.alloc.client.SpallocClientFactory.getJobFromProxyInfo;
 import static uk.ac.manchester.spinnaker.front_end.Constants.PARALLEL_SIZE;
 
 import java.io.IOException;
@@ -28,8 +29,6 @@ import org.slf4j.Logger;
 
 import com.google.errorprone.annotations.MustBeClosed;
 
-import uk.ac.manchester.spinnaker.alloc.client.SpallocClient;
-import uk.ac.manchester.spinnaker.alloc.client.SpallocClientFactory;
 import uk.ac.manchester.spinnaker.data_spec.DataSpecificationException;
 import uk.ac.manchester.spinnaker.front_end.BasicExecutor;
 import uk.ac.manchester.spinnaker.front_end.BoardLocalSupport;
@@ -61,9 +60,6 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 
 	/** The database. */
 	protected final DSEDatabaseEngine db;
-
-	/** A spalloc job, or null if not used. */
-	protected final SpallocClient.Job job;
 
 	/** How to run tasks in parallel. */
 	private final BasicExecutor executor;
@@ -99,20 +95,17 @@ public abstract class ExecuteDataSpecification extends BoardLocalSupport
 		try {
 			if (db == null) {
 				// For testing only
-				job = null;
 				txrx = null;
 				return;
 			}
 			var proxy = db.getStorageInterface().getProxyInformation();
 			if (proxy == null) {
 				log.debug("Using direct machine access for transceiver");
-				job = null;
 				txrx = new Transceiver(machine);
 			} else {
 				log.debug("Getting transceiver via proxy on {}",
 						proxy.spallocUrl);
-				job = SpallocClientFactory.getJobFromProxyInfo(proxy);
-				txrx = job.getTransceiver();
+				txrx = getJobFromProxyInfo(proxy).getTransceiver();
 			}
 		} catch (ProcessException e) {
 			throw e;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -79,6 +79,7 @@ import uk.ac.manchester.spinnaker.storage.DSEStorage.CoreToLoad;
 import uk.ac.manchester.spinnaker.storage.DSEStorage.Ethernet;
 import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
+import uk.ac.manchester.spinnaker.transceiver.TransceiverInterface;
 import uk.ac.manchester.spinnaker.utils.MathUtils;
 
 /**
@@ -125,6 +126,8 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	/**
 	 * Create an instance of this class.
 	 *
+	 * @param txrx
+	 *            The transceiver for talking to the SpiNNaker machine.
 	 * @param machine
 	 *            The SpiNNaker machine description.
 	 * @param gatherers
@@ -149,11 +152,11 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             this constructor should not be doing that!
 	 */
 	@MustBeClosed
-	public FastExecuteDataSpecification(Machine machine, List<Gather> gatherers,
-			File reportDir, DSEDatabaseEngine db)
-			throws IOException, ProcessException, InterruptedException,
-			StorageException, URISyntaxException {
-		super(machine, db);
+	public FastExecuteDataSpecification(TransceiverInterface txrx,
+			Machine machine, List<Gather> gatherers, File reportDir,
+			DSEDatabaseEngine db) throws IOException, ProcessException,
+			InterruptedException, StorageException, URISyntaxException {
+		super(txrx, machine, db);
 		if (SPINNAKER_COMPARE_UPLOAD != null) {
 			log.warn(
 					"detailed comparison of uploaded data enabled; "
@@ -419,7 +422,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 			this.storage = storage;
 			this.bar = bar;
 			this.execContext = new ExecutionContext(txrx);
-			connection = new ThrottledConnection(txrx, board,
+			this.connection = new ThrottledConnection(txrx, board,
 					gathererForChip.get(board.location).getIptag());
 		}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/FastExecuteDataSpecification.java
@@ -420,7 +420,7 @@ public class FastExecuteDataSpecification extends ExecuteDataSpecification {
 			this.bar = bar;
 			this.execContext = new ExecutionContext(txrx);
 			connection = new ThrottledConnection(txrx, board,
-					gathererForChip.get(board.location).getIptag(), job);
+					gathererForChip.get(board.location).getIptag());
 		}
 
 		@Override

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/HostExecuteDataSpecification.java
@@ -18,8 +18,8 @@ package uk.ac.manchester.spinnaker.front_end.dse;
 
 import static java.lang.Integer.toUnsignedLong;
 import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.front_end.Constants.CORE_DATA_SDRAM_BASE_TAG;
 import static uk.ac.manchester.spinnaker.data_spec.Constants.APP_PTR_TABLE_BYTE_SIZE;
+import static uk.ac.manchester.spinnaker.front_end.Constants.CORE_DATA_SDRAM_BASE_TAG;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -44,6 +44,7 @@ import uk.ac.manchester.spinnaker.storage.DSEStorage.CoreToLoad;
 import uk.ac.manchester.spinnaker.storage.DSEStorage.Ethernet;
 import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
+import uk.ac.manchester.spinnaker.transceiver.TransceiverInterface;
 
 /**
  * Executes the host based data specification.
@@ -60,6 +61,8 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	/**
 	 * Create a high-level DSE interface.
 	 *
+	 * @param txrx
+	 *            The transceiver for talking to the SpiNNaker machine.
 	 * @param machine
 	 *            The description of the SpiNNaker machine.
 	 * @param db
@@ -79,10 +82,11 @@ public class HostExecuteDataSpecification extends ExecuteDataSpecification {
 	 *             this constructor should not be doing that!
 	 */
 	@MustBeClosed
-	public HostExecuteDataSpecification(Machine machine, DSEDatabaseEngine db)
+	public HostExecuteDataSpecification(TransceiverInterface txrx,
+			Machine machine, DSEDatabaseEngine db)
 			throws IOException, ProcessException, InterruptedException,
 			StorageException, URISyntaxException {
-		super(machine, db);
+		super(txrx, machine, db);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/dse/ThrottledConnection.java
@@ -19,12 +19,9 @@ package uk.ac.manchester.spinnaker.front_end.dse;
 import static java.lang.System.nanoTime;
 import static java.net.InetAddress.getByName;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.messages.Constants.SCP_SCAMP_PORT;
 import static uk.ac.manchester.spinnaker.utils.MathUtils.hexbyte;
 import static uk.ac.manchester.spinnaker.utils.UnitConstants.NSEC_PER_USEC;
 import static uk.ac.manchester.spinnaker.utils.WaitUtils.waitUntil;
@@ -34,14 +31,12 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 
 import com.google.errorprone.annotations.MustBeClosed;
 
-import uk.ac.manchester.spinnaker.alloc.client.SpallocClient;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.ChipLocation;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
@@ -49,7 +44,6 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPMessage;
 import uk.ac.manchester.spinnaker.storage.DSEStorage.Ethernet;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.TransceiverInterface;
-import uk.ac.manchester.spinnaker.utils.Daemon;
 
 /**
  * An SDP connection that uses a throttle to stop SCAMP from overloading. Note
@@ -66,11 +60,7 @@ class ThrottledConnection implements Closeable {
 	/** The {@link #receive()} timeout, in milliseconds. */
 	private static final int TIMEOUT_MS = 2000;
 
-	private static final ScheduledExecutorService CLOSER;
-
 	static {
-		CLOSER = newSingleThreadScheduledExecutor(
-				r -> new Daemon(r, "ThrottledConnection.Closer"));
 		log.info("inter-message minimum time set to {}us",
 				THROTTLE_NS / NSEC_PER_USEC);
 	}
@@ -93,8 +83,6 @@ class ThrottledConnection implements Closeable {
 	 *            The SpiNNaker board to talk to.
 	 * @param iptag
 	 *            The tag to reprogram to talk to this connection.
-	 * @param job
-	 *            A spalloc job to use to open the connection, or null if none.
 	 * @throws IOException
 	 *             If IO fails.
 	 * @throws ProcessException
@@ -105,15 +93,11 @@ class ThrottledConnection implements Closeable {
 	@MustBeClosed
 	@SuppressWarnings("MustBeClosed")
 	ThrottledConnection(TransceiverInterface transceiver, Ethernet board,
-			IPTag iptag, SpallocClient.Job job)
+			IPTag iptag)
 			throws IOException, ProcessException, InterruptedException {
 		location = board.location;
-		if (job == null) {
-			connection = new SCPConnection(location,
-					getByName(board.ethernetAddress), SCP_SCAMP_PORT);
-		} else {
-			connection = job.getConnection(location);
-		}
+		connection = transceiver.createScpConnection(location,
+				getByName(board.ethernetAddress));
 		log.info(
 				"created throttled connection to {} ({}) from {}:{}; "
 						+ "reprogramming tag #{} to point to this connection",
@@ -166,22 +150,9 @@ class ThrottledConnection implements Closeable {
 	}
 
 	@Override
-	@SuppressWarnings("FutureReturnValueIgnored")
 	public void close() {
 		if (closed.compareAndSet(false, true)) {
-			// Prevent reuse of existing socket IDs for other boards
-			CLOSER.schedule(() -> {
-				try {
-					var name = "";
-					if (log.isInfoEnabled()) {
-						name = connection.toString();
-					}
-					connection.close();
-					log.info("closed {}", name);
-				} catch (IOException e) {
-					log.warn("failed to close connection", e);
-				}
-			}, 1, SECONDS);
+			connection.closeEventually();
 		}
 	}
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
@@ -63,11 +63,7 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 
 	private static final int ENTRY_TEXT = 2;
 
-	private TransceiverInterface txrx;
-
-	private Machine machine;
-
-	private BasicExecutor executor;
+	private final BasicExecutor executor;
 
 	/**
 	 * Create a IOBUF retriever.
@@ -83,9 +79,7 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	@SuppressWarnings("MustBeClosed")
 	public IobufRetriever(TransceiverInterface transceiver, Machine machine,
 			int parallelSize) {
-		super(machine);
-		txrx = transceiver;
-		this.machine = machine;
+		super(transceiver, machine);
 		executor = new BasicExecutor(parallelSize);
 	}
 

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -132,7 +132,7 @@ class TestFrontEnd {
 		var called = new ValueHolder<>("none");
 		try {
 			CommandLineInterface.hostFactory =
-					(m, db) -> new HostExecuteDataSpecification(m, null) {
+					(t, m, db) -> new HostExecuteDataSpecification(t, m, null) {
 						@Override
 						public void loadSystemCores() {
 							called.setValue("dse_sys");
@@ -182,8 +182,8 @@ class TestFrontEnd {
 		var saved = CommandLineInterface.fastFactory;
 		var called = new ValueHolder<>("none");
 		try {
-			CommandLineInterface.fastFactory = (m, g, r,
-					db) -> new FastExecuteDataSpecification(m, g, r, null) {
+			CommandLineInterface.fastFactory = (t, m, g, r,
+					db) -> new FastExecuteDataSpecification(t, m, g, r, null) {
 						@Override
 						public void loadCores() {
 							called.setValue("mon");

--- a/SpiNNaker-front-end/src/test/resources/machine.json
+++ b/SpiNNaker-front-end/src/test/resources/machine.json
@@ -4,5 +4,13 @@
 	"root": [0, 0],
 	"ethernetResources": {},
 	"standardResources": {},
-	"chips": []
+	"chips": [
+		[
+			0, 0, {
+				"cores": 1,
+				"ethernet": [0, 0],
+				"ipAddress": "127.0.0.1"
+			}
+		]
+	]
 }

--- a/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/dse.sql
+++ b/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/dse.sql
@@ -56,3 +56,10 @@ CREATE VIEW IF NOT EXISTS core_view AS
 		x, y, processor, is_system, app_id, content,
 		start_address, memory_used, memory_written
 	FROM ethernet NATURAL JOIN core;
+
+-- Information about how to access the connection proxying
+-- WARNING! May include credentials
+CREATE TABLE IF NOT EXISTS proxy_configuration(
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    value TEXT NOT NULL);


### PR DESCRIPTION
This lets us reduce the amount of need for keeping knowledge of jobs within the front end; the transceiver has that info and makes proxies if it makes sense to do so. Getting that right involves pushing some more smarts into `SCPConnection` so that we don't need to have that level of smartness in the users of it (it has subclasses that override the smartness).

This fixes #671
