### PR TITLE
More type constraints on SCP messages

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/Addresses.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/Addresses.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.bmp;
+
+import java.net.InetAddress;
+
+/** The IP addresses associated with a SpiNNaker board. */
+public final class Addresses {
+	// TODO convert to record in 17
+	/** The IPv4 address of the BMP. */
+	public final InetAddress bmpIPAddress;
+
+	/** The IPv4 address of the managed SpiNNaker board. */
+	public final InetAddress spinIPAddress;
+
+	Addresses(InetAddress bmpIPAddress, InetAddress spinIPAddress) {
+		this.bmpIPAddress = bmpIPAddress;
+		this.spinIPAddress = spinIPAddress;
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
@@ -18,8 +18,8 @@ package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
+import static uk.ac.manchester.spinnaker.messages.model.TransferUnit.efficientTransferUnit;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_READ;
-import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTransferUnit;
 
 import java.nio.ByteBuffer;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPReadMemory.java
@@ -65,7 +65,7 @@ public class BMPReadMemory extends BMPRequest<BMPReadMemory.Response> {
 	 * that it is up to the caller to manage the buffer position of the returned
 	 * response if it is to be read from multiple times.
 	 */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<ByteBuffer> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Read", CMD_READ, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPRequest.java
@@ -23,6 +23,8 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.function.Supplier;
 
+import com.google.errorprone.annotations.ForOverride;
+
 import uk.ac.manchester.spinnaker.machine.board.BMPBoard;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
@@ -237,6 +239,7 @@ public abstract class BMPRequest<T extends BMPRequest.BMPResponse>
 		 *            header.
 		 * @return The parsed value.
 		 */
+		@ForOverride
 		protected abstract T parse(ByteBuffer buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPWriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/BMPWriteMemory.java
@@ -16,8 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.bmp;
 
+import static uk.ac.manchester.spinnaker.messages.model.TransferUnit.efficientTransferUnit;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_WRITE;
-import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTransferUnit;
 
 import java.nio.ByteBuffer;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/EraseFlash.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/EraseFlash.java
@@ -71,7 +71,7 @@ public final class EraseFlash extends BMPRequest<EraseFlash.Response> {
 	}
 
 	/** The response from a request to erase flash. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<MemoryLocation> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetBMPVersion.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetBMPVersion.java
@@ -45,7 +45,7 @@ public class GetBMPVersion extends BMPRequest<GetBMPVersion.Response> {
 	}
 
 	/** An SCP response to a request for the version of software running. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<VersionInfo> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetFPGAResetStatus.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetFPGAResetStatus.java
@@ -18,8 +18,8 @@ package uk.ac.manchester.spinnaker.messages.bmp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
+import static uk.ac.manchester.spinnaker.messages.model.TransferUnit.WORD;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_READ;
-import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.WORD;
 
 import java.nio.ByteBuffer;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetFPGAResetStatus.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/GetFPGAResetStatus.java
@@ -50,7 +50,7 @@ public class GetFPGAResetStatus
 	private static final int XIL_RST_BIT = 14;
 
 	/** The response to a request to get the FPGA reset status of a board. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<Boolean> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadADC.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadADC.java
@@ -49,7 +49,7 @@ public class ReadADC extends BMPRequest<ReadADC.Response> {
 	}
 
 	/** An SCP response to a request for ADC information. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<ADCInfo> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadCANStatus.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadCANStatus.java
@@ -52,7 +52,7 @@ public class ReadCANStatus extends BMPRequest<ReadCANStatus.Response> {
 	}
 
 	/** An SCP response to a request for the CAN status. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<MappableIterable<BMPBoard>> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadFPGARegister.java
@@ -63,7 +63,7 @@ public class ReadFPGARegister extends BMPRequest<ReadFPGARegister.Response> {
 	}
 
 	/** An SCP response to a request for the contents of an FPGA register. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<Integer> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadIPAddress.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadIPAddress.java
@@ -85,7 +85,7 @@ public class ReadIPAddress extends BMPRequest<ReadIPAddress.Response> {
 	}
 
 	/** An SCP response to a request for IP address information. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<Addresses> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadIPAddress.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadIPAddress.java
@@ -25,6 +25,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.board.BMPBoard;
+import uk.ac.manchester.spinnaker.messages.model.Addresses;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlash.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlash.java
@@ -65,7 +65,7 @@ public class ReadSerialFlash extends BMPRequest<ReadSerialFlash.Response> {
 	 * that it is up to the caller to manage the buffer position of the returned
 	 * response if it is to be read from multiple times.
 	 */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<ByteBuffer> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Read Serial Flash", CMD_BMP_SF, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlashCRC.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialFlashCRC.java
@@ -54,7 +54,7 @@ public class ReadSerialFlashCRC
 	/**
 	 * An SCP response to a request to get the CRC of serial flash.
 	 */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<Integer> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Read Serial Flash CRC", CMD_BMP_SF, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialVector.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/bmp/ReadSerialVector.java
@@ -45,7 +45,7 @@ public class ReadSerialVector extends BMPRequest<ReadSerialVector.Response> {
 	}
 
 	/** An SCP response to a request for serial data. */
-	public static final class Response
+	protected final class Response
 			extends BMPRequest.PayloadedResponse<SerialVector> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Addresses.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/Addresses.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.bmp;
+package uk.ac.manchester.spinnaker.messages.model;
 
 import java.net.InetAddress;
 
@@ -27,7 +27,13 @@ public final class Addresses {
 	/** The IPv4 address of the managed SpiNNaker board. */
 	public final InetAddress spinIPAddress;
 
-	Addresses(InetAddress bmpIPAddress, InetAddress spinIPAddress) {
+	/**
+	 * @param bmpIPAddress
+	 *            The IPv4 address of the BMP.
+	 * @param spinIPAddress
+	 *            The IPv4 address of the managed SpiNNaker board.
+	 */
+	public Addresses(InetAddress bmpIPAddress, InetAddress spinIPAddress) {
 		this.bmpIPAddress = bmpIPAddress;
 		this.spinIPAddress = spinIPAddress;
 	}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagFieldDefinitions.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/IPTagFieldDefinitions.java
@@ -14,49 +14,46 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.scp;
+package uk.ac.manchester.spinnaker.messages.model;
 
 /** Constants for working with tags. */
-abstract class IPTagFieldDefinitions {
-	private IPTagFieldDefinitions() {
-	}
-
+public interface IPTagFieldDefinitions {
 	/** The index of the use sender bit in argument 1. */
-	static final int USE_SENDER_BIT = 30;
+	int USE_SENDER_BIT = 30;
 
 	/** The index of the reverse flag bit in argument 1. */
-	static final int REVERSE_FIELD_BIT = 29;
+	int REVERSE_FIELD_BIT = 29;
 
 	/** The index of the strip SDP flag bit in argument 1. */
-	static final int STRIP_FIELD_BIT = 28;
+	int STRIP_FIELD_BIT = 28;
 
 	/** The index of the reverse flag bit in argument 1. */
-	static final int COMMAND_FIELD = 16;
+	int COMMAND_FIELD = 16;
 
 	/** The index of the command field in argument 1. */
-	static final int SDP_PORT_FIELD = 13;
+	int SDP_PORT_FIELD = 13;
 
 	/** The index of the SDP port field in argument 1. */
-	static final int DEST_P_FIELD = 8;
+	int DEST_P_FIELD = 8;
 
 	/** Bottom three bits. */
-	static final int THREE_BITS_MASK = 0b00000111;
+	int THREE_BITS_MASK = 0b00000111;
 
 	/** Bottom five bits. */
-	static final int CORE_MASK = 0b00011111;
+	int CORE_MASK = 0b00011111;
 
 	/** The index of the X field in argument 2. */
-	static final int DEST_X_FIELD = 24;
+	int DEST_X_FIELD = 24;
 
 	/** The index of the Y field in argument 2. */
-	static final int DEST_Y_FIELD = 16;
+	int DEST_Y_FIELD = 16;
 
 	/** The mask of the port field in argument 2. */
-	static final int PORT_MASK = 0xFFFF;
+	int PORT_MASK = 0xFFFF;
 
 	/** Shift by one byte. */
-	static final int BYTE_SHIFT = 8;
+	int BYTE_SHIFT = 8;
 
 	/** Bits in an SDP port. */
-	static final int PORT_SHIFT = 5;
+	int PORT_SHIFT = 5;
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TagDescription.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TagDescription.java
@@ -14,12 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.scp;
+package uk.ac.manchester.spinnaker.messages.model;
 
 import static java.net.InetAddress.getByAddress;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.CORE_MASK;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.PORT_SHIFT;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.CORE_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.PORT_SHIFT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -32,7 +32,6 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.tags.IPTag;
 import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
 import uk.ac.manchester.spinnaker.machine.tags.Tag;
-import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
 
 /** Description of a tag. */
 public final class TagDescription {
@@ -81,8 +80,21 @@ public final class TagDescription {
 	/** What tag was this info about? */
 	private final int tag;
 
-	TagDescription(ByteBuffer buffer, HasChipLocation src, InetAddress host,
-			int tag) throws UnknownHostException {
+	/**
+	 * @param buffer
+	 *            The buffer to parse.
+	 * @param src
+	 *            What chip did this come from?
+	 * @param host
+	 *            What address did that chip have? (Only for creating a
+	 *            {@link Tag}.)
+	 * @param tag
+	 *            What was the tag ID? (Only for creating a {@link Tag}.)
+	 * @throws UnknownHostException
+	 *             If we can't parse the host. Unexpected.
+	 */
+	public TagDescription(ByteBuffer buffer, HasChipLocation src,
+			InetAddress host, int tag) throws UnknownHostException {
 		byte[] ipBytes = new byte[IPV4_BYTES];
 		buffer.get(ipBytes);
 		ipAddress = getByAddress(ipBytes);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TagInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TagInfo.java
@@ -14,15 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.scp;
+package uk.ac.manchester.spinnaker.messages.model;
 
-import static java.lang.Byte.toUnsignedInt;
-
-import java.nio.ByteBuffer;
-
-import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
+import com.google.errorprone.annotations.Immutable;
 
 /** Information about a tag pool on an Ethernet-connected chip. */
+@Immutable
 public final class TagInfo {
 	/**
 	 * The timeout for transient IP tags (i.e., responses to SCP commands).
@@ -35,10 +32,19 @@ public final class TagInfo {
 	/** The count of the number of fixed IP tag entries. */
 	public final int fixedSize;
 
-	TagInfo(ByteBuffer buffer) {
-		transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
-		buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
-		poolSize = toUnsignedInt(buffer.get());
-		fixedSize = toUnsignedInt(buffer.get());
+	/**
+	 * @param transientTimeout
+	 *            The timeout for transient IP tags (i.e., responses to SCP
+	 *            commands).
+	 * @param poolSize
+	 *            The count of the IP tag pool size.
+	 * @param fixedSize
+	 *            The count of the number of fixed IP tag entries.
+	 */
+	public TagInfo(IPTagTimeOutWaitTime transientTimeout, int poolSize,
+			int fixedSize) {
+		this.transientTimeout = transientTimeout;
+		this.poolSize = poolSize;
+		this.fixedSize = fixedSize;
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TransferUnit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/TransferUnit.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.ac.manchester.spinnaker.messages.scp;
+package uk.ac.manchester.spinnaker.messages.model;
 
 import static uk.ac.manchester.spinnaker.messages.Constants.WORD_SIZE;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/AllocFree.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/AllocFree.java
@@ -13,29 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.ac.manchester.spinnaker.messages.model;
+package uk.ac.manchester.spinnaker.messages.scp;
 
 /**
- * The basic router commands, handled by {@code cmd_rtr()} in
+ * The SCP Allocation and Free codes. For {@code cmd_alloc()} in
  * {@code scamp-cmd.c}.
  */
-public enum RouterCommand {
-	/** Initialise. */
-	ROUTER_INIT,
-	/** Clear (entry=arg2, count). */
-	ROUTER_CLEAR,
-	/** Load (addr=arg2, count, offset=arg3, app_id). */
-	ROUTER_LOAD,
-	/**
-	 * Set/get Fixed Route register (arg2 = route). if bit 31 of arg1 set then
-	 * return FR reg else set it
-	 */
-	ROUTER_FIXED;
+enum AllocFree {
+	/** Allocate SDRAM. */
+	ALLOC_SDRAM(0),
+	/** Free SDRAM using a Pointer. */
+	FREE_SDRAM_BY_POINTER(1),
+	/** Free SDRAM using an APP ID. */
+	FREE_SDRAM_BY_APP_ID(2),
+	/** Allocate Routing Entries. */
+	ALLOC_ROUTING(3),
+	/** Free Routing Entries by Pointer. */
+	FREE_ROUTING_BY_POINTER(4),
+	/** Free Routing Entries by APP ID. */
+	FREE_ROUTING_BY_APP_ID(5);
 
-	/** The BMP-encoded value. */
+	/** The SARK operation value. */
 	public final byte value;
 
-	RouterCommand() {
-		value = (byte) ordinal();
+	AllocFree(int value) {
+		this.value = (byte) value;
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationRun.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationRun.java
@@ -30,6 +30,7 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.ValidP;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.SystemVariableDefinition;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
 
 /**
@@ -41,7 +42,7 @@ import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
  * Calls {@code proc_start_app()} in {@code scamp-app.c}.
  */
 @UsedInJavadocOnly(SystemVariableDefinition.class)
-public class ApplicationRun extends SCPRequest<CheckOKResponse> {
+public class ApplicationRun extends SCPRequest<EmptyResponse> {
 	private static final int WAIT_BIT = 18;
 
 	/**
@@ -98,7 +99,8 @@ public class ApplicationRun extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Run Application", CMD_AR, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Run Application", CMD_AR, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationStop.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ApplicationStop.java
@@ -28,6 +28,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_NNP;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.messages.model.AppID;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to stop an application. There is no response payload.
@@ -36,7 +37,7 @@ import uk.ac.manchester.spinnaker.messages.model.AppID;
  * turn triggers a call to {@code proc_stop_app()} in {@code scamp-app.c} across
  * all SCAMP instances.
  */
-public final class ApplicationStop extends SCPRequest<CheckOKResponse> {
+public final class ApplicationStop extends SCPRequest<EmptyResponse> {
 	private static final int SHIFT = 28;
 
 	private static final int NN_CMD_SIG0 = 0;
@@ -77,7 +78,8 @@ public final class ApplicationStop extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Send Stop", CMD_NNP, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Send Stop", CMD_NNP, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CheckOKResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CheckOKResponse.java
@@ -24,7 +24,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * An SCP response to a request which returns nothing other than OK or an error.
  * Subclasses add {@linkplain PayloadedResponse payload parsing}.
  */
-public class CheckOKResponse extends SCPResponse {
+public abstract class CheckOKResponse extends SCPResponse {
 	/**
 	 * Create an instance.
 	 *
@@ -37,7 +37,7 @@ public class CheckOKResponse extends SCPResponse {
 	 * @throws UnexpectedResponseCodeException
 	 *             If the response wasn't OK.
 	 */
-	public CheckOKResponse(String operation, Enum<?> command,
+	CheckOKResponse(String operation, Enum<?> command,
 			ByteBuffer buffer) throws UnexpectedResponseCodeException {
 		super(buffer);
 		throwIfNotOK(operation, command);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ClearIOBUF.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ClearIOBUF.java
@@ -29,7 +29,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * This calls {@code sark_io_buf_reset()} in {@code sark_io.c} (via
  * {@code simulation_control_scp_callback()} in {@code simulation.c}).
  */
-public class ClearIOBUF extends FECRequest<CheckOKResponse> {
+public class ClearIOBUF extends FECRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The core to clear the IOBUF of.
@@ -39,8 +39,8 @@ public class ClearIOBUF extends FECRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer)
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new CheckOKResponse("clear IOBUF", CLEAR_IOBUF, buffer);
+		return new EmptyResponse("clear IOBUF", CLEAR_IOBUF, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ClearReinjectionQueue.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ClearReinjectionQueue.java
@@ -21,6 +21,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.ReinjectorCommand.CLEAR;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to set the dropped packet reinjected packet types. There is no
@@ -28,7 +29,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
  * <p>
  * Handled by {@code reinjection_clear()} in {@code extra_monitor_support.c}.
  */
-public class ClearReinjectionQueue extends ReinjectorRequest<CheckOKResponse> {
+public class ClearReinjectionQueue extends ReinjectorRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The coordinates of the monitor core.
@@ -38,7 +39,8 @@ public class ClearReinjectionQueue extends ReinjectorRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Clear reinjection queue", CLEAR, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Clear reinjection queue", CLEAR, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ConnectionAwareMessage.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ConnectionAwareMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.scp;
+
+import uk.ac.manchester.spinnaker.connections.SCPConnection;
+import uk.ac.manchester.spinnaker.messages.SerializableMessage;
+
+/**
+ * An interface that is applied to a message when it wants to be told what
+ * connection it is being sent down prior to it being sent. This is intended to
+ * allow information about the connection to be used in producing the parsed
+ * response object.
+ *
+ * @author Donal Fellows
+ */
+public interface ConnectionAwareMessage extends SerializableMessage {
+	/**
+	 * Tell the object what connection it is being sent on. This will usually
+	 * (except during testing) be called prior to issuing the sequence number,
+	 * but the information provided should not be used until the response is
+	 * being parsed.
+	 *
+	 * @param connection
+	 *            The connection. Should <em>not</em> be modified by this
+	 *            method.
+	 */
+	void setConnection(SCPConnection connection);
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
@@ -75,7 +75,8 @@ public class CountState extends SCPRequest<CountState.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/CountState.java
@@ -83,7 +83,7 @@ public class CountState extends SCPRequest<CountState.Response> {
 	/**
 	 * An SCP response to a request for the number of cores in a given state.
 	 */
-	public static final class Response
+	protected static final class Response
 			extends PayloadedResponse<Integer, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("CountState", CMD_SIG, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/EmptyResponse.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/EmptyResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018-2019 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.scp;
+
+import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
+
+/**
+ * An SCP response to a request which has an empty payload.
+ */
+public class EmptyResponse extends CheckOKResponse {
+	/**
+	 * Create an instance.
+	 *
+	 * @param operation
+	 *            The overall operation that we are doing.
+	 * @param command
+	 *            The command that we are handling a response to.
+	 * @param buffer
+	 *            The buffer holding the response data.
+	 * @throws UnexpectedResponseCodeException
+	 *             If the response wasn't OK.
+	 */
+	EmptyResponse(String operation, Enum<?> command, ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		super(operation, command, buffer);
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FillRequest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to fill a region of memory on a chip with repeated words of
@@ -30,7 +31,7 @@ import uk.ac.manchester.spinnaker.machine.MemoryLocation;
  * Calls {@code sark_cmd_fill()} in {@code sark_base.c}, or {@code cmd_fill()}
  * in {@code bmp_cmd.c} if sent to a BMP.
  */
-public final class FillRequest extends SCPRequest<CheckOKResponse> {
+public final class FillRequest extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param chip
 	 *            The chip to read from
@@ -49,7 +50,8 @@ public final class FillRequest extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Fill", CMD_FILL, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Fill", CMD_FILL, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
@@ -15,9 +15,9 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.RouterCommand.ROUTER_FIXED;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
+import static uk.ac.manchester.spinnaker.messages.scp.RouterCommand.FIXED;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 
 import java.nio.ByteBuffer;
@@ -35,7 +35,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  */
 public final class FixedRouteInitialise extends SCPRequest<EmptyResponse> {
 	private static int argument1(AppID appID) {
-		return (appID.appID << BYTE1) | (ROUTER_FIXED.value << BYTE0);
+		return (appID.appID << BYTE1) | (FIXED.value << BYTE0);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteInitialise.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.RoutingEntry;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * Sets a fixed route entry. There is no response payload.
@@ -33,7 +34,7 @@ import uk.ac.manchester.spinnaker.messages.model.AppID;
  * Calls {@code rtr_fr_set()} in {@code sark_hw.c}, via {@code rtr_cmd()} in
  * {@code scamp-cmd.c}.
  */
-public final class FixedRouteInitialise extends SCPRequest<CheckOKResponse> {
+public final class FixedRouteInitialise extends SCPRequest<EmptyResponse> {
 	private static int argument1(AppID appID) {
 		return (appID.appID << BYTE1) | (ROUTER_FIXED.value << BYTE0);
 	}
@@ -48,6 +49,7 @@ public final class FixedRouteInitialise extends SCPRequest<CheckOKResponse> {
 	 */
 	public FixedRouteInitialise(HasChipLocation chip, int entry, AppID appID) {
 		super(chip.getScampCore(), CMD_RTR, argument1(appID), entry);
+		// The entry must not have the top bit set; normally true
 	}
 
 	/**
@@ -64,7 +66,8 @@ public final class FixedRouteInitialise extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Fixed Route Initialise", CMD_RTR, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Fixed Route Initialise", CMD_RTR, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
@@ -41,6 +41,7 @@ public final class FixedRouteRead extends SCPRequest<FixedRouteRead.Response> {
 		return (appID.appID << BYTE1) | (ROUTER_FIXED.value << BYTE0);
 	}
 
+	// Top bit set = do a read
 	private static int argument2() {
 		return 1 << TOP_BIT;
 	}
@@ -56,7 +57,8 @@ public final class FixedRouteRead extends SCPRequest<FixedRouteRead.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
@@ -63,7 +63,7 @@ public final class FixedRouteRead extends SCPRequest<FixedRouteRead.Response> {
 	}
 
 	/** Response for the fixed route read. */
-	public static final class Response
+	protected final class Response
 			extends PayloadedResponse<RoutingEntry, RuntimeException> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FixedRouteRead.java
@@ -15,10 +15,10 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.RouterCommand.ROUTER_FIXED;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.TOP_BIT;
+import static uk.ac.manchester.spinnaker.messages.scp.RouterCommand.FIXED;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 
 import java.nio.ByteBuffer;
@@ -37,7 +37,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  */
 public final class FixedRouteRead extends SCPRequest<FixedRouteRead.Response> {
 	private static int argument1(AppID appID) {
-		return (appID.appID << BYTE1) | (ROUTER_FIXED.value << BYTE0);
+		return (appID.appID << BYTE1) | (FIXED.value << BYTE0);
 	}
 
 	// Top bit set = do a read

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillData.java
@@ -30,6 +30,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_FFD;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to flood fill some data. There is no response payload.
@@ -41,7 +42,7 @@ import uk.ac.manchester.spinnaker.machine.MemoryLocation;
  * @see FloodFillStart
  * @see FloodFillEnd
  */
-public class FloodFillData extends SCPRequest<CheckOKResponse> {
+public class FloodFillData extends SCPRequest<EmptyResponse> {
 	private static final int FFD_NNP_FORWARD_RETRY =
 			(FORWARD_LINKS << BYTE3) | ((DELAY | DATA_RESEND) << BYTE2);
 
@@ -114,7 +115,8 @@ public class FloodFillData extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Flood Fill", CMD_FFD, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Flood Fill", CMD_FFD, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillEnd.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillEnd.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import uk.ac.manchester.spinnaker.machine.ValidP;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to finish a flood fill of data across all cores and launch the
@@ -38,7 +39,7 @@ import uk.ac.manchester.spinnaker.messages.model.AppID;
  * <p>
  * Handled ultimately by {@code nn_cmd_ffe()} in {@code scamp-nn.c}.
  */
-public final class FloodFillEnd extends SCPRequest<CheckOKResponse> {
+public final class FloodFillEnd extends SCPRequest<EmptyResponse> {
 	// Send on all links, std inter-message delay, no message resends
 	private static final int NNP_FORWARD_RETRY =
 			(FORWARD_LINKS << BYTE1) | (DELAY << BYTE0);
@@ -106,7 +107,8 @@ public final class FloodFillEnd extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Flood Fill", CMD_NNP, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Flood Fill", CMD_NNP, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/FloodFillStart.java
@@ -31,6 +31,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_NNP;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to start a flood fill of data. There is no response payload.
@@ -38,12 +39,12 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
  * Calls {@code nn_cmd_ffs()} in {@code scamp-nn.c} on all cores via
  * {@code ff_nn_send()} in {@code scamp-nn.c}.
  */
-public final class FloodFillStart extends SCPRequest<CheckOKResponse> {
+public final class FloodFillStart extends SCPRequest<EmptyResponse> {
 	// See nn_rcv_pkt()
 	private static final int NN_CMD_FFS = 6;
 
-	private static final int NNP_FORWARD_RETRY = (ADD_ID << TOP_BIT)
-			| (FORWARD_LINKS << BYTE1) | (DELAY << BYTE0);
+	private static final int NNP_FORWARD_RETRY =
+			(ADD_ID << TOP_BIT) | (FORWARD_LINKS << BYTE1) | (DELAY << BYTE0);
 
 	private static final int NO_CHIP = 0xFFFF;
 
@@ -101,7 +102,8 @@ public final class FloodFillStart extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Flood Fill", CMD_NNP, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Flood Fill", CMD_NNP, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
@@ -61,7 +61,8 @@ public class GetChipInfo extends SCPRequest<GetChipInfo.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetChipInfo.java
@@ -67,13 +67,14 @@ public class GetChipInfo extends SCPRequest<GetChipInfo.Response> {
 	}
 
 	/** An SCP response to a request for the version of software running. */
-	public static final class Response
+	protected final class Response
 			extends PayloadedResponse<ChipSummaryInfo, RuntimeException> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {
 			super("Version", CMD_INFO, buffer);
 		}
 
+		/** @return The chip summary information. */
 		@Override
 		protected ChipSummaryInfo parse(ByteBuffer buffer) {
 			return new ChipSummaryInfo(buffer, sdpHeader.getSource());

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetReinjectionStatus.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetReinjectionStatus.java
@@ -42,7 +42,8 @@ public class GetReinjectionStatus
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetReinjectionStatus.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetReinjectionStatus.java
@@ -50,7 +50,7 @@ public class GetReinjectionStatus
 	/**
 	 * An SCP response to a request for the dropped packet reinjection status.
 	 */
-	public static final class Response
+	protected final class Response
 			extends PayloadedResponse<ReinjectionStatus, RuntimeException> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetVersion.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/GetVersion.java
@@ -41,7 +41,8 @@ public class GetVersion extends SCPRequest<GetVersion.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
@@ -33,7 +33,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * Handled by {@code cmd_iptag()} in {@code scamp-cmd.c} (or {@code bmp_cmd.c},
  * if sent to a BMP).
  */
-public class IPTagClear extends SCPRequest<CheckOKResponse> {
+public class IPTagClear extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param chip
 	 *            The chip to clear the tag on.
@@ -50,8 +50,8 @@ public class IPTagClear extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer)
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new CheckOKResponse("Clear IP Tag", CMD_IPTAG, buffer);
+		return new EmptyResponse("Clear IP Tag", CMD_IPTAG, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
@@ -17,8 +17,8 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.CLR;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagClear.java
@@ -15,9 +15,9 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.CLR;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.CLR;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagCommand.java
@@ -13,27 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.ac.manchester.spinnaker.messages.model;
+package uk.ac.manchester.spinnaker.messages.scp;
 
-/** The SCP Allocation and Free codes. */
-public enum AllocFree {
-	/** Allocate SDRAM. */
-	ALLOC_SDRAM(0),
-	/** Free SDRAM using a Pointer. */
-	FREE_SDRAM_BY_POINTER(1),
-	/** Free SDRAM using an APP ID. */
-	FREE_SDRAM_BY_APP_ID(2),
-	/** Allocate Routing Entries. */
-	ALLOC_ROUTING(3),
-	/** Free Routing Entries by Pointer. */
-	FREE_ROUTING_BY_POINTER(4),
-	/** Free Routing Entries by APP ID. */
-	FREE_ROUTING_BY_APP_ID(5);
+/** SCP IP tag Commands. For {@code cmd_iptag()} in {@code scamp-cmd.c}. */
+enum IPTagCommand {
+	/** Create. */
+	NEW(0),
+	/** Update. */
+	SET(1),
+	/** Fetch. */
+	GET(2),
+	/** Delete. */
+	CLR(3),
+	/** Update Meta. */
+	TTO(4);
 
-	/** The SARK operation value. */
+	/** The SCAMP-encoded value. */
 	public final byte value;
 
-	AllocFree(int value) {
+	IPTagCommand(int value) {
 		this.value = (byte) value;
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
@@ -16,34 +16,23 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static java.net.InetAddress.getByAddress;
 import static java.util.Objects.requireNonNull;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.GET;
 import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.CORE_MASK;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.PORT_SHIFT;
 import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
-import uk.ac.manchester.spinnaker.machine.ChipLocation;
-import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
-import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
-import uk.ac.manchester.spinnaker.machine.tags.IPTag;
-import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
-import uk.ac.manchester.spinnaker.machine.tags.Tag;
 import uk.ac.manchester.spinnaker.machine.tags.TagID;
-import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
- * An SCP Request to get an IP tag. The
- * response payload is the {@linkplain TagDescription tag description}.
+ * An SCP Request to get an IP tag. The response payload is the
+ * {@linkplain TagDescription tag description}.
  * <p>
  * Handled by {@code cmd_iptag()} in {@code scamp-cmd.c} (or {@code bmp_cmd.c},
  * if sent to a BMP).
@@ -82,132 +71,6 @@ public class IPTagGet extends SCPRequest<IPTagGet.Response>
 		return new Response(buffer);
 	}
 
-	/** Description of a tag. */
-	public final class TagDescription {
-		/**
-		 * The count of the number of packets that have been sent with the tag.
-		 */
-		public final int count;
-
-		/** The flags of the tag. */
-		public final short flags;
-
-		/** The IP address of the tag. */
-		public final InetAddress ipAddress;
-
-		/** The MAC address of the tag, as an array of 6 bytes. */
-		public final byte[] macAddress;
-
-		/** The port of the tag. */
-		public final int port;
-
-		/** The receive port of the tag. */
-		public final int rxPort;
-
-		/**
-		 * The location of the core on the chip which the tag is defined on and
-		 * where the core that handles the tag's messages resides.
-		 */
-		public final HasCoreLocation spinCore;
-
-		/** The spin-port of the IP tag. */
-		public final int spinPort;
-
-		/** The timeout of the tag. */
-		public final IPTagTimeOutWaitTime timeout;
-
-		/** Where did the message that we've parsed this from originate from? */
-		private final ChipLocation src;
-
-		private TagDescription(ByteBuffer buffer, HasChipLocation src)
-				throws UnknownHostException {
-			byte[] ipBytes = new byte[IPV4_BYTES];
-			buffer.get(ipBytes);
-			ipAddress = getByAddress(ipBytes);
-
-			macAddress = new byte[MAC_BYTES];
-			buffer.get(macAddress);
-
-			port = Short.toUnsignedInt(buffer.getShort());
-			timeout = IPTagTimeOutWaitTime.get(buffer.getShort());
-			flags = buffer.getShort();
-			count = buffer.getInt();
-			rxPort = Short.toUnsignedInt(buffer.getShort());
-			int y = Byte.toUnsignedInt(buffer.get());
-			int x = Byte.toUnsignedInt(buffer.get());
-			int pp = Byte.toUnsignedInt(buffer.get());
-			spinCore = new CoreLocation(x, y, pp & CORE_MASK);
-			spinPort = (pp >>> PORT_SHIFT) & THREE_BITS_MASK;
-			this.src = src.asChipLocation();
-		}
-
-		private static final int IPV4_BYTES = 4;
-
-		private static final int MAC_BYTES = 6;
-
-		private static final int USE_BIT = 15;
-
-		private static final int TEMP_BIT = 14;
-
-		private static final int ARP_BIT = 13;
-
-		private static final int REV_BIT = 9;
-
-		private static final int STRIP_BIT = 8;
-
-		private boolean bitset(int bit) {
-			return (flags & (1 << bit)) != 0;
-		}
-
-		/** @return True if the tag is marked as being in use. */
-		public boolean isInUse() {
-			return bitset(USE_BIT);
-		}
-
-		/** @return True if the tag is temporary. */
-		public boolean isTemporary() {
-			return bitset(TEMP_BIT);
-		}
-
-		/**
-		 * @return True if the tag is in the ARP state (where the MAC address is
-		 *         being looked up; this is a transient state so unlikely).
-		 */
-		public boolean isARP() {
-			return bitset(ARP_BIT);
-		}
-
-		/** @return True if the tag is a reverse tag. */
-		public boolean isReverse() {
-			return bitset(REV_BIT);
-		}
-
-		/** @return True if the tag is to strip the SDP header. */
-		public boolean isStrippingSDP() {
-			return bitset(STRIP_BIT);
-		}
-
-		/**
-		 * Get the standard tag descriptor. Not properly meaningful unless the
-		 * tag is {@linkplain #isInUse() in use}.
-		 *
-		 * @return The tag descriptor. May be an {@link IPTag} or a
-		 *         {@link ReverseIPTag}.
-		 */
-		public Tag getTag() {
-			var host = requireNonNull(conn,
-					"can only describe a tag fully after the message has "
-							+ "been sent on a connection")
-					.getRemoteIPAddress();
-			if (isReverse()) {
-				return new ReverseIPTag(host, tag, rxPort, spinCore, spinPort);
-			} else {
-				return new IPTag(host, src, tag, ipAddress, port,
-						isStrippingSDP());
-			}
-		}
-	}
-
 	/** An SCP response to a request for an IP tags. */
 	protected final class Response
 			extends PayloadedResponse<TagDescription, UnknownHostException> {
@@ -219,7 +82,11 @@ public class IPTagGet extends SCPRequest<IPTagGet.Response>
 		@Override
 		protected TagDescription parse(ByteBuffer buffer)
 				throws UnknownHostException {
-			return new TagDescription(buffer, sdpHeader.getSource());
+			requireNonNull(conn,
+					"can only describe a tag fully after the message has "
+							+ "been sent on a connection");
+			return new TagDescription(buffer, sdpHeader.getSource(),
+					conn.getRemoteIPAddress(), tag);
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
@@ -209,7 +209,7 @@ public class IPTagGet extends SCPRequest<IPTagGet.Response>
 	}
 
 	/** An SCP response to a request for an IP tags. */
-	public final class Response
+	protected final class Response
 			extends PayloadedResponse<TagDescription, UnknownHostException> {
 		private Response(ByteBuffer buffer)
 				throws UnexpectedResponseCodeException, UnknownHostException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
@@ -18,8 +18,8 @@ package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.util.Objects.requireNonNull;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.GET;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.net.UnknownHostException;
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.tags.TagID;
+import uk.ac.manchester.spinnaker.messages.model.TagDescription;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGet.java
@@ -16,9 +16,9 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.util.Objects.requireNonNull;
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.GET;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.GET;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.net.UnknownHostException;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -66,7 +66,7 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 		/** The count of the number of fixed IP tag entries. */
 		public final int fixedSize;
 
-		private TagInfo(ByteBuffer buffer) {
+		TagInfo(ByteBuffer buffer) {
 			transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
 			buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
 			poolSize = toUnsignedInt(buffer.get());
@@ -75,7 +75,7 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 	}
 
 	/** An SCP response to a request for information about IP tags. */
-	public static final class Response
+	public final class Response
 			extends PayloadedResponse<TagInfo, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Get IP Tag Info", CMD_IPTAG, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -16,8 +16,8 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.TTO;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -16,7 +16,6 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static java.lang.Byte.toUnsignedInt;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;
 import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
@@ -24,7 +23,6 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
-import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
@@ -54,32 +52,11 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 		return new IPTagGetInfo.Response(buffer);
 	}
 
-	/** Information about a tag pool on an Ethernet-connected chip. */
-	public static final class TagInfo {
-		/**
-		 * The timeout for transient IP tags (i.e., responses to SCP commands).
-		 */
-		public final IPTagTimeOutWaitTime transientTimeout;
-
-		/** The count of the IP tag pool size. */
-		public final int poolSize;
-
-		/** The count of the number of fixed IP tag entries. */
-		public final int fixedSize;
-
-		TagInfo(ByteBuffer buffer) {
-			transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
-			buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
-			poolSize = toUnsignedInt(buffer.get());
-			fixedSize = toUnsignedInt(buffer.get());
-		}
-	}
-
 	/** An SCP response to a request for information about IP tags. */
 	protected final class Response
 			extends PayloadedResponse<TagInfo, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
-			super("Get IP Tag Info", CMD_IPTAG, buffer);
+			super("Get IP Tag Table Info", CMD_IPTAG, buffer);
 		}
 
 		@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -16,13 +16,16 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static java.lang.Byte.toUnsignedInt;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
+import uk.ac.manchester.spinnaker.messages.model.TagInfo;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
@@ -60,8 +63,12 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 		}
 
 		@Override
-		protected TagInfo parse(ByteBuffer buffer) throws RuntimeException {
-			return new TagInfo(buffer);
+		protected TagInfo parse(ByteBuffer buffer) {
+			var transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
+			buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
+			var poolSize = toUnsignedInt(buffer.get());
+			var fixedSize = toUnsignedInt(buffer.get());
+			return new TagInfo(transientTimeout, poolSize, fixedSize);
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagGetInfo.java
@@ -54,6 +54,7 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 		return new IPTagGetInfo.Response(buffer);
 	}
 
+	/** Information about a tag pool on an Ethernet-connected chip. */
 	public static final class TagInfo {
 		/**
 		 * The timeout for transient IP tags (i.e., responses to SCP commands).
@@ -75,7 +76,7 @@ public class IPTagGetInfo extends SCPRequest<IPTagGetInfo.Response> {
 	}
 
 	/** An SCP response to a request for information about IP tags. */
-	public final class Response
+	protected final class Response
 			extends PayloadedResponse<TagInfo, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Get IP Tag Info", CMD_IPTAG, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -20,12 +20,12 @@ import static java.lang.Byte.toUnsignedInt;
 import static java.util.stream.IntStream.range;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.BYTE_SHIFT;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.PORT_MASK;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.STRIP_FIELD_BIT;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.USE_SENDER_BIT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.BYTE_SHIFT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.PORT_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.STRIP_FIELD_BIT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.USE_SENDER_BIT;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -18,13 +18,13 @@ package uk.ac.manchester.spinnaker.messages.scp;
 import static java.lang.Byte.toUnsignedInt;
 import static java.util.stream.IntStream.range;
 import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.BYTE_SHIFT;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.PORT_MASK;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.STRIP_FIELD_BIT;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.USE_SENDER_BIT;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.SET;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSet.java
@@ -52,7 +52,7 @@ import uk.ac.manchester.spinnaker.utils.validation.UDPPort;
  *
  * @see ReverseIPTagSet
  */
-public class IPTagSet extends SCPRequest<CheckOKResponse> {
+public class IPTagSet extends SCPRequest<EmptyResponse> {
 	private static final Logger log = getLogger(IPTagSet.class);
 
 	private static final int INADDRSZ = 4;
@@ -107,8 +107,8 @@ public class IPTagSet extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer)
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new CheckOKResponse("Set IP Tag", CMD_IPTAG, buffer);
+		return new EmptyResponse("Set IP Tag", CMD_IPTAG, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -25,11 +25,10 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
-import uk.ac.manchester.spinnaker.messages.scp.IPTagGetInfo.TagInfo;
 
 /**
  * An SCP request to set the transient timeout for future SCP requests. The
- * response payload is the {@linkplain IPTagGetInfo.TagInfo tag <em>system</em>
+ * response payload is the {@linkplain TagInfo tag <em>system</em>
  * information}.
  * <p>
  * Handled by {@code cmd_iptag()} in {@code scamp-cmd.c} (or {@code bmp_cmd.c},
@@ -48,15 +47,15 @@ public class IPTagSetTTO extends SCPRequest<IPTagSetTTO.Response> {
 	}
 
 	@Override
-	public IPTagSetTTO.Response getSCPResponse(ByteBuffer buffer)
+	public Response getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new IPTagSetTTO.Response(buffer);
+		return new Response(buffer);
 	}
 
 	protected final class Response
 			extends PayloadedResponse<TagInfo, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
-			super("Get IP Tag Info", CMD_IPTAG, buffer);
+			super("Set IP Tag Timeout", CMD_IPTAG, buffer);
 		}
 
 		@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -53,7 +53,7 @@ public class IPTagSetTTO extends SCPRequest<IPTagSetTTO.Response> {
 		return new IPTagSetTTO.Response(buffer);
 	}
 
-	public final class Response
+	protected final class Response
 			extends PayloadedResponse<TagInfo, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Get IP Tag Info", CMD_IPTAG, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -16,8 +16,8 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.Byte.toUnsignedInt;
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.TTO;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -16,14 +16,16 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static java.lang.Byte.toUnsignedInt;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.TTO;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
+import uk.ac.manchester.spinnaker.messages.model.TagInfo;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
@@ -59,8 +61,12 @@ public class IPTagSetTTO extends SCPRequest<IPTagSetTTO.Response> {
 		}
 
 		@Override
-		protected TagInfo parse(ByteBuffer buffer) throws RuntimeException {
-			return new TagInfo(buffer);
+		protected TagInfo parse(ByteBuffer buffer) {
+			var transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
+			buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
+			var poolSize = toUnsignedInt(buffer.get());
+			var fixedSize = toUnsignedInt(buffer.get());
+			return new TagInfo(transientTimeout, poolSize, fixedSize);
 		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/IPTagSetTTO.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
 import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
+import uk.ac.manchester.spinnaker.messages.scp.IPTagGetInfo.TagInfo;
 
 /**
  * An SCP request to set the transient timeout for future SCP requests. The
@@ -34,7 +35,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * Handled by {@code cmd_iptag()} in {@code scamp-cmd.c} (or {@code bmp_cmd.c},
  * if sent to a BMP).
  */
-public class IPTagSetTTO extends SCPRequest<IPTagGetInfo.Response> {
+public class IPTagSetTTO extends SCPRequest<IPTagSetTTO.Response> {
 	/**
 	 * @param chip
 	 *            The chip to set the tag timout on.
@@ -47,8 +48,20 @@ public class IPTagSetTTO extends SCPRequest<IPTagGetInfo.Response> {
 	}
 
 	@Override
-	public IPTagGetInfo.Response getSCPResponse(ByteBuffer buffer)
+	public IPTagSetTTO.Response getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new IPTagGetInfo.Response(buffer);
+		return new IPTagSetTTO.Response(buffer);
+	}
+
+	public final class Response
+			extends PayloadedResponse<TagInfo, RuntimeException> {
+		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
+			super("Get IP Tag Info", CMD_IPTAG, buffer);
+		}
+
+		@Override
+		protected TagInfo parse(ByteBuffer buffer) throws RuntimeException {
+			return new TagInfo(buffer);
+		}
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -77,7 +77,8 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadLink.java
@@ -87,7 +87,7 @@ public class ReadLink extends SCPRequest<ReadLink.Response> {
 	 * chip. Note that it is up to the caller to manage the buffer position of
 	 * the returned response if it is to be read from multiple times.
 	 */
-	public static final class Response
+	protected final class Response
 			extends PayloadedResponse<ByteBuffer, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Read Link", CMD_LINK_READ, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -80,7 +80,7 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	 * that it is up to the caller to manage the buffer position of the returned
 	 * response if it is to be read from multiple times.
 	 */
-	public static final class Response
+	protected final class Response
 			extends PayloadedResponse<ByteBuffer, RuntimeException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException {
 			super("Read", CMD_READ, buffer);

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -18,8 +18,8 @@ package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static uk.ac.manchester.spinnaker.messages.Constants.UDP_MESSAGE_MAX_SIZE;
+import static uk.ac.manchester.spinnaker.messages.model.TransferUnit.efficientTransferUnit;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_READ;
-import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTransferUnit;
 
 import java.nio.ByteBuffer;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReadMemory.java
@@ -70,7 +70,8 @@ public class ReadMemory extends SCPRequest<ReadMemory.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
 		return new Response(buffer);
 	}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ResetReinjectionCounters.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ResetReinjectionCounters.java
@@ -21,6 +21,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.ReinjectorCommand.RESET_CO
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to reset the statistics counters of the dropped packet
@@ -29,8 +30,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
  * Handled by {@code reinjection_reset_counters()} in
  * {@code extra_monitor_support.c}.
  */
-public class ResetReinjectionCounters
-		extends ReinjectorRequest<CheckOKResponse> {
+public class ResetReinjectionCounters extends ReinjectorRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The coordinates of the monitor core.
@@ -40,8 +40,9 @@ public class ResetReinjectionCounters
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Reset dropped packet reinjection counters",
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Reset dropped packet reinjection counters",
 				RESET_COUNTERS, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
@@ -17,15 +17,15 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.COMMAND_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.DEST_P_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.DEST_X_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.DEST_Y_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.PORT_MASK;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.REVERSE_FIELD_BIT;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.SDP_PORT_FIELD;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.STRIP_FIELD_BIT;
-import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.DEST_P_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.DEST_X_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.DEST_Y_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.PORT_MASK;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.REVERSE_FIELD_BIT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.SDP_PORT_FIELD;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.STRIP_FIELD_BIT;
+import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.IPTagCommand.SET;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.COMMAND_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.DEST_P_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.DEST_X_FIELD;
@@ -25,6 +24,7 @@ import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.RE
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.SDP_PORT_FIELD;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.STRIP_FIELD_BIT;
 import static uk.ac.manchester.spinnaker.messages.model.IPTagFieldDefinitions.THREE_BITS_MASK;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagCommand.SET;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_IPTAG;
 
 import java.nio.ByteBuffer;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/ReverseIPTagSet.java
@@ -49,7 +49,7 @@ import uk.ac.manchester.spinnaker.utils.validation.UDPPort;
  *
  * @see IPTagSet
  */
-public class ReverseIPTagSet extends SCPRequest<CheckOKResponse> {
+public class ReverseIPTagSet extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param chip
 	 *            The chip to set the tag on.
@@ -89,8 +89,8 @@ public class ReverseIPTagSet extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer)
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new CheckOKResponse("Set Reverse IP Tag", CMD_IPTAG, buffer);
+		return new EmptyResponse("Set Reverse IP Tag", CMD_IPTAG, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
@@ -16,7 +16,7 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.spinnaker.messages.model.AllocFree.ALLOC_ROUTING;
+import static uk.ac.manchester.spinnaker.messages.scp.AllocFree.ALLOC_ROUTING;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_ALLOC;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
@@ -65,7 +65,7 @@ public class RouterAlloc extends SCPRequest<RouterAlloc.Response> {
 	}
 
 	/** An SCP response to a request to allocate router entries. */
-	public final class Response extends
+	protected final class Response extends
 			PayloadedResponse<Integer, MemoryAllocationFailedException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
 				MemoryAllocationFailedException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterAlloc.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.MemoryAllocationFailedException;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to allocate space for routing entries. The response payload is
@@ -57,14 +58,17 @@ public class RouterAlloc extends SCPRequest<RouterAlloc.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException,
+			MemoryAllocationFailedException {
 		return new Response(buffer);
 	}
 
 	/** An SCP response to a request to allocate router entries. */
 	public final class Response extends
 			PayloadedResponse<Integer, MemoryAllocationFailedException> {
-		Response(ByteBuffer buffer) throws Exception {
+		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
+				MemoryAllocationFailedException {
 			super("Router Allocation", CMD_ALLOC, buffer);
 		}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
@@ -15,7 +15,7 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.RouterCommand.ROUTER_INIT;
+import static uk.ac.manchester.spinnaker.messages.scp.RouterCommand.INIT;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 
 import java.nio.ByteBuffer;
@@ -35,7 +35,7 @@ public class RouterClear extends SCPRequest<EmptyResponse> {
 	 *            The coordinates of the chip to clear the router of
 	 */
 	public RouterClear(HasChipLocation chip) {
-		super(chip.getScampCore(), CMD_RTR, ROUTER_INIT.value);
+		super(chip.getScampCore(), CMD_RTR, INIT.value);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterClear.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to clear the router on a chip. There is no response payload.
@@ -29,7 +30,7 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
  * Calls {@code rtr_mc_init()} in {@code sark_hw.c}, via {@code rtr_cmd()} in
  * {@code scamp-cmd.c}.
  */
-public class RouterClear extends SCPRequest<CheckOKResponse> {
+public class RouterClear extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param chip
 	 *            The coordinates of the chip to clear the router of
@@ -39,7 +40,8 @@ public class RouterClear extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Router Clear", CMD_RTR, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Router Clear", CMD_RTR, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterCommand.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterCommand.java
@@ -13,25 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.ac.manchester.spinnaker.messages.model;
+package uk.ac.manchester.spinnaker.messages.scp;
 
-/** SCP IP tag Commands. */
-public enum IPTagCommand {
-	/** Create. */
-	NEW(0),
-	/** Update. */
-	SET(1),
-	/** Fetch. */
-	GET(2),
-	/** Delete. */
-	CLR(3),
-	/** Update Meta. */
-	TTO(4);
+/**
+ * The basic router commands, handled by {@code cmd_rtr()} in
+ * {@code scamp-cmd.c}.
+ */
+enum RouterCommand {
+	/** Initialise. */
+	INIT,
+	/** Clear (entry=arg2, count). */
+	CLEAR,
+	/** Load (addr=arg2, count, offset=arg3, app_id). */
+	LOAD,
+	/**
+	 * Set/get Fixed Route register (arg2 = route). if bit 31 of arg1 set then
+	 * return FR reg else set it
+	 */
+	FIXED;
 
 	/** The SCAMP-encoded value. */
 	public final byte value;
 
-	IPTagCommand(int value) {
-		this.value = (byte) value;
+	RouterCommand() {
+		value = (byte) ordinal();
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * A request to initialise the router on a chip. There is no response payload.
@@ -34,7 +35,7 @@ import uk.ac.manchester.spinnaker.messages.model.AppID;
  * Ultimately handled by {@code rtr_mc_load()} in {@code sark_hw.c} (via
  * {@code cmd_rtr()} in {@code scamp-cmd.c}).
  */
-public class RouterInit extends SCPRequest<CheckOKResponse> {
+public class RouterInit extends SCPRequest<EmptyResponse> {
 	/** One reserved for SCAMP. */
 	private static final int MAX_ENTRIES = 1023;
 
@@ -55,8 +56,7 @@ public class RouterInit extends SCPRequest<CheckOKResponse> {
 	 *             If a bad address or entry count is given
 	 */
 	public RouterInit(HasChipLocation chip, int numEntries,
-			MemoryLocation tableAddress, int baseIndex,
-			AppID appID) {
+			MemoryLocation tableAddress, int baseIndex, AppID appID) {
 		super(chip.getScampCore(), CMD_RTR, argument1(numEntries, appID),
 				tableAddress.address, baseIndex);
 		if (baseIndex < 0) {
@@ -78,7 +78,8 @@ public class RouterInit extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Router Init", CMD_RTR, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Router Init", CMD_RTR, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterInit.java
@@ -15,10 +15,10 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.RouterCommand.ROUTER_LOAD;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.HALF1;
+import static uk.ac.manchester.spinnaker.messages.scp.RouterCommand.LOAD;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_RTR;
 
 import java.nio.ByteBuffer;
@@ -73,7 +73,7 @@ public class RouterInit extends SCPRequest<EmptyResponse> {
 					"numEntries must be no more than " + MAX_ENTRIES);
 		}
 		return (numEntries << HALF1) | (appID.appID << BYTE1)
-				| (ROUTER_LOAD.value << BYTE0);
+				| (LOAD.value << BYTE0);
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterTableRequest.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/RouterTableRequest.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import com.google.errorprone.annotations.ForOverride;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
 
 /**
@@ -31,7 +32,7 @@ import uk.ac.manchester.spinnaker.messages.sdp.SDPHeader;
  * table.
  */
 //TODO Seal in 17
-public abstract class RouterTableRequest extends SCPRequest<CheckOKResponse> {
+public abstract class RouterTableRequest extends SCPRequest<EmptyResponse> {
 	private final RouterTableCommand cmd;
 
 	/**
@@ -55,9 +56,9 @@ public abstract class RouterTableRequest extends SCPRequest<CheckOKResponse> {
 	abstract String describe();
 
 	@Override
-	public final CheckOKResponse getSCPResponse(ByteBuffer buffer)
-			throws Exception {
-		return new CheckOKResponse(describe(), cmd, buffer);
+	public final EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse(describe(), cmd, buffer);
 	}
 
 	/**

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
@@ -29,6 +29,7 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.MemoryAllocationFailedException;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to allocate space in the SDRAM space. The response payload is
@@ -92,14 +93,17 @@ public class SDRAMAlloc extends SCPRequest<SDRAMAlloc.Response> {
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException,
+			MemoryAllocationFailedException {
 		return new Response(buffer);
 	}
 
 	/** An SCP response to a request to allocate space in SDRAM. */
 	public final class Response extends
 			PayloadedResponse<MemoryLocation, MemoryAllocationFailedException> {
-		Response(ByteBuffer buffer) throws Exception {
+		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
+				MemoryAllocationFailedException {
 			super("SDRAM Allocation", CMD_ALLOC, buffer);
 		}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
@@ -16,7 +16,7 @@
 package uk.ac.manchester.spinnaker.messages.scp;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.spinnaker.messages.model.AllocFree.ALLOC_SDRAM;
+import static uk.ac.manchester.spinnaker.messages.scp.AllocFree.ALLOC_SDRAM;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE2;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMAlloc.java
@@ -100,7 +100,7 @@ public class SDRAMAlloc extends SCPRequest<SDRAMAlloc.Response> {
 	}
 
 	/** An SCP response to a request to allocate space in SDRAM. */
-	public final class Response extends
+	protected final class Response extends
 			PayloadedResponse<MemoryLocation, MemoryAllocationFailedException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
 				MemoryAllocationFailedException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.MemoryAllocationFailedException;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to free space in the SDRAM. The response payload is the number
@@ -72,20 +73,23 @@ public class SDRAMDeAlloc extends SCPRequest<SDRAMDeAlloc.Response> {
 	 * [  31-16 |   15-8 | 7-0 ]
 	 * [ unused | app_id |  op ]
 	 */
-	// @formatter:off
+	// @formatter:on
 	private static int argument1(AppID appID) {
 		return (appID.appID << BYTE1) | (FREE_SDRAM_BY_APP_ID.value << BYTE0);
 	}
 
 	@Override
-	public Response getSCPResponse(ByteBuffer buffer) throws Exception {
+	public Response getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException,
+			MemoryAllocationFailedException {
 		return new Response(buffer);
 	}
 
 	/** An SCP response to a request to deallocate SDRAM. */
 	public final class Response extends
 			PayloadedResponse<Integer, MemoryAllocationFailedException> {
-		Response(ByteBuffer buffer) throws Exception {
+		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
+				MemoryAllocationFailedException {
 			super("SDRAM Deallocation", CMD_ALLOC, buffer);
 		}
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
@@ -15,8 +15,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
-import static uk.ac.manchester.spinnaker.messages.model.AllocFree.FREE_SDRAM_BY_APP_ID;
-import static uk.ac.manchester.spinnaker.messages.model.AllocFree.FREE_SDRAM_BY_POINTER;
+import static uk.ac.manchester.spinnaker.messages.scp.AllocFree.FREE_SDRAM_BY_APP_ID;
+import static uk.ac.manchester.spinnaker.messages.scp.AllocFree.FREE_SDRAM_BY_POINTER;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE0;
 import static uk.ac.manchester.spinnaker.messages.scp.Bits.BYTE1;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_ALLOC;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SDRAMDeAlloc.java
@@ -86,7 +86,7 @@ public class SDRAMDeAlloc extends SCPRequest<SDRAMDeAlloc.Response> {
 	}
 
 	/** An SCP response to a request to deallocate SDRAM. */
-	public final class Response extends
+	protected final class Response extends
 			PayloadedResponse<Integer, MemoryAllocationFailedException> {
 		Response(ByteBuffer buffer) throws UnexpectedResponseCodeException,
 				MemoryAllocationFailedException {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SendSignal.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SendSignal.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.messages.model.AppID;
 import uk.ac.manchester.spinnaker.messages.model.Signal;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to send a signal to cores. This supports any signal that uses
@@ -41,7 +42,7 @@ import uk.ac.manchester.spinnaker.messages.model.Signal;
  *
  * @see CountState
  */
-public class SendSignal extends SCPRequest<CheckOKResponse> {
+public class SendSignal extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param appID
 	 *            The ID of the application to signal (only for multicast
@@ -66,7 +67,8 @@ public class SendSignal extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Send Signal", CMD_SIG, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Send Signal", CMD_SIG, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetLED.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetLED.java
@@ -23,13 +23,14 @@ import java.util.Map;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.messages.model.LEDAction;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP request to change the state of an LED. There is no response payload.
  * <p>
  * Handled by {@code sark_led_set()} in {@code sark_hw.c}.
  */
-public class SetLED extends SCPRequest<CheckOKResponse> {
+public class SetLED extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The SpiNNaker core that will set the BMPSetLED
@@ -49,7 +50,8 @@ public class SetLED extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Set LED", CMD_LED, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Set LED", CMD_LED, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetReinjectionPacketTypes.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetReinjectionPacketTypes.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.ReinjectorCommand.SET_PACK
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to set the dropped packet reinjected packet types. There is no
@@ -31,7 +32,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
  * {@code extra_monitor_support.c}.
  */
 public class SetReinjectionPacketTypes
-		extends ReinjectorRequest<CheckOKResponse> {
+		extends ReinjectorRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The coordinates of the monitor core.
@@ -62,8 +63,9 @@ public class SetReinjectionPacketTypes
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Set reinjected packet types",
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Set reinjected packet types",
 				SET_PACKET_TYPES, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetRouterEmergencyTimeout.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetRouterEmergencyTimeout.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.ReinjectorCommand.SET_ROUT
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to set the router emergency timeout for dropped packet
@@ -31,7 +32,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
  * {@code extra_monitor_support.c}.
  */
 public class SetRouterEmergencyTimeout
-		extends ReinjectorRequest<CheckOKResponse> {
+		extends ReinjectorRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The coordinates of the monitor core.
@@ -47,8 +48,9 @@ public class SetRouterEmergencyTimeout
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Set router emergency timeout",
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Set router emergency timeout",
 				SET_ROUTER_EMERGENCY_TIMEOUT, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetRouterTimeout.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/SetRouterTimeout.java
@@ -22,6 +22,7 @@ import static uk.ac.manchester.spinnaker.messages.scp.ReinjectorCommand.SET_ROUT
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * An SCP Request to the extra monitor core to set the router timeout for
@@ -30,7 +31,7 @@ import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
  * Handled by {@code reinjection_set_timeout_sdp()} in
  * {@code extra_monitor_support.c}.
  */
-public class SetRouterTimeout extends ReinjectorRequest<CheckOKResponse> {
+public class SetRouterTimeout extends ReinjectorRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The coordinates of the monitor core.
@@ -46,8 +47,9 @@ public class SetRouterTimeout extends ReinjectorRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Set router timeout", SET_ROUTER_TIMEOUT,
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Set router timeout", SET_ROUTER_TIMEOUT,
 				buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TagDescription.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TagDescription.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2018-2023 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.scp;
+
+import static java.net.InetAddress.getByAddress;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.CORE_MASK;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.PORT_SHIFT;
+import static uk.ac.manchester.spinnaker.messages.scp.IPTagFieldDefinitions.THREE_BITS_MASK;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.machine.ChipLocation;
+import uk.ac.manchester.spinnaker.machine.CoreLocation;
+import uk.ac.manchester.spinnaker.machine.HasChipLocation;
+import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
+import uk.ac.manchester.spinnaker.machine.tags.IPTag;
+import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
+import uk.ac.manchester.spinnaker.machine.tags.Tag;
+import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
+
+/** Description of a tag. */
+public final class TagDescription {
+	// TODO convert to a record in Java 17
+	/**
+	 * The count of the number of packets that have been sent with the tag.
+	 */
+	public final int count;
+
+	/** The flags of the tag. */
+	public final short flags;
+
+	/** The IP address of the tag. */
+	public final InetAddress ipAddress;
+
+	/** The MAC address of the tag, as an array of 6 bytes. */
+	public final byte[] macAddress;
+
+	/** The port of the tag. */
+	public final int port;
+
+	/** The receive port of the tag. */
+	public final int rxPort;
+
+	/**
+	 * The location of the core on the chip which the tag is defined on and
+	 * where the core that handles the tag's messages resides.
+	 */
+	public final HasCoreLocation spinCore;
+
+	/** The spin-port of the IP tag. */
+	public final int spinPort;
+
+	/** The timeout of the tag. */
+	public final IPTagTimeOutWaitTime timeout;
+
+	/** Where did the message that we've parsed this from originate from? */
+	private final ChipLocation src;
+
+	/**
+	 * On what SpiNNaker board did this info originate? Assumes we were talking
+	 * directly to the board.
+	 */
+	private final InetAddress host;
+
+	/** What tag was this info about? */
+	private final int tag;
+
+	TagDescription(ByteBuffer buffer, HasChipLocation src, InetAddress host,
+			int tag) throws UnknownHostException {
+		byte[] ipBytes = new byte[IPV4_BYTES];
+		buffer.get(ipBytes);
+		ipAddress = getByAddress(ipBytes);
+
+		macAddress = new byte[MAC_BYTES];
+		buffer.get(macAddress);
+
+		port = Short.toUnsignedInt(buffer.getShort());
+		timeout = IPTagTimeOutWaitTime.get(buffer.getShort());
+		flags = buffer.getShort();
+		count = buffer.getInt();
+		rxPort = Short.toUnsignedInt(buffer.getShort());
+		int y = Byte.toUnsignedInt(buffer.get());
+		int x = Byte.toUnsignedInt(buffer.get());
+		int pp = Byte.toUnsignedInt(buffer.get());
+		spinCore = new CoreLocation(x, y, pp & CORE_MASK);
+		spinPort = (pp >>> PORT_SHIFT) & THREE_BITS_MASK;
+		this.src = src.asChipLocation();
+		this.host = host;
+		this.tag = tag;
+	}
+
+	private static final int IPV4_BYTES = 4;
+
+	private static final int MAC_BYTES = 6;
+
+	private static final int USE_BIT = 15;
+
+	private static final int TEMP_BIT = 14;
+
+	private static final int ARP_BIT = 13;
+
+	private static final int REV_BIT = 9;
+
+	private static final int STRIP_BIT = 8;
+
+	private boolean bitset(int bit) {
+		return (flags & (1 << bit)) != 0;
+	}
+
+	/** @return True if the tag is marked as being in use. */
+	public boolean isInUse() {
+		return bitset(USE_BIT);
+	}
+
+	/** @return True if the tag is temporary. */
+	public boolean isTemporary() {
+		return bitset(TEMP_BIT);
+	}
+
+	/**
+	 * @return True if the tag is in the ARP state (where the MAC address is
+	 *         being looked up; this is a transient state so unlikely).
+	 */
+	public boolean isARP() {
+		return bitset(ARP_BIT);
+	}
+
+	/** @return True if the tag is a reverse tag. */
+	public boolean isReverse() {
+		return bitset(REV_BIT);
+	}
+
+	/** @return True if the tag is to strip the SDP header. */
+	public boolean isStrippingSDP() {
+		return bitset(STRIP_BIT);
+	}
+
+	/**
+	 * Get the standard tag descriptor. Not properly meaningful unless the tag
+	 * is {@linkplain #isInUse() in use}.
+	 *
+	 * @return The tag descriptor. May be an {@link IPTag} or a
+	 *         {@link ReverseIPTag}.
+	 */
+	public Tag getTag() {
+		if (isReverse()) {
+			return new ReverseIPTag(host, tag, rxPort, spinCore, spinPort);
+		} else {
+			return new IPTag(host, src, tag, ipAddress, port, isStrippingSDP());
+		}
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TagInfo.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/TagInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2023 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package uk.ac.manchester.spinnaker.messages.scp;
+
+import static java.lang.Byte.toUnsignedInt;
+
+import java.nio.ByteBuffer;
+
+import uk.ac.manchester.spinnaker.messages.model.IPTagTimeOutWaitTime;
+
+/** Information about a tag pool on an Ethernet-connected chip. */
+public final class TagInfo {
+	/**
+	 * The timeout for transient IP tags (i.e., responses to SCP commands).
+	 */
+	public final IPTagTimeOutWaitTime transientTimeout;
+
+	/** The count of the IP tag pool size. */
+	public final int poolSize;
+
+	/** The count of the number of fixed IP tag entries. */
+	public final int fixedSize;
+
+	TagInfo(ByteBuffer buffer) {
+		transientTimeout = IPTagTimeOutWaitTime.get(buffer.get());
+		buffer.get(); // skip 1 (sizeof(iptag_t) isn't relevant to us)
+		poolSize = toUnsignedInt(buffer.get());
+		fixedSize = toUnsignedInt(buffer.get());
+	}
+}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/UpdateRuntime.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/UpdateRuntime.java
@@ -29,7 +29,7 @@ import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException
  * <p>
  * This calls {@code simulation_control_scp_callback()} in {@code simulation.c}.
  */
-public class UpdateRuntime extends FECRequest<CheckOKResponse> {
+public class UpdateRuntime extends FECRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            The SpiNNaker core to update the runtime info of.
@@ -53,8 +53,8 @@ public class UpdateRuntime extends FECRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer)
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
 			throws UnexpectedResponseCodeException {
-		return new CheckOKResponse("update runtime", NEW_RUNTIME_ID, buffer);
+		return new EmptyResponse("update runtime", NEW_RUNTIME_ID, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteLink.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * A request to write memory on a neighbouring chip. There is no response
@@ -30,7 +31,7 @@ import uk.ac.manchester.spinnaker.machine.MemoryLocation;
  * <p>
  * Calls {@code cmd_link_write()} in {@code scamp-cmd.c}.
  */
-public class WriteLink extends SCPRequest<CheckOKResponse> {
+public class WriteLink extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            the core to write via
@@ -51,7 +52,8 @@ public class WriteLink extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Write Memory", CMD_LINK_WRITE, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Write Memory", CMD_LINK_WRITE, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
@@ -16,8 +16,8 @@
  */
 package uk.ac.manchester.spinnaker.messages.scp;
 
+import static uk.ac.manchester.spinnaker.messages.model.TransferUnit.efficientTransferUnit;
 import static uk.ac.manchester.spinnaker.messages.scp.SCPCommand.CMD_WRITE;
-import static uk.ac.manchester.spinnaker.messages.scp.TransferUnit.efficientTransferUnit;
 
 import java.nio.ByteBuffer;
 

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/scp/WriteMemory.java
@@ -24,13 +24,14 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.spinnaker.machine.HasChipLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
+import uk.ac.manchester.spinnaker.messages.model.UnexpectedResponseCodeException;
 
 /**
  * A request to write memory on a chip. There is no response payload.
  * <p>
  * Calls {@code sark_cmd_write()} in {@code sark_base.c}.
  */
-public class WriteMemory extends SCPRequest<CheckOKResponse> {
+public class WriteMemory extends SCPRequest<EmptyResponse> {
 	/**
 	 * @param core
 	 *            the core to write via
@@ -69,7 +70,8 @@ public class WriteMemory extends SCPRequest<CheckOKResponse> {
 	}
 
 	@Override
-	public CheckOKResponse getSCPResponse(ByteBuffer buffer) throws Exception {
-		return new CheckOKResponse("Write", CMD_WRITE, buffer);
+	public EmptyResponse getSCPResponse(ByteBuffer buffer)
+			throws UnexpectedResponseCodeException {
+		return new EmptyResponse("Write", CMD_WRITE, buffer);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetTagsProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/GetTagsProcess.java
@@ -19,15 +19,12 @@ package uk.ac.manchester.spinnaker.transceiver;
 import static java.util.stream.IntStream.range;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 
 import uk.ac.manchester.spinnaker.connections.ConnectionSelector;
 import uk.ac.manchester.spinnaker.connections.SCPConnection;
-import uk.ac.manchester.spinnaker.machine.tags.IPTag;
-import uk.ac.manchester.spinnaker.machine.tags.ReverseIPTag;
 import uk.ac.manchester.spinnaker.machine.tags.Tag;
 import uk.ac.manchester.spinnaker.messages.scp.IPTagGet;
 import uk.ac.manchester.spinnaker.messages.scp.IPTagGetInfo;
@@ -65,11 +62,9 @@ class GetTagsProcess extends TxrxProcess {
 			throws IOException, ProcessException, InterruptedException {
 		var tags = new TreeMap<Integer, Tag>();
 		for (var tag : range(0, getTagCount(connection)).toArray()) {
-			sendRequest(new IPTagGet(connection.getChip(), tag), response -> {
-				var info = response.get();
+			sendGet(new IPTagGet(connection.getChip(), tag), info -> {
 				if (info.isInUse()) {
-					tags.put(tag, createTag(connection.getRemoteIPAddress(),
-							tag, response, info));
+					tags.put(tag, info.getTag());
 				}
 			});
 		}
@@ -81,17 +76,6 @@ class GetTagsProcess extends TxrxProcess {
 			throws IOException, ProcessException, InterruptedException {
 		var tagInfo = retrieve(new IPTagGetInfo(connection.getChip()));
 		return tagInfo.poolSize + tagInfo.fixedSize;
-	}
-
-	private static Tag createTag(InetAddress host, int tag,
-			IPTagGet.Response res, IPTagGet.TagDescription info) {
-		if (info.isReverse()) {
-			return new ReverseIPTag(host, tag, info.rxPort, info.spinCore,
-					info.spinPort);
-		} else {
-			return new IPTag(host, res.sdpHeader.getSource().asChipLocation(),
-					tag, info.ipAddress, info.port, info.isStrippingSDP());
-		}
 	}
 
 	/**
@@ -112,11 +96,9 @@ class GetTagsProcess extends TxrxProcess {
 			throws IOException, ProcessException, InterruptedException {
 		var tagUsages = new TreeMap<Tag, Integer>();
 		for (var tag : range(0, getTagCount(connection)).toArray()) {
-			sendRequest(new IPTagGet(connection.getChip(), tag), response -> {
-				var info = response.get();
+			sendGet(new IPTagGet(connection.getChip(), tag), info -> {
 				if (info.isInUse()) {
-					tagUsages.put(createTag(connection.getRemoteIPAddress(),
-							tag, response, info), info.count);
+					tagUsages.put(info.getTag(), info.count);
 				}
 			});
 		}

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -149,8 +149,8 @@ import uk.ac.manchester.spinnaker.messages.model.Version;
 import uk.ac.manchester.spinnaker.messages.model.VersionInfo;
 import uk.ac.manchester.spinnaker.messages.scp.ApplicationRun;
 import uk.ac.manchester.spinnaker.messages.scp.ApplicationStop;
-import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
 import uk.ac.manchester.spinnaker.messages.scp.CountState;
+import uk.ac.manchester.spinnaker.messages.scp.EmptyResponse;
 import uk.ac.manchester.spinnaker.messages.scp.GetChipInfo;
 import uk.ac.manchester.spinnaker.messages.scp.GetVersion;
 import uk.ac.manchester.spinnaker.messages.scp.IPTagClear;
@@ -1202,12 +1202,10 @@ public class Transceiver extends UDPTransceiver
 	/**
 	 * Do a synchronous call of an SCP operation using the default connection
 	 * for a request, sending the given message and completely processing the
-	 * interaction before returning its response. This can only properly handle
-	 * those calls that involve a single request and a single reply;
-	 * fortunately, that's many of them!
+	 * interaction. There is no payload in the response, and no result from this
+	 * method. This can only properly handle those calls that involve a single
+	 * request and a single reply; fortunately, that's many of them!
 	 *
-	 * @param <T>
-	 *            The type of the response.
 	 * @param request
 	 *            The request to make.
 	 * @return The successful response to the request.
@@ -1218,9 +1216,9 @@ public class Transceiver extends UDPTransceiver
 	 * @throws InterruptedException
 	 *             If the communications were interrupted.
 	 */
-	private <T extends CheckOKResponse> T call(SCPRequest<T> request)
+	private void call(SCPRequest<EmptyResponse> request)
 			throws ProcessException, IOException, InterruptedException {
-		return new TxrxProcess(scpSelector, this).call(request);
+		new TxrxProcess(scpSelector, this).call(request);
 	}
 
 	/**
@@ -1300,7 +1298,8 @@ public class Transceiver extends UDPTransceiver
 		 */
 		var process = simpleProcess();
 		for (var connection : scpConnections) {
-			process.call(
+			// we apparently don't save the timeout...
+			process.retrieve(
 					new IPTagSetTTO(connection.getChip(), TIMEOUT_2560_ms));
 		}
 
@@ -2388,7 +2387,8 @@ public class Transceiver extends UDPTransceiver
 	@ParallelSafe
 	public void freeSDRAM(HasChipLocation chip, MemoryLocation baseAddress)
 			throws IOException, ProcessException, InterruptedException {
-		call(new SDRAMDeAlloc(chip, baseAddress));
+		// Ignore the result of this
+		get(new SDRAMDeAlloc(chip, baseAddress));
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TxrxProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/TxrxProcess.java
@@ -51,10 +51,13 @@ import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
 import uk.ac.manchester.spinnaker.messages.scp.CommandCode;
+import uk.ac.manchester.spinnaker.messages.scp.ConnectionAwareMessage;
+import uk.ac.manchester.spinnaker.messages.scp.EmptyResponse;
 import uk.ac.manchester.spinnaker.messages.scp.NoResponse;
 import uk.ac.manchester.spinnaker.messages.scp.PayloadedResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResponse;
+import uk.ac.manchester.spinnaker.messages.scp.SCPResult;
 import uk.ac.manchester.spinnaker.messages.scp.SCPResultMessage;
 import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
@@ -250,8 +253,7 @@ public class TxrxProcess {
 	/**
 	 * Send a request. The actual payload of the response to this request is to
 	 * be considered to be uninteresting provided it doesn't indicate a failure.
-	 * In particular, the response is <em>just</em> a {@link CheckOKResponse}
-	 * and not one of its subclasses.
+	 * In particular, the response is a {@link EmptyResponse}.
 	 *
 	 * @param request
 	 *            The request to send.
@@ -260,7 +262,7 @@ public class TxrxProcess {
 	 * @throws InterruptedException
 	 *             If communications are interrupted while preparing to send.
 	 */
-	protected final void sendRequest(SCPRequest<CheckOKResponse> request)
+	protected final void sendRequest(SCPRequest<EmptyResponse> request)
 			throws IOException, InterruptedException {
 		pipeline(request).send(request, null);
 	}
@@ -312,11 +314,8 @@ public class TxrxProcess {
 	 * Do a synchronous call of an SCP operation, sending the given message and
 	 * completely processing the interaction before returning its response.
 	 *
-	 * @param <Resp>
-	 *            The type of the response; implicit in the type of the request.
 	 * @param request
 	 *            The request to send
-	 * @return The successful response to the request
 	 * @throws IOException
 	 *             If the communications fail
 	 * @throws ProcessException
@@ -324,14 +323,13 @@ public class TxrxProcess {
 	 * @throws InterruptedException
 	 *             If the communications were interrupted.
 	 */
-	protected final <
-			Resp extends CheckOKResponse> Resp call(SCPRequest<Resp> request)
+	protected final void call(SCPRequest<EmptyResponse> request)
 					throws IOException, ProcessException, InterruptedException {
-		var holder = new ValueHolder<Resp>();
+		var holder = new ValueHolder<EmptyResponse>();
 		resetFailureState();
 		sendRequest(request, holder::setValue);
 		finishBatch();
-		return holder.getValue();
+		assert holder.getValue().result == SCPResult.RC_OK;
 	}
 
 	/**
@@ -607,6 +605,10 @@ public class TxrxProcess {
 		 */
 		private <T extends CheckOKResponse> Request<T> registerRequest(
 				SCPRequest<T> request, Consumer<T> callback) {
+			if (request instanceof ConnectionAwareMessage) {
+				ConnectionAwareMessage cam = (ConnectionAwareMessage) request;
+				cam.setConnection(connection);
+			}
 			synchronized (outstandingRequests) {
 				int sequence = toUnsignedInt(request.scpRequestHeader
 						.issueSequenceNumber(outstandingRequests.keySet()));

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/WriteMemoryProcess.java
@@ -34,7 +34,7 @@ import uk.ac.manchester.spinnaker.connections.SCPConnection;
 import uk.ac.manchester.spinnaker.machine.Direction;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
 import uk.ac.manchester.spinnaker.machine.MemoryLocation;
-import uk.ac.manchester.spinnaker.messages.scp.CheckOKResponse;
+import uk.ac.manchester.spinnaker.messages.scp.EmptyResponse;
 import uk.ac.manchester.spinnaker.messages.scp.SCPRequest;
 import uk.ac.manchester.spinnaker.messages.scp.WriteLink;
 import uk.ac.manchester.spinnaker.messages.scp.WriteMemory;
@@ -281,7 +281,7 @@ class WriteMemoryProcess extends TxrxProcess {
 	 * @throws InterruptedException
 	 *             If the communications were interrupted.
 	 */
-	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
+	private <T extends SCPRequest<EmptyResponse>> void writeMemoryFlow(
 			MemoryLocation baseAddress, ByteBuffer data,
 			MessageProvider<T> msgProvider)
 			throws IOException, ProcessException, InterruptedException {
@@ -313,7 +313,7 @@ class WriteMemoryProcess extends TxrxProcess {
 	 * @throws InterruptedException
 	 *             If the communications were interrupted.
 	 */
-	private <T extends SCPRequest<CheckOKResponse>> void writeMemoryFlow(
+	private <T extends SCPRequest<EmptyResponse>> void writeMemoryFlow(
 			MemoryLocation baseAddress, InputStream data, int bytesToWrite,
 			MessageProvider<T> msgProvider)
 			throws IOException, ProcessException, InterruptedException {

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestOKResponse.java
@@ -67,7 +67,7 @@ class TestOKResponse {
 		bytes.putShort(result).putShort(seq).flip();
 
 		assertNotNull(
-				new CheckOKResponse("testing operation", CMD_DPRI, bytes));
+				new EmptyResponse("testing operation", CMD_DPRI, bytes));
 	}
 
 	@Test
@@ -100,7 +100,6 @@ class TestOKResponse {
 		bytes.putShort(result).putShort(seq).flip();
 
 		assertThrows(UnexpectedResponseCodeException.class,
-				() -> new CheckOKResponse("testing operation", CMD_DPRI,
-						bytes));
+				() -> new EmptyResponse("testing operation", CMD_DPRI, bytes));
 	}
 }

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/messages/scp/TestVersion.java
@@ -75,10 +75,11 @@ class TestVersion {
 		data.flip();
 
 		var response = new GetVersion.Response(data);
-		assertEquals("sark", response.get().name);
-		assertEquals("spinnaker", response.get().hardware);
-		assertEquals(new Version(2, 34, 0), response.get().versionNumber);
-		assertEquals(new CoreLocation(14, 31, 0), response.get().core);
+		var ver = response.get();
+		assertEquals("sark", ver.name);
+		assertEquals("spinnaker", ver.hardware);
+		assertEquals(new Version(2, 34, 0), ver.versionNumber);
+		assertEquals(new CoreLocation(14, 31, 0), ver.core);
 	}
 
 	@Test


### PR DESCRIPTION
Introducing `EmptyResponse`, which lets us more clearly distinguish between messages that produce payloads in their reponse, messages that have empty payloads, and messages that don't have responses at all. This matters because they have different usage patterns.

`IPTagGet` is a special case in that making it aware of what connection it is sent on allows us to let its response produce full `Tag` instances. I'd thought that more messages would care, but it seems this isn't the case at the moment, so what I have there is slightly over-engineered.