### PR TITLE
Machine and Job Equality

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -1459,6 +1459,17 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			rememberer.removeProxyForJob(id, proxy);
 		}
 
+		@Override
+		public boolean equals(Object other) {
+			// Equality is defined exactly by the database ID
+			return (other instanceof JobImpl) && (id == ((JobImpl) other).id);
+		}
+
+		@Override
+		public int hashCode() {
+			return id;
+		}
+
 		private final class SubMachineImpl implements SubMachine {
 			/** The machine that this sub-machine is part of. */
 			private final Machine machine;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -919,6 +919,18 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		}
 
 		@Override
+		public boolean equals(Object other) {
+			// Equality is defined exactly by the database ID
+			return (other instanceof MachineImpl)
+					&& (id == ((MachineImpl) other).id);
+		}
+
+		@Override
+		public int hashCode() {
+			return id;
+		}
+
+		@Override
 		public String toString() {
 			return "Machine(" + name + ")";
 		}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
@@ -20,8 +20,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
-import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.BoardLocation;
+import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.Job;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.SubMachine;
 import uk.ac.manchester.spinnaker.alloc.model.JobState;
 import uk.ac.manchester.spinnaker.alloc.proxy.ProxyCore;
@@ -34,7 +34,7 @@ import uk.ac.manchester.spinnaker.machine.ChipLocation;
  *
  * @author Donal Fellows
  */
-public abstract class StubJob implements SpallocAPI.Job {
+public abstract class StubJob implements Job {
 	@Override
 	public void waitForChange(Duration timeout) {
 		throw new UnsupportedOperationException();
@@ -138,5 +138,19 @@ public abstract class StubJob implements SpallocAPI.Job {
 	@Override
 	public void forgetProxy(ProxyCore proxy) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final boolean equals(Object other) {
+		if (other instanceof Job) {
+			Job j = (Job) other;
+			return getId() == j.getId();
+		}
+		return false;
+	}
+
+	@Override
+	public final int hashCode() {
+		return getId();
 	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.BoardLocation;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.Machine;
 import uk.ac.manchester.spinnaker.alloc.model.BoardCoords;
@@ -37,7 +36,7 @@ import uk.ac.manchester.spinnaker.machine.board.TriadCoords;
  *
  * @author Donal Fellows
  */
-public abstract class StubMachine implements SpallocAPI.Machine {
+public abstract class StubMachine implements Machine {
 	@Override
 	public void waitForChange(Duration timeout) {
 		throw new UnsupportedOperationException();
@@ -131,8 +130,8 @@ public abstract class StubMachine implements SpallocAPI.Machine {
 
 	@Override
 	public final boolean equals(Object other) {
-		if (other instanceof SpallocAPI.Machine) {
-			SpallocAPI.Machine m = (Machine) other;
+		if (other instanceof Machine) {
+			Machine m = (Machine) other;
 			return getId() == m.getId();
 		}
 		return false;

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.BoardLocation;
+import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.Machine;
 import uk.ac.manchester.spinnaker.alloc.model.BoardCoords;
 import uk.ac.manchester.spinnaker.alloc.model.DownLink;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
@@ -126,5 +127,19 @@ public abstract class StubMachine implements SpallocAPI.Machine {
 	@Override
 	public List<Integer> getBoardNumbers(BMPCoords bmp) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final boolean equals(Object other) {
+		if (other instanceof SpallocAPI.Machine) {
+			SpallocAPI.Machine m = (Machine) other;
+			return getId() == m.getId();
+		}
+		return false;
+	}
+
+	@Override
+	public final int hashCode() {
+		return getId();
 	}
 }


### PR DESCRIPTION
Make it so that machines and jobs have a proper notion of when they're equal (that corresponds exactly to when they have the same database ID).