### PR TITLE
Tweak the CodeQL build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,7 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        version: [ 11 ]
 
     steps:
     - name: Checkout repository
@@ -61,6 +62,13 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Set up right Java version: https://github.com/github/codeql-action/issues/825
+    - uses: actions/setup-java@v3.6.0
+      with:
+        java-version: ${{ matrix.version }}
+        distribution: zulu
+        cache: maven
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
We want to enable caching of dependencies because selected dependencies (especially the node binary, but others too) are pulled from locations that aren't 100% stable...