### PR TITLE
github.io links can (and should) be https

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ message: If you use this software, please cite it as below.
 title: Java host code for working with SpiNNaker machines.
 repository-code: https://github.com/SpiNNakerManchester/JavaSpiNNaker
 version: 6.0.0
-url: http://spinnakermanchester.github.io/
+url: https://spinnakermanchester.github.io/
 license: GPL-3.0-or-later
 date-released: 2021-04-09
 identifier: JavaSpiNNaker

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ This option says where to find the built version of JavaSpiNNaker. If you have f
 [Spalloc Server](https://github.com/SpiNNakerManchester/JavaSpiNNaker/tree/master/SpiNNaker-allocserv) is its own sub-project.
 
 # Documentation
-[API documentation](http://spinnakermanchester.github.io/JavaSpiNNaker/apidocs/) (Javadoc)
+[API documentation](https://spinnakermanchester.github.io/JavaSpiNNaker/apidocs/) (Javadoc)
 <br>
-[Maven metadata](http://spinnakermanchester.github.io/JavaSpiNNaker/)
+[Maven metadata](https://spinnakermanchester.github.io/JavaSpiNNaker/)

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGA.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/model/FPGA.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.spinnaker.messages.model;
  * Identifiers for the FPGAs on a SpiNNaker board, as managed by BMP.
  * <p>
  * SpiNNaker FPGA identifiers, taken from the
- * <a href="http://spinnakermanchester.github.io/docs/spin5-links.pdf">SpiNN-5
+ * <a href="https://spinnakermanchester.github.io/docs/spin5-links.pdf">SpiNN-5
  * FPGA SATA Links</a> datasheet.
  */
 public enum FPGA {

--- a/pom.xml
+++ b/pom.xml
@@ -785,7 +785,7 @@ limitations under the License.
 	<name>SpiNNaker Java Host</name>
 	<description>Implementation of the host software for SpiNNaker in Java.</description>
 	<inceptionYear>2018</inceptionYear>
-	<url>http://spinnakermanchester.github.io/</url>
+	<url>https://spinnakermanchester.github.io/</url>
 	<organization>
 		<name>SpiNNaker Team @ University of Manchester</name>
 		<url>http://apt.cs.manchester.ac.uk/projects/SpiNNaker/</url>
@@ -818,7 +818,7 @@ limitations under the License.
 		<site>
 			<id>github-pages</id>
 			<name>GitHub Pages</name>
-			<url>http://spinnakermanchester.github.io/JavaSpiNNaker</url>
+			<url>https://spinnakermanchester.github.io/JavaSpiNNaker</url>
 		</site>
 	</distributionManagement>
 	<mailingLists>


### PR DESCRIPTION
No idea when this was switched on for all content, but it was probably always more hassle for Github staff to have turned off than on.