### PR TITLE
License tweak a few more files

### DIFF
--- a/SpiNNaker-allocserv/src/main/frontend/package.json
+++ b/SpiNNaker-allocserv/src/main/frontend/package.json
@@ -2,7 +2,7 @@
 	"name": "spalloc-support",
 	"version": "0.0.1",
 	"description": "Support code for JavaSpiNNaker's Spalloc Service implementation",
-	"license": "GPL-3.0",
+	"license": "ASL-2.0",
 	"repository": "github:SpiNNakerManchester/JavaSpiNNaker",
 	"author": "Donal K. Fellows",
 	"dependencies": {

--- a/SpiNNaker-allocserv/src/main/resources-filtered/swagger.properties
+++ b/SpiNNaker-allocserv/src/main/resources-filtered/swagger.properties
@@ -16,7 +16,7 @@ title = ${project.name}
 description = ${project.description}
 version = ${project.version}
 contact = ${project.organization.name}
-license = GNU General Public License, version 3
-license.url = https://www.gnu.org/licenses/gpl-3.0.en.html
+license = Apache License, Version 2.0
+license.url = http://www.apache.org/licenses/LICENSE-2.0
 # Link to terms of service, when we define them
 # terms.url = ???

--- a/SpiNNaker-front-end/src/test/resources/uk/ac/manchester/spinnaker/front_end/iobuf/empty.aplx
+++ b/SpiNNaker-front-end/src/test/resources/uk/ac/manchester/spinnaker/front_end/iobuf/empty.aplx
@@ -1,14 +1,13 @@
 # Copyright (c) 2022 The University of Manchester
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/SpiNNaker-front-end/src/test/resources/uk/ac/manchester/spinnaker/front_end/iobuf/empty.dict
+++ b/SpiNNaker-front-end/src/test/resources/uk/ac/manchester/spinnaker/front_end/iobuf/empty.dict
@@ -1,17 +1,16 @@
 # Copyright (c) 2022 The University of Manchester
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 1,abc,-d-%d-e-%d-f-%d
 2,abc,,d,%d,e,%d,f,%d
 foo,abcde,-d-%d-e-%d-f-%d

--- a/pom.xml
+++ b/pom.xml
@@ -792,8 +792,8 @@ limitations under the License.
 	</organization>
 	<licenses>
 		<license>
-			<url>https://www.gnu.org/licenses/gpl-3.0.en.html</url>
-			<name>GNU General Public License, version 3</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<name>Apache License, Version 2.0</name>
 			<distribution>manual</distribution>
 		</license>
 	</licenses>


### PR DESCRIPTION
I'd missed some places, either because they were RAT-excluded or because they were metadata. (Split out from #726 because that's too big a change.)

As noted in #723, `CITATION.cff` has not had its metdata section updated because 6.0.0 is released under the GPL. We will need to fix when 7 goes out, but can't until we have the DOI.