### PR TITLE
Correct use of GROUP BY

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -569,7 +569,8 @@ public abstract class SQLQueries {
 					+ "user_name AS reporter_name "
 					+ "FROM board_reports JOIN user_info ON reporter = user_id "
 					+ "JOIN boards USING (board_id) "
-					+ "WHERE machine_id = :machine_id GROUP BY board_id";
+					+ "WHERE machine_id = :machine_id "
+					+ "ORDER BY board_id, report_id";
 
 	/**
 	 * Get the problem reports about a board.

--- a/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle.sql
@@ -31,19 +31,31 @@ WITH RECURSIVE
 		LIMIT (SELECT height FROM m)),
 	-- Form the sequences into grids of points
 	c(x,y,z) AS (SELECT x, y, z FROM cx, cy, triad),
-	g(x,y) AS (SELECT x, y FROM gx, gy)
+	g(x,y) AS (SELECT x, y FROM gx, gy),
+	-- Root coords and number of boards available from that point
+	-- NB: Can't use board ID safely as we are using a GROUP BY
+	root(x,y,z,available) AS (
+		SELECT g.x AS x, g.y AS y, 0 AS z,
+			SUM(boards.may_be_allocated) AS available
+		FROM args
+			JOIN c
+			JOIN g
+			JOIN boards USING (machine_id)
+			JOIN m
+		WHERE
+			boards.x = (c.x + g.x) % m.width
+			AND boards.y = (c.y + g.y) % m.height
+			AND boards.z = c.z
+		GROUP BY g.x, g.y)
 SELECT
-	root.board_id AS id,
-	root.x AS x, root.y AS y, root.z AS z,
+	boards.board_id AS id,
+	boards.x AS x,
+	boards.y AS y,
+	boards.z AS z,
 	root.available AS available
-FROM args, boards, (
-	SELECT board_id, boards.x AS x, boards.y AS y, boards.z AS z,
-		SUM(boards.may_be_allocated) AS available
-	FROM args JOIN c JOIN g JOIN boards USING (machine_id) JOIN m
-	WHERE
-		boards.x = (c.x + g.x) % m.width AND boards.y = (c.y + g.y) % m.height
-		AND boards.z = c.z
-	GROUP BY g.x, g.y) AS root
-WHERE available >= args.width * args.height - args.max_dead_boards
-	AND boards.board_id = id AND boards.may_be_allocated > 0
+FROM args
+	JOIN boards USING (machine_id)
+	JOIN root USING (x, y, z)
+WHERE root.available >= args.width * args.height - args.max_dead_boards
+	AND boards.may_be_allocated > 0
 ORDER BY power_off_timestamp ASC;

--- a/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
@@ -18,43 +18,36 @@ WITH RECURSIVE
 	args(root_id, width, height, machine_id, max_dead_boards) AS (
 		VALUES (:board_id, :width, :height, :machine_id, :max_dead_boards)),
 	-- Profile the machines and boards to the one we care about
-	m AS (SELECT machines.* FROM machines JOIN args USING (machine_id) LIMIT 1),
-	bs AS (SELECT boards.* FROM boards JOIN args USING (machine_id)),
+	m AS (
+		SELECT machines.* FROM machines JOIN args USING (machine_id)
+		LIMIT 1),
+	bs AS (
+		SELECT boards.* FROM boards JOIN args USING (machine_id)),
+	selected_root AS (
+		SELECT bs.* FROM bs JOIN args ON bs.board_id = args.root_id
+		LIMIT 1),
 	-- Generate sequences of right size
 	cx(x) AS (SELECT 0 UNION ALL SELECT x+1 FROM cx
 		LIMIT (SELECT width FROM args)),
 	cy(y) AS (SELECT 0 UNION ALL SELECT y+1 FROM cy
 		LIMIT (SELECT height FROM args)),
-	triad(z) AS (VALUES (0), (1), (2)),
-	gx(x) AS (SELECT 0 UNION ALL SELECT x+1 FROM gx
-		LIMIT (SELECT width FROM m)),
-	gy(y) AS (SELECT 0 UNION ALL SELECT y+1 FROM gy
-		LIMIT (SELECT height FROM m)),
+	cz(z) AS (VALUES (0), (1), (2)),
 	-- Form the sequences into grids of points
-	c(x,y,z) AS (SELECT x, y, z FROM cx, cy, triad),
-	g(x,y) AS (SELECT x, y FROM gx, gy),
-	-- Root coords and number of boards available from that point
-	-- NB: Can't use board ID safely as we are using a GROUP BY
-	root(x,y,z,available) AS (
-		SELECT g.x AS x, g.y AS y, 0 AS z,
-			SUM(bs.may_be_allocated) AS available
-		FROM args
-			JOIN c
-			JOIN g
-			JOIN bs
-			JOIN m
-		WHERE
-			bs.x = (c.x + g.x) % m.width
-			AND bs.y = (c.y + g.y) % m.height
-			AND bs.z = c.z
-		GROUP BY g.x, g.y)
+	c(x,y,z) AS (SELECT x, y, z FROM cx, cy, cz),
+	-- Count boards in rectangle based at specified root
+	root_count(available) AS (
+		SELECT SUM(bs.may_be_allocated)
+		FROM selected_root, m, c, bs
+		WHERE bs.x = (c.x + selected_root.x) % m.width
+			AND bs.y = (c.y + selected_root.y) % m.height
+			AND bs.z = c.z)
 SELECT
-	bs.board_id AS id,
-	bs.x AS x, bs.y AS y, bs.z AS z,
-	root.available AS available
-FROM args
-	JOIN bs ON args.root_id = bs.board_id
-	JOIN root USING (x, y, z)
-WHERE available >= args.width * args.height - args.max_dead_boards
-	AND bs.may_be_allocated > 0
+	selected_root.board_id AS id,
+	selected_root.x AS x,
+	selected_root.y AS y,
+	selected_root.z AS z,
+	root_count.available AS available
+FROM args, selected_root, root_count
+WHERE root_count.available >= args.width * args.height - args.max_dead_boards
+	AND selected_root.may_be_allocated > 0
 LIMIT 1;

--- a/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
@@ -37,7 +37,7 @@ WITH RECURSIVE
 	-- NB: Can't use board ID safely as we are using a GROUP BY
 	root(x,y,z,available) AS (
 		SELECT g.x AS x, g.y AS y, 0 AS z,
-			SUM(boards.may_be_allocated) AS available
+			SUM(bs.may_be_allocated) AS available
 		FROM args
 			JOIN c
 			JOIN g

--- a/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/find_rectangle_at.sql
@@ -32,19 +32,29 @@ WITH RECURSIVE
 		LIMIT (SELECT height FROM m)),
 	-- Form the sequences into grids of points
 	c(x,y,z) AS (SELECT x, y, z FROM cx, cy, triad),
-	g(x,y) AS (SELECT x, y FROM gx, gy)
+	g(x,y) AS (SELECT x, y FROM gx, gy),
+	-- Root coords and number of boards available from that point
+	-- NB: Can't use board ID safely as we are using a GROUP BY
+	root(x,y,z,available) AS (
+		SELECT g.x AS x, g.y AS y, 0 AS z,
+			SUM(boards.may_be_allocated) AS available
+		FROM args
+			JOIN c
+			JOIN g
+			JOIN bs
+			JOIN m
+		WHERE
+			bs.x = (c.x + g.x) % m.width
+			AND bs.y = (c.y + g.y) % m.height
+			AND bs.z = c.z
+		GROUP BY g.x, g.y)
 SELECT
-	root.board_id AS id,
-	root.x AS x, root.y AS y, root.z AS z,
+	bs.board_id AS id,
+	bs.x AS x, bs.y AS y, bs.z AS z,
 	root.available AS available
-FROM args, bs, (
-	SELECT board_id, bs.x AS x, bs.y AS y, bs.z AS z,
-		SUM(bs.may_be_allocated) AS available
-	FROM bs, c, g, args, m
-	WHERE bs.x = (c.x + g.x) % m.width AND bs.y = (c.y + g.y) % m.height
-		AND bs.z = c.z
-	GROUP BY g.x, g.y) AS root
-WHERE args.root_id = id
-	AND available >= args.width * args.height - args.max_dead_boards
-	AND bs.board_id = id AND bs.may_be_allocated > 0
+FROM args
+	JOIN bs ON args.root_id = bs.board_id
+	JOIN root USING (x, y, z)
+WHERE available >= args.width * args.height - args.max_dead_boards
+	AND bs.may_be_allocated > 0
 LIMIT 1;

--- a/SpiNNaker-allocserv/src/main/resources/queries/get_reported_boards.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/get_reported_boards.sql
@@ -14,17 +14,22 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -- Get boards with more problem reports than a critical threshold
+WITH report_counts AS (
+	SELECT
+		board_reports.board_id,
+		COUNT(board_report.report_id) AS num_reports
+	FROM board_reports
+	JOIN boards USING (board_id)
+	WHERE boards.functioning IS NOT 0 -- Ignore disabled boards
+	GROUP BY board_id)
 SELECT
-    board_reports.board_id,
-    COUNT(*) AS num_reports,
+    boards.board_id,
+    report_counts.num_reports,
     boards.x,
     boards.y,
     boards.z,
     boards.address
 FROM
-	board_reports
+	report_counts
 	JOIN boards USING (board_id)
-	JOIN jobs USING (job_id)
-WHERE functioning IS NOT 0
-GROUP BY board_reports.board_id
-HAVING num_reports >= :threshold;
+WHERE report_counts.num_reports >= :threshold;

--- a/SpiNNaker-allocserv/src/main/resources/queries/get_reported_boards.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/get_reported_boards.sql
@@ -17,7 +17,7 @@
 WITH report_counts AS (
 	SELECT
 		board_reports.board_id,
-		COUNT(board_report.report_id) AS num_reports
+		COUNT(board_reports.report_id) AS num_reports
 	FROM board_reports
 	JOIN boards USING (board_id)
 	WHERE boards.functioning IS NOT 0 -- Ignore disabled boards


### PR DESCRIPTION
This makes the code use `GROUP BY` and aggregates correctly, not relying on the DB to select a special row from the group for us. We simply can't be sure that the DB will choose correctly. Fortunately, we have indices already set up that let us efficiently handle this by using the coordinates of the root of the group (which we were grouping by) and inflating that back to the ID of the board at that point.

The report handling just looked wrong.

This fixes #693
