### PR TITLE
Improve validation

### DIFF
--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/Limits.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/Limits.java
@@ -16,20 +16,33 @@
  */
 package uk.ac.manchester.spinnaker.machine.board;
 
-/** Various limits. */
+/**
+ * Various limits. These are constrained by the requirement that each of the
+ * dimensions of the coordinates for a chip fit in an unsigned byte.
+ */
 interface Limits {
 	/**
-	 * Max triad X coordinate. Any larger and the chips become unaddressible, as
-	 * some of the coordinates on the board will go above 256.
+	 * Max triad X coordinate. Any larger and the chips become unaddressible.
 	 */
 	int MAX_TRIAD_X = 20;
 
 	/**
-	 * Max triad Y coordinate. Any larger and the chips become unaddressible, as
-	 * some of the coordinates on the board will go above 256.
+	 * Max triad Y coordinate. Any larger and the chips become unaddressible.
 	 */
 	int MAX_TRIAD_Y = 20;
 
 	/** Max triad Z coordinate. */
 	int MAX_TRIAD_Z = 2;
+
+	/**
+	 * Maximum cabinet number. Any larger than this will result in the
+	 * underlying chips becoming unaddressible.
+	 */
+	int MAX_CABINET = 31;
+
+	/**
+	 * Maximum frame number. Any larger than this will result in the underlying
+	 * chips becoming unaddressible.
+	 */
+	int MAX_FRAME = 31;
 }

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidBoardNumber.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidBoardNumber.java
@@ -21,7 +21,6 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static java.util.Objects.isNull;
 import static uk.ac.manchester.spinnaker.machine.board.BMPBoard.MAX_BOARD_NUMBER;
 
 import java.lang.annotation.Documented;
@@ -29,9 +28,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.PositiveOrZero;
 
 /**
  * Validates that a board number is in a sane range.
@@ -41,7 +41,10 @@ import javax.validation.Payload;
 @Documented
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE_USE })
-@Constraint(validatedBy = BoardNumberValidator.class)
+@PositiveOrZero
+@Max(MAX_BOARD_NUMBER)
+@Constraint(validatedBy = {})
+@ReportAsSingleViolation
 public @interface ValidBoardNumber {
 	/**
 	 * Message on constraint violated.
@@ -64,16 +67,4 @@ public @interface ValidBoardNumber {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
-
-class BoardNumberValidator
-		implements ConstraintValidator<ValidBoardNumber, Integer> {
-	@Override
-	public void initialize(ValidBoardNumber annotation) {
-	}
-
-	@Override
-	public boolean isValid(Integer value, ConstraintValidatorContext context) {
-		return isNull(value) || ((value >= 0) && (value <= MAX_BOARD_NUMBER));
-	}
 }

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidCabinetNumber.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidCabinetNumber.java
@@ -21,16 +21,17 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static java.util.Objects.isNull;
+import static uk.ac.manchester.spinnaker.machine.board.Limits.MAX_CABINET;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.PositiveOrZero;
 
 /**
  * Validates that a cabinet number is in a sane range.
@@ -40,7 +41,10 @@ import javax.validation.Payload;
 @Documented
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE_USE })
-@Constraint(validatedBy = CabinetNumberValidator.class)
+@PositiveOrZero
+@Max(MAX_CABINET)
+@Constraint(validatedBy = {})
+@ReportAsSingleViolation
 public @interface ValidCabinetNumber {
 	/**
 	 * Message on constraint violated.
@@ -63,18 +67,4 @@ public @interface ValidCabinetNumber {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
-
-class CabinetNumberValidator
-		implements ConstraintValidator<ValidCabinetNumber, Integer> {
-	private static final int MAX_CABINET = 31;
-
-	@Override
-	public void initialize(ValidCabinetNumber annotation) {
-	}
-
-	@Override
-	public boolean isValid(Integer value, ConstraintValidatorContext context) {
-		return isNull(value) || ((value >= 0) && (value <= MAX_CABINET));
-	}
 }

--- a/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidFrameNumber.java
+++ b/SpiNNaker-machine/src/main/java/uk/ac/manchester/spinnaker/machine/board/ValidFrameNumber.java
@@ -21,16 +21,17 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static java.util.Objects.isNull;
+import static uk.ac.manchester.spinnaker.machine.board.Limits.MAX_FRAME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.PositiveOrZero;
 
 /**
  * Validates that a frame number is in a sane range.
@@ -40,7 +41,10 @@ import javax.validation.Payload;
 @Documented
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE_USE })
-@Constraint(validatedBy = FrameNumberValidator.class)
+@PositiveOrZero
+@Max(MAX_FRAME)
+@Constraint(validatedBy = {})
+@ReportAsSingleViolation
 public @interface ValidFrameNumber {
 	/**
 	 * Message on constraint violated.
@@ -63,18 +67,4 @@ public @interface ValidFrameNumber {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
-
-class FrameNumberValidator
-		implements ConstraintValidator<ValidFrameNumber, Integer> {
-	private static final int MAX_FRAME = 31;
-
-	@Override
-	public void initialize(ValidFrameNumber annotation) {
-	}
-
-	@Override
-	public boolean isValid(Integer value, ConstraintValidatorContext context) {
-		return isNull(value) || ((value >= 0) && (value <= MAX_FRAME));
-	}
 }

--- a/SpiNNaker-py2json/pom.xml
+++ b/SpiNNaker-py2json/pom.xml
@@ -66,6 +66,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<artifactId>error_prone_annotations</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.2.5.Final</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
 			<scope>test</scope>

--- a/SpiNNaker-py2json/src/test/java/uk/ac/manchester/spinnaker/py2json/TestConvert.java
+++ b/SpiNNaker-py2json/src/test/java/uk/ac/manchester/spinnaker/py2json/TestConvert.java
@@ -122,6 +122,7 @@ class TestConvert {
 		var f = getFile(CSV_DEFINED);
 		try (var mdl = new MachineDefinitionConverter()) {
 			var c = mdl.loadClassicConfigurationDefinition(f, true);
+			mdl.validate(c);
 			assertEquals(1, c.machines.size());
 			var machine = c.machines.get(0);
 			assertNotNull(machine);

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/IPAddress.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/IPAddress.java
@@ -46,7 +46,7 @@ import javax.validation.Payload;
 @Target({
 	METHOD, FIELD, PARAMETER, TYPE_USE
 })
-@Constraint(validatedBy = IPAddressValidator.class)
+@Constraint(validatedBy = IPAddress.Validator.class)
 public @interface IPAddress {
 	/**
 	 * Whether {@code null} is allowed. It defaults to being disallowed.
@@ -82,41 +82,44 @@ public @interface IPAddress {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
 
-/** Validator for {@link IPAddress} constraints. */
-class IPAddressValidator implements ConstraintValidator<IPAddress, String> {
-	private Pattern pattern;
+	/**
+	 * Validator for {@link IPAddress} constraints. Not intended for direct use.
+	 */
+	class Validator implements ConstraintValidator<IPAddress, String> {
+		private Pattern pattern;
 
-	private boolean emptyOK;
+		private boolean emptyOK;
 
-	private boolean nullOK;
+		private boolean nullOK;
 
-	@Override
-	public void initialize(IPAddress annotation) {
-		if (isNull(pattern)) {
-			pattern = Pattern.compile("^\\d+[.]\\d+[.]\\d+[.]\\d+$");
+		@Override
+		public void initialize(IPAddress annotation) {
+			if (isNull(pattern)) {
+				pattern = Pattern.compile("^\\d+[.]\\d+[.]\\d+[.]\\d+$");
+			}
+			emptyOK = annotation.emptyOK();
+			nullOK = annotation.nullOK();
 		}
-		emptyOK = annotation.emptyOK();
-		nullOK = annotation.nullOK();
-	}
 
-	@Override
-	public boolean isValid(String value, ConstraintValidatorContext context) {
-		if (isNull(value)) {
-			return nullOK;
-		} else if (value.isEmpty()) {
-			return emptyOK;
-		}
-		if (!pattern.matcher(value).matches()) {
-			return false;
-		}
-		// Cheap checks succeeded; use the real parser now!
-		try {
-			InetAddress.getByName(value);
-			return true;
-		} catch (UnknownHostException e) {
-			return false;
+		@Override
+		public boolean isValid(String value,
+				ConstraintValidatorContext context) {
+			if (isNull(value)) {
+				return nullOK;
+			} else if (value.isEmpty()) {
+				return emptyOK;
+			}
+			if (!pattern.matcher(value).matches()) {
+				return false;
+			}
+			// Cheap checks succeeded; use the real parser now!
+			try {
+				InetAddress.getByName(value);
+				return true;
+			} catch (UnknownHostException e) {
+				return false;
+			}
 		}
 	}
 }

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/TCPPort.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/TCPPort.java
@@ -41,7 +41,7 @@ import javax.validation.Payload;
 @Documented
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE_USE })
-@Constraint(validatedBy = TCPPortValidator.class)
+@Constraint(validatedBy = TCPPort.Validator.class)
 public @interface TCPPort {
 	/** The minimum ordinary TCP port number. */
 	int MIN_TCP_PORT = 1024;
@@ -92,32 +92,36 @@ public @interface TCPPort {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
 
-class TCPPortValidator implements ConstraintValidator<TCPPort, Integer> {
-	private static final int MAX_STD_PORT = 32767;
+	/**
+	 * Validator for {@link TCPPort} constraints. Not intended for direct use.
+	 */
+	class Validator implements ConstraintValidator<TCPPort, Integer> {
+		private static final int MAX_STD_PORT = 32767;
 
-	private boolean acceptZero;
+		private boolean acceptZero;
 
-	private int min;
+		private int min;
 
-	private int max;
+		private int max;
 
-	@Override
-	public void initialize(TCPPort annotation) {
-		acceptZero = annotation.any();
-		min = annotation.system() ? 1 : TCPPort.MIN_TCP_PORT;
-		max = annotation.ephemeral() ? TCPPort.MAX_TCP_PORT : MAX_STD_PORT;
-	}
-
-	@Override
-	public boolean isValid(Integer value, ConstraintValidatorContext context) {
-		if (isNull(value)) {
-			return true;
+		@Override
+		public void initialize(TCPPort annotation) {
+			acceptZero = annotation.any();
+			min = annotation.system() ? 1 : TCPPort.MIN_TCP_PORT;
+			max = annotation.ephemeral() ? TCPPort.MAX_TCP_PORT : MAX_STD_PORT;
 		}
-		if (value == 0) {
-			return acceptZero;
+
+		@Override
+		public boolean isValid(Integer value,
+				ConstraintValidatorContext context) {
+			if (isNull(value)) {
+				return true;
+			}
+			if (value == 0) {
+				return acceptZero;
+			}
+			return (value >= min) && (value <= max);
 		}
-		return (value >= min) && (value <= max);
 	}
 }

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/UDPPort.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/validation/UDPPort.java
@@ -40,7 +40,7 @@ import javax.validation.Payload;
 @Documented
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE_USE })
-@Constraint(validatedBy = UDPPortValidator.class)
+@Constraint(validatedBy = UDPPort.Validator.class)
 public @interface UDPPort {
 	/** The minimum ordinary UDP port number. */
 	int MIN_UDP_PORT = 1024;
@@ -91,32 +91,36 @@ public @interface UDPPort {
 	 * @return Payloads, if any.
 	 */
 	Class<? extends Payload>[] payload() default {};
-}
 
-class UDPPortValidator implements ConstraintValidator<UDPPort, Integer> {
-	private static final int MAX_STD_PORT = 32767;
+	/**
+	 * Validator for {@link UDPPort} constraints. Not intended for direct use.
+	 */
+	class Validator implements ConstraintValidator<UDPPort, Integer> {
+		private static final int MAX_STD_PORT = 32767;
 
-	private boolean acceptZero;
+		private boolean acceptZero;
 
-	private int min;
+		private int min;
 
-	private int max;
+		private int max;
 
-	@Override
-	public void initialize(UDPPort annotation) {
-		acceptZero = annotation.any();
-		min = annotation.system() ? 1 : UDPPort.MIN_UDP_PORT;
-		max = annotation.ephemeral() ? UDPPort.MAX_UDP_PORT : MAX_STD_PORT;
-	}
-
-	@Override
-	public boolean isValid(Integer value, ConstraintValidatorContext context) {
-		if (isNull(value)) {
-			return true;
+		@Override
+		public void initialize(UDPPort annotation) {
+			acceptZero = annotation.any();
+			min = annotation.system() ? 1 : UDPPort.MIN_UDP_PORT;
+			max = annotation.ephemeral() ? UDPPort.MAX_UDP_PORT : MAX_STD_PORT;
 		}
-		if (value == 0) {
-			return acceptZero;
+
+		@Override
+		public boolean isValid(Integer value,
+				ConstraintValidatorContext context) {
+			if (isNull(value)) {
+				return true;
+			}
+			if (value == 0) {
+				return acceptZero;
+			}
+			return (value >= min) && (value <= max);
 		}
-		return (value >= min) && (value <= max);
 	}
 }


### PR DESCRIPTION
This does validation in py2json (instead of leaving its need noted as a `TODO` 🙄) so we should capture faults in configs earlier. It also fixes and simplifies some validators; Spring must be using custom validator loading code that worked before, but non-hosted validation is another use case.