### PR TITLE
Tidy up now we use MySQL

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
@@ -503,13 +503,13 @@ public class MachineStateControl extends DatabaseAwareBean {
 
 	private boolean changed(Connection conn, int boardId) {
 		try (var synched = conn.update(MARK_BOARD_BLACKLIST_CHANGED)) {
-			return synched.call(Instant.now(), boardId) > 0;
+			return synched.call(boardId) > 0;
 		}
 	}
 
 	private boolean synched(Connection conn, int boardId) {
 		try (var synched = conn.update(MARK_BOARD_BLACKLIST_SYNCHED)) {
-			return synched.call(Instant.now(), boardId) > 0;
+			return synched.call(boardId) > 0;
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/UserControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/UserControl.java
@@ -174,9 +174,10 @@ public class UserControl extends DatabaseAwareBean {
 	}
 
 	private final class UpdatePassSQL extends UserCheckSQL {
-		private Query getPasswordedUser = conn.query(GET_LOCAL_USER_DETAILS);
+		private final Query getPasswordedUser =
+				conn.query(GET_LOCAL_USER_DETAILS);
 
-		private Update setPassword = conn.update(SET_USER_PASS);
+		private final Update setPassword = conn.update(SET_USER_PASS);
 
 		@Override
 		public void close() {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -142,11 +142,12 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 	}
 
 	private final class ListMachinesSQL extends AbstractSQL {
-		private Query listMachines = conn.query(GET_ALL_MACHINES);
+		private final Query listMachines = conn.query(GET_ALL_MACHINES);
 
-		private Query countMachineThings = conn.query(COUNT_MACHINE_THINGS);
+		private final Query countMachineThings =
+				conn.query(COUNT_MACHINE_THINGS);
 
-		private Query getTags = conn.query(GET_TAGS);
+		private final Query getTags = conn.query(GET_TAGS);
 
 		@Override
 		public void close() {
@@ -629,8 +630,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 	private static Optional<Integer> insertJob(Connection conn, MachineImpl m,
 			int owner, int group, Duration keepaliveInterval, byte[] req) {
 		try (var makeJob = conn.update(INSERT_JOB)) {
-			return makeJob.key(m.id, owner, group, keepaliveInterval, req,
-					Instant.now(), Instant.now());
+			return makeJob.key(m.id, owner, group, keepaliveInterval, req);
 		}
 	}
 
@@ -721,7 +721,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		int userId = getUser(sql.getConnection(), permit.name).orElseThrow(
 				() -> new ReportRollbackExn("no such user: %s", permit.name));
 		sql.insertReport.key(problem.boardId, problem.jobId,
-				description, userId, Instant.now()).ifPresent(email::issue);
+				description, userId).ifPresent(email::issue);
 		return takeBoardsOutOfService(sql, email).map(acted -> {
 			email.footer(acted);
 			return email;
@@ -1259,8 +1259,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			}
 			try (var conn = getConnection();
 					var keepAlive = conn.update(UPDATE_KEEPALIVE)) {
-				conn.transaction(() -> keepAlive.call(Instant.now(),
-						keepaliveAddress, id));
+				conn.transaction(() -> keepAlive.call(keepaliveAddress, id));
 			}
 		}
 
@@ -1485,7 +1484,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		 */
 		private void addIssueReport(BoardReportSQL u, int boardId, String issue,
 				int userId, EmailBuilder email) {
-			u.insertReport.key(boardId, id, issue, userId, Instant.now())
+			u.insertReport.key(boardId, id, issue, userId)
 					.ifPresent(email::issue);
 		}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -41,7 +41,6 @@ import static uk.ac.manchester.spinnaker.utils.CollectionUtils.curry;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
@@ -155,13 +154,15 @@ public class BMPController extends DatabaseAwareBean {
 
 	private final ThreadGroup group = new ThreadGroup("BMP workers");
 
-	private Deque<Function<AfterSQL, Boolean>> cleanupTasks =
+	private final Deque<Function<AfterSQL, Boolean>> cleanupTasks =
 			new ConcurrentLinkedDeque<>();
 
-	private Deque<Runnable> postCleanupTasks = new ConcurrentLinkedDeque<>();
+	private final Deque<Runnable> postCleanupTasks =
+			new ConcurrentLinkedDeque<>();
 
 	/** We have our own pool. */
-	private ExecutorService executor = newCachedThreadPool(this::makeThread);
+	private final ExecutorService executor =
+			newCachedThreadPool(this::makeThread);
 
 	@GuardedBy("this")
 	private Throwable bmpProcessingException;
@@ -1104,7 +1105,7 @@ public class BMPController extends DatabaseAwareBean {
 				// The outer loop is always over a small set, fortunately
 				for (var machine : machines) {
 					stream(sql.getJobIdsWithChanges.call(integer("job_id"),
-							machine.getId(), Instant.now()))
+							machine.getId()))
 							.filter(jobId -> !busyJobs.contains(jobId))
 							.forEach(jobId -> takeRequestsForJob(machine, jobId,
 									sql, requestCollector));
@@ -1304,16 +1305,16 @@ public class BMPController extends DatabaseAwareBean {
 		// What follows are type-safe wrappers
 
 		int setBoardPowerOn(Integer boardId) {
-			return setBoardPowerOn.call(Instant.now(), boardId);
+			return setBoardPowerOn.call(boardId);
 		}
 
 		int setBoardPowerOff(Integer boardId) {
-			return setBoardPowerOff.call(Instant.now(), boardId);
+			return setBoardPowerOff.call(boardId);
 		}
 
 		int setJobState(JobState state, int pending, Integer jobId) {
 			if (state == JobState.DESTROYED) {
-				return setJobDestroyed.call(pending, Instant.now(), jobId);
+				return setJobDestroyed.call(pending, jobId);
 			}
 			return setJobState.call(state, pending, jobId);
 		}
@@ -1358,8 +1359,8 @@ public class BMPController extends DatabaseAwareBean {
 
 		int insertBoardReport(
 				int boardId, Integer jobId, String issue, int userId) {
-			return insertBoardReport.key(boardId, jobId, issue, userId,
-					Instant.now()).orElseThrow();
+			return insertBoardReport.key(boardId, jobId, issue, userId)
+					.orElseThrow();
 		}
 
 		int markBoardAsDead(Integer boardId) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/FirmwareLoader.java
@@ -663,13 +663,13 @@ class FirmwareDefinition {
 	List<String> bitfileNames;
 
 	/** Where to load each of the bitfiles from. */
-	private Map<String, Resource> bitFiles = new HashMap<>();
+	private final Map<String, Resource> bitFiles = new HashMap<>();
 
 	/**
 	 * What the intended modification time of each of the bitfiles is. From the
 	 * manifest, because actual file modification times are broken.
 	 */
-	private Map<String, Integer> modTimes = new HashMap<>();
+	private final Map<String, Integer> modTimes = new HashMap<>();
 
 	@PostConstruct
 	private void loadManifest() throws IOException {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/PhysicalSerialMapping.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/PhysicalSerialMapping.java
@@ -52,9 +52,9 @@ class PhysicalSerialMapping {
 	@Value("classpath:blacklists/spin5-serial.txt")
 	private Resource spin5serialFile;
 
-	private Map<String, String> physicalToLogical = new HashMap<>();
+	private final Map<String, String> physicalToLogical = new HashMap<>();
 
-	private Map<String, String> logicalToPhysical = new HashMap<>();
+	private final Map<String, String> logicalToPhysical = new HashMap<>();
 
 	@PostConstruct
 	void loadMapping() throws IOException {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1TaskImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1TaskImpl.java
@@ -237,14 +237,14 @@ class V1TaskImpl extends V1CompatTask {
 	@Override
 	protected final Optional<Integer> createJobNumBoards(int numBoards,
 			Map<String, Object> kwargs, byte[] cmd) throws TaskException {
-		Integer maxDead = parseDec(kwargs.get("max_dead_boards"));
+		var maxDead = parseDec(kwargs.get("max_dead_boards"));
 		return createJob(new CreateNumBoards(numBoards, maxDead), kwargs, cmd);
 	}
 
 	@Override
 	protected final Optional<Integer> createJobRectangle(int width, int height,
 			Map<String, Object> kwargs, byte[] cmd) throws TaskException {
-		Integer maxDead = parseDec(kwargs.get("max_dead_boards"));
+		var maxDead = parseDec(kwargs.get("max_dead_boards"));
 		return createJob(new CreateDimensions(width, height, maxDead), kwargs,
 				cmd);
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseAPI.java
@@ -566,7 +566,7 @@ public interface DatabaseAPI {
 		 * @throws DataAccessException
 		 *             If the statement is invalid SQL.
 		 */
-		List<String> getResultSetColumnNames() throws DataAccessException;
+		List<String> getColumns() throws DataAccessException;
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseAPI.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.core.io.Resource;
+import org.springframework.dao.DataAccessException;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.google.errorprone.annotations.MustBeClosed;
@@ -508,12 +509,20 @@ public interface DatabaseAPI {
 	 * @author Donal Fellows
 	 */
 	interface StatementCommon extends AutoCloseable {
-
 		/**
 		 * Close this statement. This never throws a checked exception.
 		 */
 		@Override
 		void close();
+
+		/**
+		 * Get the list of parameters to the statement. This may be an expensive
+		 * operation.
+		 *
+		 * @return List of parameter names. Unnamed parameters <em>may</em> be
+		 *         mapped as {@code null}.
+		 */
+		List<String> getParameters();
 	}
 
 	/**
@@ -522,7 +531,6 @@ public interface DatabaseAPI {
 	 * @author Donal Fellows
 	 */
 	interface Query extends StatementCommon {
-
 		/**
 		 * Run the query on the given arguments to read a list of objects.
 		 *
@@ -546,6 +554,19 @@ public interface DatabaseAPI {
 		 * @return The resulting object.
 		 */
 		<T> Optional<T> call1(RowMapper<T> mapper, Object... arguments);
+
+		/**
+		 * Get the column names from the result set. This may be an expensive
+		 * operation.
+		 *
+		 * @return The list of column names. The names of columns where they are
+		 *         not assigned by the query is arbitrary and up to the database
+		 *         engine. This will be {@code null} if the manipulation of
+		 *         metadata fails; this isn't expected.
+		 * @throws DataAccessException
+		 *             If the statement is invalid SQL.
+		 */
+		List<String> getResultSetColumnNames() throws DataAccessException;
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseCache.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseCache.java
@@ -45,10 +45,10 @@ import org.springframework.dao.DataAccessResourceFailureException;
 abstract class DatabaseCache<Conn extends Connection> {
 	private static final Logger log = getLogger(DatabaseCache.class);
 
-	private ThreadLocal<Conn> connectionCache =
+	private final ThreadLocal<Conn> connectionCache =
 			withInitial(this::generateCachedDatabaseConnection);
 
-	private List<CloserThread> closerThreads =
+	private final List<CloserThread> closerThreads =
 			synchronizedList(new ArrayList<>());
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseEngineJDBCImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/DatabaseEngineJDBCImpl.java
@@ -342,7 +342,7 @@ public class DatabaseEngineJDBCImpl implements DatabaseAPI {
 		}
 
 		@Override
-		public List<String> getResultSetColumnNames() {
+		public List<String> getColumns() {
 			return jdbcTemplate.execute(sql,
 					(PreparedStatementCallback<List<String>>) ps -> {
 						var md = ps.getMetaData();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -238,6 +238,8 @@ public abstract class SQLQueries {
 	@Parameter("group_id")
 	@Parameter("keepalive_interval")
 	@Parameter("original_request")
+	@Parameter("keepalive_timestamp")
+	@Parameter("create_timestamp")
 	@GeneratesID
 	protected static final String INSERT_JOB = "INSERT INTO jobs("
 			+ "machine_id, owner, group_id, keepalive_interval, "
@@ -478,6 +480,7 @@ public abstract class SQLQueries {
 			"SELECT tag FROM tags WHERE machine_id = :machine_id";
 
 	/** Update the keepalive timestamp. */
+	@Parameter("keepalive_timestamp")
 	@Parameter("keepalive_host")
 	@Parameter("job_id")
 	protected static final String UPDATE_KEEPALIVE =
@@ -673,7 +676,6 @@ public abstract class SQLQueries {
 	 * Set the power state of a board. Related timestamps are updated by
 	 * trigger.
 	 */
-	@Parameter("board_power")
 	@Parameter("time_now")
 	@Parameter("board_id")
 	protected static final String SET_BOARD_POWER_OFF =
@@ -1135,8 +1137,6 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("delta")
 	@Parameter("group_id")
-	@ResultColumn("group_name")
-	@ResultColumn("quota")
 	protected static final String ADJUST_QUOTA =
 			"UPDATE user_groups SET quota = GREATEST(0, quota + :delta) "
 					+ "WHERE group_id = :group_id AND quota IS NOT NULL";
@@ -1496,6 +1496,7 @@ public abstract class SQLQueries {
 	 *
 	 * @see LocalAuthProviderImpl
 	 */
+	@Parameter("login_timestamp")
 	@Parameter("openid_subject")
 	@Parameter("user_id")
 	protected static final String MARK_LOGIN_SUCCESS =
@@ -1511,12 +1512,10 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("failure_limit")
 	@Parameter("user_id")
-	@ResultColumn("locked")
-	@SingleRowResult
+	@Parameter("timestamp_now")
 	protected static final String MARK_LOGIN_FAILURE =
 			"UPDATE user_info SET failure_count = failure_count + 1, "
-					+ "last_fail_timestamp = "
-					+ ":login_timestamp, "
+					+ "last_fail_timestamp = :login_timestamp, "
 					+ "locked = (failure_count + 1 >= :failure_limit) "
 					+ "WHERE user_id = :user_id";
 
@@ -1526,7 +1525,7 @@ public abstract class SQLQueries {
 	 * @see LocalAuthProviderImpl
 	 */
 	@Parameter("lock_interval")
-	@ResultColumn("user_name")
+	@Parameter("timestamp_now")
 	protected static final String UNLOCK_LOCKED_USERS =
 			"UPDATE user_info SET failure_count = 0, last_fail_timestamp = 0, "
 					+ "locked = 0 WHERE last_fail_timestamp + :lock_interval "
@@ -1805,6 +1804,7 @@ public abstract class SQLQueries {
 	 *
 	 * @see MachineStateControl
 	 */
+	@Parameter("timestamp_now")
 	@Parameter("board_id")
 	protected static final String MARK_BOARD_BLACKLIST_CHANGED =
 			"UPDATE boards SET blacklist_set_timestamp = "
@@ -1816,6 +1816,7 @@ public abstract class SQLQueries {
 	 *
 	 * @see MachineStateControl
 	 */
+	@Parameter("timestamp_now")
 	@Parameter("board_id")
 	protected static final String MARK_BOARD_BLACKLIST_SYNCHED =
 			"UPDATE boards SET blacklist_sync_timestamp = "

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -565,8 +565,8 @@ public abstract class SQLQueries {
 	@ResultColumn("board_id")
 	@ResultColumn("report_id")
 	@ResultColumn("reported_issue")
-	@ResultColumn("reporter_name")
 	@ResultColumn("report_timestamp")
+	@ResultColumn("reporter_name")
 	protected static final String GET_MACHINE_REPORTS =
 			"SELECT board_id, report_id, reported_issue, report_timestamp, "
 					+ "user_name AS reporter_name "
@@ -584,8 +584,8 @@ public abstract class SQLQueries {
 	@ResultColumn("board_id")
 	@ResultColumn("report_id")
 	@ResultColumn("reported_issue")
-	@ResultColumn("reporter_name")
 	@ResultColumn("report_timestamp")
+	@ResultColumn("reporter_name")
 	protected static final String GET_BOARD_REPORTS =
 			"SELECT board_id, report_id, reported_issue, report_timestamp, "
 					+ "user_name AS reporter_name "

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -490,6 +490,7 @@ public abstract class SQLQueries {
 
 	/** Mark a job as dead. */
 	@Parameter("death_reason")
+	@Parameter("timestamp")
 	@Parameter("job_id")
 	protected static final String DESTROY_JOB =
 			"UPDATE jobs SET job_state = 4, death_reason = :death_reason, "
@@ -688,6 +689,7 @@ public abstract class SQLQueries {
 	 *
 	 * @see AllocatorTask
 	 */
+	@Parameter("time_now")
 	@ResultColumn("job_id")
 	protected static final String FIND_EXPIRED_JOBS = //
 			"SELECT job_id FROM jobs " //
@@ -2172,7 +2174,7 @@ public abstract class SQLQueries {
 	@Parameter("alloc_id")
 	@Parameter("job_id")
 	@Parameter("board_id")
-	@Parameter("alloc_timestamp")
+	@Parameter("allocation_timestamp")
 	protected static final String WRITE_HISTORICAL_ALLOCS =
 			"INSERT IGNORE INTO board_allocations( "
 			+ "alloc_id, job_id, board_id, allocation_timestamp) "
@@ -2188,7 +2190,7 @@ public abstract class SQLQueries {
 	@Parameter("width")
 	@Parameter("height")
 	@Parameter("depth")
-	@Parameter("allocated_root")
+	@Parameter("root_id")
 	@Parameter("keepalive_interval")
 	@Parameter("keepalive_host")
 	@Parameter("death_reason")
@@ -2279,11 +2281,11 @@ public abstract class SQLQueries {
 	@Parameter("to_state")
 	@Parameter("power")
 	@Parameter("fpga_n")
-	@Parameter("fpga_s")
 	@Parameter("fpga_e")
+	@Parameter("fpga_se")
+	@Parameter("fpga_s")
 	@Parameter("fpga_w")
 	@Parameter("fpga_nw")
-	@Parameter("fpga_se")
 	@GeneratesID
 	@Value("classpath:queries/issue_change_for_job.sql")
 	protected Resource issueChangeForJob;
@@ -2330,8 +2332,8 @@ public abstract class SQLQueries {
 	 * @see Spalloc
 	 */
 	@Parameter("machine_id")
-	@Parameter("chip_x")
-	@Parameter("chip_y")
+	@Parameter("x")
+	@Parameter("y")
 	@ResultColumn("board_id")
 	@ResultColumn("address")
 	@ResultColumn("bmp_id")
@@ -2360,9 +2362,9 @@ public abstract class SQLQueries {
 	 * @see Spalloc
 	 */
 	@Parameter("job_id")
-	@Parameter("root_board_id")
-	@Parameter("chip_x")
-	@Parameter("chip_y")
+	@Parameter("board_id")
+	@Parameter("x")
+	@Parameter("y")
 	@ResultColumn("board_id")
 	@ResultColumn("address")
 	@ResultColumn("x")

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -2199,7 +2199,7 @@ public abstract class SQLQueries {
 	@Parameter("allocation_timestamp")
 	@Parameter("allocation_size")
 	@Parameter("machine_name")
-	@Parameter("user_name")
+	@Parameter("owner_name")
 	@Parameter("group_id")
 	@Parameter("group_name")
 	protected static final String WRITE_HISTORICAL_JOBS =

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/proxy/SpinWSHandler.java
@@ -79,7 +79,7 @@ public class SpinWSHandler extends BinaryWebSocketHandler
 
 	private ExecutorService executor;
 
-	private ConnectionIDIssuer idIssuer = new ConnectionIDIssuer();
+	private final ConnectionIDIssuer idIssuer = new ConnectionIDIssuer();
 
 	SpinWSHandler() {
 		var group = new ThreadGroup("ws/udp workers");

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/LocalAuthProviderImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/LocalAuthProviderImpl.java
@@ -32,7 +32,6 @@ import static uk.ac.manchester.spinnaker.alloc.security.TrustLevel.ADMIN;
 import static uk.ac.manchester.spinnaker.alloc.security.TrustLevel.USER;
 import static uk.ac.manchester.spinnaker.utils.OptionalUtils.ifElse;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -568,7 +567,7 @@ public class LocalAuthProviderImpl extends DatabaseAwareBean
 		 *            Who logged in?
 		 */
 		void noteLoginSuccessForUser(int userId) {
-			if (loginSuccess.call(Instant.now(), null, userId) != 1) {
+			if (loginSuccess.call(null, userId) != 1) {
 				log.warn("failed to note success for user {}", userId);
 			}
 		}
@@ -583,7 +582,7 @@ public class LocalAuthProviderImpl extends DatabaseAwareBean
 		 *            What is their OpenID {@code sub} (subject) claim?
 		 */
 		void noteLoginSuccessForUser(int userId, String subject) {
-			if (loginSuccess.call(Instant.now(), subject, userId) != 1) {
+			if (loginSuccess.call(subject, userId) != 1) {
 				log.warn("failed to note success for user {}", userId);
 			}
 		}
@@ -599,12 +598,12 @@ public class LocalAuthProviderImpl extends DatabaseAwareBean
 		 *            gets a temporary lock applied.
 		 */
 		void noteLoginFailureForUser(int userId, String username) {
-			loginFailure.call(Instant.now(), authProps.getMaxLoginFailures(),
-					userId);
+			loginFailure.call(authProps.getMaxLoginFailures(), userId);
+			// TODO check if that locked; MySQL doesn't have RETURNING clauses
 		}
 
 		void unlock() {
-			unlock.call(authProps.getAccountLockDuration(), Instant.now());
+			unlock.call(authProps.getAccountLockDuration());
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/SecurityConfig.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/security/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
 
 	private static final ParameterizedTypeReference<
 			Map<String, Object>> PARAMETERIZED_RESPONSE_TYPE =
-					new ParameterizedTypeReference<Map<String, Object>>() {
+					new ParameterizedTypeReference<>() {
 					};
 
 	private static final MediaType DEFAULT_CONTENT_TYPE = MediaType

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/JobStateResponse.java
@@ -25,7 +25,6 @@ import static uk.ac.manchester.spinnaker.alloc.web.WebServiceComponentNames.JOB_
 import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
-import java.util.Optional;
 
 import javax.ws.rs.core.UriInfo;
 
@@ -97,7 +96,7 @@ public class JobStateResponse {
 
 	private static CreateJobRequest origRequest(JsonMapper mapper, Job job) {
 		try {
-			Optional<byte[]> data = job.getOriginalRequest();
+			var data = job.getOriginalRequest();
 			if (!data.isPresent()) {
 				return null;
 			}

--- a/SpiNNaker-allocserv/src/main/resources/queries/get_jobs_with_changes.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/get_jobs_with_changes.sql
@@ -15,7 +15,7 @@
 WITH
 	-- Arguments and current timestamp
 	args(machine_id, now) AS (
-		SELECT :machine_id, :time_now),
+		SELECT :machine_id, UNIX_TIMESTAMP()),
 	-- The machine on which we are allocating
 	m AS (SELECT machines.* FROM machines JOIN args USING (machine_id) LIMIT 1),
 	-- The set of boards that are "busy" settling after changing state

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -35,6 +35,7 @@ import static uk.ac.manchester.spinnaker.alloc.model.GroupRecord.GroupType.INTER
 import static uk.ac.manchester.spinnaker.alloc.model.JobState.UNKNOWN;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -68,6 +69,11 @@ class DMLTest extends SimpleDBTestBase {
 		var d = Duration.ofSeconds(100);
 		try (var u = c.update(INSERT_JOB)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("machine_id", "user_id", "group_id",
+								"keepalive_interval", "original_request",
+								"keepalive_timestamp", "create_timestamp"),
+						u.getParameters());
 				// No such machine
 				assertThrowsFK(() -> u.call(NO_MACHINE, NO_USER, NO_GROUP, d,
 						new byte[0], 0, 0));
@@ -80,6 +86,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_REQ_N_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id", "num_boards", "max_dead_boards",
+						"priority"), u.getParameters());
 				// No such job
 				assertThrowsFK(() -> u.call(NO_JOB, 1, 0, 0));
 				assertThrowsCheck(() -> u.call(NO_JOB, -1, 0, 0));
@@ -92,6 +100,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_REQ_SIZE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id", "width", "height",
+						"max_dead_boards", "priority"), u.getParameters());
 				// No such job
 				assertThrowsFK(() -> u.call(NO_JOB, 1, 1, 0, 0));
 				assertThrowsCheck(() -> u.call(NO_JOB, -1, -1, 0, 0));
@@ -104,6 +114,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_REQ_SIZE_BOARD)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("job_id", "board_id", "width", "height",
+								"max_dead_boards", "priority"),
+						u.getParameters());
 				// No such job
 				assertThrowsFK(() -> u.call(NO_JOB, NO_BOARD, 1, 1, 0, 0));
 				assertThrowsCheck(() -> u.call(NO_JOB, NO_BOARD, -1, -1, 0, 0));
@@ -117,6 +131,8 @@ class DMLTest extends SimpleDBTestBase {
 		try (var u = c.update(INSERT_REQ_BOARD)) {
 			c.transaction(() -> {
 				// No such job or board
+				assertEquals(List.of("job_id", "board_id", "priority"),
+						u.getParameters());
 				assertThrowsFK(() -> u.call(NO_JOB, NO_BOARD, 0));
 			});
 		}
@@ -127,6 +143,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(UPDATE_KEEPALIVE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("keepalive_timestamp", "keepalive_host",
+						"job_id"), u.getParameters());
 				assertEquals(0, u.call(0, NO_NAME, NO_JOB));
 			});
 		}
@@ -137,6 +155,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DESTROY_JOB)) {
 			c.transaction(() -> {
+				assertEquals(List.of("death_reason", "job_id"),
+						u.getParameters());
 				assertEquals(0, u.call("anything", 0, NO_JOB));
 			});
 		}
@@ -147,6 +167,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_TASK)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -157,6 +178,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ALLOCATE_BOARDS_JOB)) {
 			c.transaction(() -> {
+				assertEquals(List.of("width", "height", "depth", "board_id",
+						"num_boards", "time_now", "allocated_board_id",
+						"job_id"), u.getParameters());
 				assertEquals(0, u.call(-1, -1, -1, NO_BOARD, 0, 0, NO_BOARD,
 						NO_JOB));
 			});
@@ -168,6 +192,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DEALLOCATE_BOARDS_JOB)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -178,6 +203,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ALLOCATE_BOARDS_BOARD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id", "board_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB, NO_BOARD));
 			});
 		}
@@ -188,6 +214,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_STATE_PENDING)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_state", "num_pending", "job_id"),
+						u.getParameters());
 				assertEquals(0, u.call(JobState.UNKNOWN, 0, NO_JOB));
 			});
 		}
@@ -198,6 +226,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_STATE_DESTROYED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("num_pending", "time_now", "job_id"),
+						u.getParameters());
 				assertEquals(0, u.call(0, 0, NO_JOB));
 			});
 		}
@@ -208,6 +238,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(BUMP_IMPORTANCE)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), u.getParameters());
 				// table should be empty
 				assertEquals(0, u.call());
 			});
@@ -219,6 +250,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(KILL_JOB_ALLOC_TASK)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -229,6 +261,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(KILL_JOB_PENDING)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -239,6 +272,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_IN_PROGRESS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("in_progress", "change_id"),
+						u.getParameters());
 				assertEquals(0, u.call(false, NO_JOB));
 			});
 		}
@@ -249,6 +284,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(issueChangeForJob)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id", "board_id", "from_state",
+						"to_state", "power", "fpga_n", "fpga_s", "fpga_e",
+						"fpga_w", "fpga_nw", "fpga_se"), u.getParameters());
 				// No such job
 				assertThrowsFK(() -> u.call(NO_JOB, NO_BOARD, UNKNOWN, UNKNOWN,
 						true, false, false, false, false, false, false));
@@ -261,6 +299,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_BOARD_POWER_ON)) {
 			c.transaction(() -> {
+				assertEquals(List.of("time_now", "board_id"),
+						u.getParameters());
 				assertEquals(0, u.call(0, NO_BOARD));
 			});
 		}
@@ -271,6 +311,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_BOARD_POWER_OFF)) {
 			c.transaction(() -> {
+				assertEquals(List.of("time_now", "board_id"),
+						u.getParameters());
 				assertEquals(0, u.call(0, NO_BOARD));
 			});
 		}
@@ -281,6 +323,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(FINISHED_PENDING)) {
 			c.transaction(() -> {
+				assertEquals(List.of("change_id"), u.getParameters());
 				assertEquals(0, u.call(NO_CHANGE));
 			});
 		}
@@ -291,6 +334,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_MACHINE_SPINN_5)) {
 			c.transaction(() -> {
+				assertEquals(List.of("name", "width", "height", "depth"),
+						u.getParameters());
 				// Bad depth
 				assertThrowsCheck(() -> u.call(NO_NAME, -1, -1, -1));
 			});
@@ -302,6 +347,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_TAG)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "tag"), u.getParameters());
 				// No machine
 				assertThrowsFK(() -> u.call(NO_MACHINE, NO_NAME));
 			});
@@ -313,6 +359,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_MACHINE_TAGS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), u.getParameters());
 				// No machine, no tags for it
 				assertEquals(0, u.call(NO_MACHINE));
 			});
@@ -324,6 +371,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_BMP)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("machine_id", "address", "cabinet", "frame"),
+						u.getParameters());
 				// No machine
 				assertThrowsFK(() -> u.call(NO_MACHINE, NO_NAME, 0, 0));
 			});
@@ -335,6 +385,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_BOARD)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("machine_id", "address", "bmp_id", "board_num",
+								"x", "y", "z", "root_x", "root_y", "enabled"),
+						u.getParameters());
 				// No machine
 				assertThrowsFK(() -> u.call(NO_MACHINE, NO_NAME, NO_BMP, 0, 0,
 						0, 0, 0, 0, true));
@@ -346,10 +400,13 @@ class DMLTest extends SimpleDBTestBase {
 	void insertLink() {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_LINK)) {
-			c.transaction(() ->
+			c.transaction(() -> {
+				assertEquals(
+						List.of("board_1", "dir_1", "board_2", "dir_2", "live"),
+						u.getParameters());
 				// No board, but no failure because "IGNORE"
-				u.call(NO_BOARD, Direction.N, NO_BOARD,
-						Direction.S, false));
+				u.call(NO_BOARD, Direction.N, NO_BOARD, Direction.S, false);
+			});
 		}
 	}
 
@@ -358,6 +415,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_MAX_COORDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("max_x", "max_y", "machine_id"),
+						u.getParameters());
 				// No machine
 				assertEquals(0, u.call(0, 0, NO_MACHINE));
 			});
@@ -369,6 +428,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_MACHINE_STATE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("in_service", "machine_name"),
+						u.getParameters());
 				// No machine
 				assertEquals(0, u.call(true, NO_NAME));
 			});
@@ -380,6 +441,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_FUNCTIONING_FIELD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("enabled", "board_id"), u.getParameters());
 				assertEquals(0, u.call(false, NO_BOARD));
 			});
 		}
@@ -390,7 +452,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DECREMENT_QUOTA)) {
 			c.transaction(() -> {
-				assertEquals(0, u.call(0, NO_USER)); // really quota_id
+				assertEquals(List.of("usage", "group_id"), u.getParameters());
+				assertEquals(0, u.call(0, NO_GROUP)); // really quota_id
 			});
 		}
 	}
@@ -400,6 +463,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_CONSOLIDATED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -410,6 +474,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ADJUST_QUOTA)) {
 			c.transaction(() -> {
+				assertEquals(List.of("delta", "group_id"), u.getParameters());
 				assertEquals(0, u.call(0, NO_GROUP));
 			});
 		}
@@ -420,6 +485,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_LOGIN_SUCCESS)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("login_timestamp", "openid_subject", "user_id"),
+						u.getParameters());
 				assertEquals(0, u.call(0, NO_NAME, NO_USER));
 			});
 		}
@@ -428,9 +496,11 @@ class DMLTest extends SimpleDBTestBase {
 	@Test
 	void markLoginFailure() {
 		assumeWritable(c);
-		// Tricky! Has a RETURNING clause
 		try (var u = c.update(MARK_LOGIN_FAILURE)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("login_timestamp", "failure_limit", "user_id"),
+						u.getParameters());
 				assertEquals(0, u.call(0, 0, NO_USER));
 			});
 		}
@@ -439,9 +509,10 @@ class DMLTest extends SimpleDBTestBase {
 	@Test
 	void unlockLockedUsers() {
 		assumeWritable(c);
-		// Tricky! Has a RETURNING clause
 		try (var u = c.update(UNLOCK_LOCKED_USERS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("lock_interval", "timestamp_now"),
+						u.getParameters());
 				assertEquals(0, u.call(Duration.ofDays(1000), 0));
 			});
 		}
@@ -452,6 +523,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_USER)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id"), u.getParameters());
 				assertEquals(0, u.call(NO_USER));
 			});
 		}
@@ -462,6 +534,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_USER_TRUST)) {
 			c.transaction(() -> {
+				assertEquals(List.of("trust", "user_id"), u.getParameters());
 				assertEquals(0, u.call(TrustLevel.BASIC, NO_USER));
 			});
 		}
@@ -472,6 +545,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_USER_LOCKED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("locked", "user_id"), u.getParameters());
 				assertEquals(0, u.call(false, NO_USER));
 			});
 		}
@@ -482,6 +556,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_USER_DISABLED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("disabled", "user_id"), u.getParameters());
 				assertEquals(0, u.call(false, NO_USER));
 			});
 		}
@@ -492,6 +567,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_USER_PASS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("password", "user_id"), u.getParameters());
 				assertEquals(0, u.call("*", NO_USER));
 			});
 		}
@@ -502,6 +578,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_USER_NAME)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name", "user_id"),
+						u.getParameters());
 				assertEquals(0, u.call(NO_NAME, NO_USER));
 			});
 		}
@@ -512,6 +590,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CREATE_USER)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("user_name", "encoded_password", "trust_level",
+								"disabled", "openid_subject"),
+						u.getParameters());
 				// DB was userless; this makes one
 				assertEquals(1,
 						u.call(NO_NAME, "*", TrustLevel.BASIC, true, NO_NAME));
@@ -524,6 +606,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CREATE_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_name", "quota", "group_type"),
+						u.getParameters());
 				// DB was groupless; this makes one
 				assertEquals(1, u.call(NO_NAME, 0, 0));
 			});
@@ -535,6 +619,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CREATE_GROUP_IF_NOT_EXISTS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_name", "quota", "group_type"),
+						u.getParameters());
 				// DB was groupless; this makes one
 				assertEquals(1, u.call(NO_NAME, 0, 0));
 				// Second time does NOT create a group
@@ -548,6 +634,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(UPDATE_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_name", "quota", "group_id"),
+						u.getParameters());
 				assertEquals(0, u.call(NO_NAME, 0, NO_GROUP));
 			});
 		}
@@ -558,6 +646,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_id"), u.getParameters());
 				assertEquals(0, u.call(NO_GROUP));
 			});
 		}
@@ -568,6 +657,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ADD_USER_TO_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id", "group_id"), u.getParameters());
 				// Can't do this; neither exists
 				assertThrowsFK(() -> u.call(NO_USER, NO_GROUP));
 			});
@@ -579,6 +669,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(REMOVE_USER_FROM_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id", "group_id"), u.getParameters());
 				assertEquals(0, u.call(NO_USER, NO_GROUP));
 			});
 		}
@@ -589,15 +680,21 @@ class DMLTest extends SimpleDBTestBase {
 		// Compound test: these statements are designed to be used together
 		assumeWritable(c);
 		try (var u1 = c.update(GROUP_SYNC_MAKE_TEMP_TABLE)) {
+			assertEquals(List.of(), u1.getParameters());
 			c.transaction(() -> {
 				u1.call();
 				try (var u2 = c.update(GROUP_SYNC_INSERT_TEMP_ROW);
 						var u3 = c.update(GROUP_SYNC_ADD_GROUPS);
 						var u4 = c.update(GROUP_SYNC_REMOVE_GROUPS);
 						var u5 = c.update(GROUP_SYNC_DROP_TEMP_TABLE)) {
+					assertEquals(List.of("group_name", "group_type"),
+							u2.getParameters());
 					assertEquals(0, u2.call(NO_NAME, INTERNAL));
+					assertEquals(List.of("user_id"), u3.getParameters());
 					assertEquals(0, u3.call(NO_USER));
+					assertEquals(List.of("user_id"), u4.getParameters());
 					assertEquals(0, u4.call(NO_USER));
+					assertEquals(List.of(), u5.getParameters());
 					u5.call();
 				}
 			});
@@ -609,6 +706,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_BOARD_REPORT)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "job_id", "issue", "user_id",
+						"time_now"), u.getParameters());
 				assertThrowsFK(
 						() -> u.call(NO_BOARD, NO_JOB, NO_NAME, NO_USER, 0));
 			});
@@ -620,6 +719,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_JOB_RECORD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -630,6 +730,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_ALLOC_RECORD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("alloc_id"), u.getParameters());
 				assertEquals(0, u.call(NO_ALLOC));
 			});
 		}
@@ -640,6 +741,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_ALLOCS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("grace_period", "time_now"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}
@@ -650,6 +753,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_JOBS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("grace_period", "time_now"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}
@@ -661,6 +766,8 @@ class DMLTest extends SimpleDBTestBase {
 		try (var conn = db.getHistoricalConnection();
 				var q = conn.update(WRITE_HISTORICAL_ALLOCS)) {
 			conn.transaction(() -> {
+				assertEquals(List.of("alloc_id", "job_id", "board_id",
+						"alloc_timestamp"), q.getParameters());
 				assertEquals(1, q.call(0, 0, 0, A_LONG_TIME));
 			});
 		}
@@ -672,9 +779,17 @@ class DMLTest extends SimpleDBTestBase {
 		try (var conn = db.getHistoricalConnection();
 				var q = conn.update(WRITE_HISTORICAL_JOBS)) {
 			conn.transaction(() -> {
-				assertEquals(1, q.call(0, 0, "", A_LONG_TIME, 0, 0, 0, 0,
-						A_LONG_TIME, "", "", A_LONG_TIME, new byte[] {},
-						A_LONG_TIME, 0, "", "", 0, ""));
+				assertEquals(List.of("job_id", "machine_id", "owner",
+						"create_timestamp", "width", "height", "depth",
+						"allocated_root", "keepalive_interval",
+						"keepalive_host", "death_reason", "death_timestamp",
+						"original_request", "allocation_timestamp",
+						"allocation_size", "machine_name", "user_name",
+						"group_id", "group_name"), q.getParameters());
+				assertEquals(1,
+						q.call(0, 0, "", A_LONG_TIME, 0, 0, 0, 0, A_LONG_TIME,
+								"", "", A_LONG_TIME, new byte[] {}, A_LONG_TIME,
+								0, "", "", 0, ""));
 			});
 		}
 	}
@@ -684,6 +799,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CLEAR_STUCK_PENDING)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), u.getParameters());
 				assertEquals(0, u.call());
 			});
 		}
@@ -694,6 +810,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_BOARD_SERIAL_IDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "bmp_serial_id",
+						"physical_serial_id"), u.getParameters());
 				assertThrowsFK(() -> u.call(NO_BOARD, "foo", "bar"));
 			});
 		}
@@ -705,6 +823,7 @@ class DMLTest extends SimpleDBTestBase {
 		var bl = new Blacklist("");
 		try (var u = c.update(COMPLETED_BLACKLIST_READ)) {
 			c.transaction(() -> {
+				assertEquals(List.of("data", "op_id"), u.getParameters());
 				assertEquals(0, u.call(bl, NO_BLACKLIST_OP));
 			});
 		}
@@ -715,6 +834,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(COMPLETED_BLACKLIST_WRITE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("op_id"), u.getParameters());
 				assertEquals(0, u.call(NO_BLACKLIST_OP));
 			});
 		}
@@ -725,6 +845,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(COMPLETED_GET_SERIAL_REQ)) {
 			c.transaction(() -> {
+				assertEquals(List.of("op_id"), u.getParameters());
 				assertEquals(0, u.call(NO_BLACKLIST_OP));
 			});
 		}
@@ -735,6 +856,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(FAILED_BLACKLIST_OP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("failure", "op_id"), u.getParameters());
 				assertEquals(0, u.call(new Exception(), NO_BLACKLIST_OP));
 			});
 		}
@@ -745,6 +867,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CREATE_BLACKLIST_READ)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), u.getParameters());
 				assertThrowsFK(() -> u.call(NO_BOARD));
 			});
 		}
@@ -756,6 +879,8 @@ class DMLTest extends SimpleDBTestBase {
 		var bl = new Blacklist("");
 		try (var u = c.update(CREATE_BLACKLIST_WRITE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "blacklist"),
+						u.getParameters());
 				assertThrowsFK(() -> u.call(NO_BOARD, bl));
 			});
 		}
@@ -766,6 +891,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CREATE_SERIAL_READ_REQ)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), u.getParameters());
 				assertThrowsFK(() -> u.call(NO_BOARD));
 			});
 		}
@@ -776,6 +902,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_BLACKLIST_OP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("op_id"), u.getParameters());
 				assertEquals(0, u.call(NO_BLACKLIST_OP));
 			});
 		}
@@ -786,6 +913,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ADD_BLACKLISTED_CHIP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "x", "y"), u.getParameters());
 				// No such board, so no insert
 				assertEquals(0, u.call(NO_BOARD, -1, -1));
 			});
@@ -797,6 +925,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ADD_BLACKLISTED_CORE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "x", "y", "p"),
+						u.getParameters());
 				// No such board, so no insert
 				assertEquals(0, u.call(NO_BOARD, -1, -1, -1));
 			});
@@ -808,6 +938,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ADD_BLACKLISTED_LINK)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "x", "y", "direction"),
+						u.getParameters());
 				// No such board, so no insert
 				assertEquals(0, u.call(NO_BOARD, -1, -1, Direction.N));
 			});
@@ -819,6 +951,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CLEAR_BLACKLISTED_CHIPS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), u.getParameters());
 				// No such board, so no delete
 				assertEquals(0, u.call(NO_BOARD));
 			});
@@ -830,6 +963,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(CLEAR_BLACKLISTED_CORES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), u.getParameters());
 				// No such board, so no delete
 				assertEquals(0, u.call(NO_BOARD));
 			});
@@ -841,6 +975,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_BOARD_BLACKLIST_CHANGED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("timestamp_now", "board_id"),
+						u.getParameters());
 				// No such board, so no delete
 				assertEquals(0, u.call(0, NO_BOARD));
 			});
@@ -852,6 +988,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_BOARD_BLACKLIST_SYNCHED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("timestamp_now", "board_id"),
+						u.getParameters());
 				// No such board, so no delete
 				assertEquals(0, u.call(0, NO_BOARD));
 			});

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.manchester.spinnaker.alloc.db;
 
+import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -639,7 +640,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_ALLOCS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, A_LONG_TIME, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}
 	}
@@ -649,7 +650,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_JOBS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, A_LONG_TIME, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -155,7 +155,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DESTROY_JOB)) {
 			c.transaction(() -> {
-				assertEquals(List.of("death_reason", "job_id"),
+				assertEquals(List.of("death_reason", "timestamp", "job_id"),
 						u.getParameters());
 				assertEquals(0, u.call("anything", 0, NO_JOB));
 			});
@@ -167,7 +167,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_TASK)) {
 			c.transaction(() -> {
-				assertEquals(List.of("job_id"), u.getParameters());
+				assertEquals(List.of("request_id"), u.getParameters());
 				assertEquals(0, u.call(NO_JOB));
 			});
 		}
@@ -284,9 +284,11 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(issueChangeForJob)) {
 			c.transaction(() -> {
-				assertEquals(List.of("job_id", "board_id", "from_state",
-						"to_state", "power", "fpga_n", "fpga_s", "fpga_e",
-						"fpga_w", "fpga_nw", "fpga_se"), u.getParameters());
+				assertEquals(
+						List.of("job_id", "board_id", "from_state", "to_state",
+								"power", "fpga_n", "fpga_e", "fpga_se",
+								"fpga_s", "fpga_w", "fpga_nw"),
+						u.getParameters());
 				// No such job
 				assertThrowsFK(() -> u.call(NO_JOB, NO_BOARD, UNKNOWN, UNKNOWN,
 						true, false, false, false, false, false, false));
@@ -767,7 +769,7 @@ class DMLTest extends SimpleDBTestBase {
 				var q = conn.update(WRITE_HISTORICAL_ALLOCS)) {
 			conn.transaction(() -> {
 				assertEquals(List.of("alloc_id", "job_id", "board_id",
-						"alloc_timestamp"), q.getParameters());
+						"allocation_timestamp"), q.getParameters());
 				assertEquals(1, q.call(0, 0, 0, A_LONG_TIME));
 			});
 		}
@@ -781,7 +783,7 @@ class DMLTest extends SimpleDBTestBase {
 			conn.transaction(() -> {
 				assertEquals(List.of("job_id", "machine_id", "owner",
 						"create_timestamp", "width", "height", "depth",
-						"allocated_root", "keepalive_interval",
+						"root_id", "keepalive_interval",
 						"keepalive_host", "death_reason", "death_timestamp",
 						"original_request", "allocation_timestamp",
 						"allocation_size", "machine_name", "user_name",

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -745,6 +745,8 @@ class DMLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("grace_period", "time_now"),
 						q.getParameters());
+				assertEquals(List.of("alloc_id", "job_id", "board_id",
+						"alloc_timestamp"), q.getColumns());
 				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}
@@ -757,6 +759,13 @@ class DMLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("grace_period", "time_now"),
 						q.getParameters());
+				assertEquals(List.of("job_id", "machine_id", "owner",
+						"create_timestamp", "width", "height", "depth",
+						"allocated_root", "keepalive_interval",
+						"keepalive_host", "death_reason", "death_timestamp",
+						"original_request", "allocation_timestamp",
+						"allocation_size", "machine_name", "user_name",
+						"group_id", "group_name"), q.getColumns());
 				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
 			});
 		}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -786,7 +786,7 @@ class DMLTest extends SimpleDBTestBase {
 						"root_id", "keepalive_interval",
 						"keepalive_host", "death_reason", "death_timestamp",
 						"original_request", "allocation_timestamp",
-						"allocation_size", "machine_name", "user_name",
+						"allocation_size", "machine_name", "owner_name",
 						"group_id", "group_name"), q.getParameters());
 				assertEquals(1,
 						q.call(0, 0, "", A_LONG_TIME, 0, 0, 0, 0, A_LONG_TIME,

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -181,8 +181,8 @@ class DMLTest extends SimpleDBTestBase {
 						List.of("width", "height", "depth", "board_id",
 								"num_boards", "allocated_board_id", "job_id"),
 						u.getParameters());
-				assertEquals(0, u.call(-1, -1, -1, NO_BOARD, 0, 0, NO_BOARD,
-						NO_JOB));
+				assertEquals(0,
+						u.call(-1, -1, -1, NO_BOARD, 0, NO_BOARD, NO_JOB));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -71,12 +71,11 @@ class DMLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(
 						List.of("machine_id", "user_id", "group_id",
-								"keepalive_interval", "original_request",
-								"keepalive_timestamp", "create_timestamp"),
+								"keepalive_interval", "original_request"),
 						u.getParameters());
 				// No such machine
 				assertThrowsFK(() -> u.call(NO_MACHINE, NO_USER, NO_GROUP, d,
-						new byte[0], 0, 0));
+						new byte[0]));
 			});
 		}
 	}
@@ -143,9 +142,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(UPDATE_KEEPALIVE)) {
 			c.transaction(() -> {
-				assertEquals(List.of("keepalive_timestamp", "keepalive_host",
-						"job_id"), u.getParameters());
-				assertEquals(0, u.call(0, NO_NAME, NO_JOB));
+				assertEquals(List.of("keepalive_host", "job_id"),
+						u.getParameters());
+				assertEquals(0, u.call(NO_NAME, NO_JOB));
 			});
 		}
 	}
@@ -155,9 +154,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(DESTROY_JOB)) {
 			c.transaction(() -> {
-				assertEquals(List.of("death_reason", "timestamp", "job_id"),
+				assertEquals(List.of("death_reason", "job_id"),
 						u.getParameters());
-				assertEquals(0, u.call("anything", 0, NO_JOB));
+				assertEquals(0, u.call("anything", NO_JOB));
 			});
 		}
 	}
@@ -178,9 +177,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(ALLOCATE_BOARDS_JOB)) {
 			c.transaction(() -> {
-				assertEquals(List.of("width", "height", "depth", "board_id",
-						"num_boards", "time_now", "allocated_board_id",
-						"job_id"), u.getParameters());
+				assertEquals(
+						List.of("width", "height", "depth", "board_id",
+								"num_boards", "allocated_board_id", "job_id"),
+						u.getParameters());
 				assertEquals(0, u.call(-1, -1, -1, NO_BOARD, 0, 0, NO_BOARD,
 						NO_JOB));
 			});
@@ -226,9 +226,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_STATE_DESTROYED)) {
 			c.transaction(() -> {
-				assertEquals(List.of("num_pending", "time_now", "job_id"),
+				assertEquals(List.of("num_pending", "job_id"),
 						u.getParameters());
-				assertEquals(0, u.call(0, 0, NO_JOB));
+				assertEquals(0, u.call(0, NO_JOB));
 			});
 		}
 	}
@@ -301,9 +301,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_BOARD_POWER_ON)) {
 			c.transaction(() -> {
-				assertEquals(List.of("time_now", "board_id"),
-						u.getParameters());
-				assertEquals(0, u.call(0, NO_BOARD));
+				assertEquals(List.of("board_id"), u.getParameters());
+				assertEquals(0, u.call(NO_BOARD));
 			});
 		}
 	}
@@ -313,9 +312,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_BOARD_POWER_OFF)) {
 			c.transaction(() -> {
-				assertEquals(List.of("time_now", "board_id"),
-						u.getParameters());
-				assertEquals(0, u.call(0, NO_BOARD));
+				assertEquals(List.of("board_id"), u.getParameters());
+				assertEquals(0, u.call(NO_BOARD));
 			});
 		}
 	}
@@ -487,10 +485,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_LOGIN_SUCCESS)) {
 			c.transaction(() -> {
-				assertEquals(
-						List.of("login_timestamp", "openid_subject", "user_id"),
+				assertEquals(List.of("openid_subject", "user_id"),
 						u.getParameters());
-				assertEquals(0, u.call(0, NO_NAME, NO_USER));
+				assertEquals(0, u.call(NO_NAME, NO_USER));
 			});
 		}
 	}
@@ -500,10 +497,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_LOGIN_FAILURE)) {
 			c.transaction(() -> {
-				assertEquals(
-						List.of("login_timestamp", "failure_limit", "user_id"),
+				assertEquals(List.of("failure_limit", "user_id"),
 						u.getParameters());
-				assertEquals(0, u.call(0, 0, NO_USER));
+				assertEquals(0, u.call(0, NO_USER));
 			});
 		}
 	}
@@ -513,9 +509,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(UNLOCK_LOCKED_USERS)) {
 			c.transaction(() -> {
-				assertEquals(List.of("lock_interval", "timestamp_now"),
-						u.getParameters());
-				assertEquals(0, u.call(Duration.ofDays(1000), 0));
+				assertEquals(List.of("lock_interval"), u.getParameters());
+				assertEquals(0, u.call(Duration.ofDays(1000)));
 			});
 		}
 	}
@@ -708,10 +703,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(INSERT_BOARD_REPORT)) {
 			c.transaction(() -> {
-				assertEquals(List.of("board_id", "job_id", "issue", "user_id",
-						"time_now"), u.getParameters());
+				assertEquals(List.of("board_id", "job_id", "issue", "user_id"),
+						u.getParameters());
 				assertThrowsFK(
-						() -> u.call(NO_BOARD, NO_JOB, NO_NAME, NO_USER, 0));
+						() -> u.call(NO_BOARD, NO_JOB, NO_NAME, NO_USER));
 			});
 		}
 	}
@@ -743,11 +738,10 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_ALLOCS)) {
 			c.transaction(() -> {
-				assertEquals(List.of("grace_period", "time_now"),
-						q.getParameters());
+				assertEquals(List.of("grace_period"), q.getParameters());
 				assertEquals(List.of("alloc_id", "job_id", "board_id",
 						"alloc_timestamp"), q.getColumns());
-				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
+				assertEquals(empty(), q.call1(Row::toString, A_LONG_TIME));
 			});
 		}
 	}
@@ -757,8 +751,7 @@ class DMLTest extends SimpleDBTestBase {
 		assumeTrue(db.isHistoricalDBAvailable());
 		try (var q = c.query(READ_HISTORICAL_JOBS)) {
 			c.transaction(() -> {
-				assertEquals(List.of("grace_period", "time_now"),
-						q.getParameters());
+				assertEquals(List.of("grace_period"), q.getParameters());
 				assertEquals(List.of("job_id", "machine_id", "owner",
 						"create_timestamp", "width", "height", "depth",
 						"allocated_root", "keepalive_interval",
@@ -766,7 +759,7 @@ class DMLTest extends SimpleDBTestBase {
 						"original_request", "allocation_timestamp",
 						"allocation_size", "machine_name", "user_name",
 						"group_id", "group_name"), q.getColumns());
-				assertEquals(empty(), q.call1((row) -> 1, A_LONG_TIME, 0));
+				assertEquals(empty(), q.call1(Row::toString, A_LONG_TIME));
 			});
 		}
 	}
@@ -986,10 +979,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_BOARD_BLACKLIST_CHANGED)) {
 			c.transaction(() -> {
-				assertEquals(List.of("timestamp_now", "board_id"),
-						u.getParameters());
+				assertEquals(List.of("board_id"), u.getParameters());
 				// No such board, so no delete
-				assertEquals(0, u.call(0, NO_BOARD));
+				assertEquals(0, u.call(NO_BOARD));
 			});
 		}
 	}
@@ -999,10 +991,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(MARK_BOARD_BLACKLIST_SYNCHED)) {
 			c.transaction(() -> {
-				assertEquals(List.of("timestamp_now", "board_id"),
-						u.getParameters());
+				assertEquals(List.of("board_id"), u.getParameters());
 				// No such board, so no delete
-				assertEquals(0, u.call(0, NO_BOARD));
+				assertEquals(0, u.call(NO_BOARD));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -888,8 +888,11 @@ class DQLTest extends SimpleDBTestBase {
 	void getSerialInfoReqs() {
 		try (var q = c.query(GET_SERIAL_INFO_REQS)) {
 			c.transaction(() -> {
-				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getResultSetColumnNames());
+				assertEquals(List.of("machine_id"), q.getParameters());
+				assertEquals(
+						List.of("op_id", "board_id", "bmp_serial_id",
+								"board_num", "cabinet", "frame"),
+						q.getResultSetColumnNames());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -468,7 +468,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "x", "y", "z"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("board_id"), q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, -1, -1, -1));
 			});
@@ -480,7 +480,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(FIND_EXPIRED_JOBS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("time_now"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("job_id"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, 0));
 			});
 		}
@@ -491,8 +491,9 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LOAD_DIR_INFO)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
-				q.call((row) -> null);
+				assertEquals(List.of("z", "direction", "dx", "dy", "dz"),
+						q.getColumns());
+				q.call(Row::toString);
 			});
 		}
 	}
@@ -502,7 +503,11 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_CHANGES)) {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("change_id", "job_id", "board_id", "power",
+						"fpga_n", "fpga_s", "fpga_e", "fpga_w", "fpga_se",
+						"fpga_nw", "in_progress", "from_state", "to_state",
+						"board_num", "bmp_id", "cabinet", "frame"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_JOB));
 			});
 		}
@@ -514,7 +519,8 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("width", "height", "machine_id",
 						"max_dead_boards"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("id", "x", "y", "z", "available"),
+						q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, -1, -1, NO_MACHINE, 0));
 			});
@@ -527,7 +533,8 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id", "width", "height",
 						"machine_id", "max_dead_boards"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("id", "x", "y", "z", "available"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD, -1, -1,
 						NO_MACHINE, 0));
 			});
@@ -540,7 +547,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "board_id"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("x", "y", "z"), q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, NO_BOARD));
 			});
@@ -553,7 +560,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "x", "y", "width", "height"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("connected_size"), q.getColumns());
 				assertEquals(0, q.call1(integer("connected_size"), NO_MACHINE,
 						-1, -1, -1, -1).orElseThrow());
 			});
@@ -565,7 +572,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(COUNT_PENDING_CHANGES)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("c"), q.getColumns());
 				assertEquals(0, q.call1(integer("c")).orElseThrow());
 			});
 		}
@@ -576,11 +583,16 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(getPerimeterLinks)) {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("board_id", "direction"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_JOB));
 			});
 		}
 	}
+
+	private static final List<String> LOCATED_BOARD = List.of("board_id",
+			"bmp_id", "job_id", "machine_name", "address", "x", "y", "z",
+			"cabinet", "frame", "board_num", "chip_x", "chip_y", "board_chip_x",
+			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
 
 	@Test
 	void findBoardByGlobalChip() {
@@ -588,7 +600,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "x", "y"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(LOCATED_BOARD, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, -1, -1));
 			});
@@ -601,7 +613,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id", "board_id", "x", "y"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(LOCATED_BOARD, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_JOB, NO_BOARD, -1, -1));
 			});
@@ -614,7 +626,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "x", "y", "z"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(LOCATED_BOARD, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, -1, -1, -1));
 			});
@@ -627,7 +639,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "cabinet", "frame", "board"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(LOCATED_BOARD, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, -1, -1, -1));
 			});
@@ -640,7 +652,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "address"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(LOCATED_BOARD, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_MACHINE, "127.0.0.1"));
 			});
@@ -653,7 +665,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "time_now"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("job_id"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE, 0));
 			});
 		}
@@ -665,7 +677,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id", "x", "y", "z", "width",
 						"height", "depth"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("board_id"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE, -1, -1,
 						-1, -1, -1, -1));
 			});
@@ -678,7 +690,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_name", "x", "y", "z"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, -1, -1, -1));
 			});
@@ -690,7 +702,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(FIND_BOARD_BY_ID)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -703,7 +715,7 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(
 						List.of("machine_name", "cabinet", "frame", "board"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, -1, -1, -1));
 			});
@@ -716,7 +728,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_name", "address"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, "256.256.256.256"));
 			});
@@ -728,7 +740,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_FUNCTIONING_FIELD)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("functioning"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -739,18 +751,21 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_GROUP_QUOTA)) {
 			c.transaction(() -> {
 				assertEquals(List.of("group_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("quota"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_GROUP));
 			});
 		}
 	}
+
+	private static final List<String> GROUP_COLUMNS =
+			List.of("group_id", "group_name", "quota", "group_type");
 
 	@Test
 	void listAllGroups() {
 		try (var q = c.query(LIST_ALL_GROUPS)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(GROUP_COLUMNS, q.getColumns());
 				// Not sure what default state is, but this should not error
 				assertNotNull(q.call(Row::toString));
 			});
@@ -762,7 +777,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_ALL_GROUPS_OF_TYPE)) {
 			c.transaction(() -> {
 				assertEquals(List.of("type"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(GROUP_COLUMNS, q.getColumns());
 				// Not sure what default state is, but this should not error
 				assertNotNull(q.call(Row::toString, GroupType.INTERNAL));
 			});
@@ -774,7 +789,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_GROUP_BY_ID)) {
 			c.transaction(() -> {
 				assertEquals(List.of("group_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(GROUP_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_GROUP));
 			});
 		}
@@ -785,7 +800,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_GROUP_BY_NAME)) {
 			c.transaction(() -> {
 				assertEquals(List.of("group_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(GROUP_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
 		}
@@ -796,18 +811,22 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USERS_OF_GROUP)) {
 			c.transaction(() -> {
 				assertEquals(List.of("group_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("membership_id", "group_id", "group_name",
+						"user_id", "user_name"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_GROUP));
 			});
 		}
 	}
+
+	private static final List<String> MEMBER_COLUMNS = List.of("membership_id",
+			"user_id", "group_id", "user_name", "group_name");
 
 	@Test
 	void getMembership() {
 		try (var q = c.query(GET_MEMBERSHIP)) {
 			c.transaction(() -> {
 				assertEquals(List.of("membership_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(MEMBER_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MEMBER));
 			});
 		}
@@ -818,7 +837,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_MEMBERSHIPS_OF_USER)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(MEMBER_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_USER));
 			});
 		}
@@ -829,7 +848,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_QUOTA)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("quota_total", "user_id"), q.getColumns());
 				// Still get a quota, it is just 0
 				assertNotEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
@@ -841,7 +860,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_CURRENT_USAGE)) {
 			c.transaction(() -> {
 				assertEquals(List.of("group_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("current_usage"), q.getColumns());
 				assertEquals(0, q.call1(integer("current_usage"), NO_GROUP)
 						.orElseThrow());
 			});
@@ -853,7 +872,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_JOB_USAGE_AND_QUOTA)) {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("quota_used", "quota"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_JOB));
 			});
 		}
@@ -864,7 +883,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_CONSOLIDATION_TARGETS)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("job_id", "group_id", "quota_used"),
+						q.getColumns());
 				// Empty DB has no consolidation targets
 				assertEquals(empty(), q.call1(Row::toString));
 			});
@@ -876,8 +896,9 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(IS_USER_LOCKED)) {
 			c.transaction(() -> {
 				assertEquals(List.of("username"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
-				// Empty DB has no consolidation targets
+				assertEquals(List.of("user_id", "locked", "disabled"),
+						q.getColumns());
+				// Testing DB has no users by default
 				assertEquals(empty(), q.call1(Row::toString, ""));
 			});
 		}
@@ -888,18 +909,22 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_AUTHORITIES)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("trust_level", "encrypted_password",
+						"openid_subject"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_USER));
 			});
 		}
 	}
+
+	private static final List<String> BASIC_USER_COLUMNS =
+			List.of("user_id", "user_name", "openid_subject");
 
 	@Test
 	void listAllUsers() {
 		try (var q = c.query(LIST_ALL_USERS)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BASIC_USER_COLUMNS, q.getColumns());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1(Row::toString));
 			});
@@ -911,7 +936,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_ALL_USERS_OF_TYPE)) {
 			c.transaction(() -> {
 				assertEquals(List.of("internal"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(BASIC_USER_COLUMNS, q.getColumns());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1(Row::toString, false));
 			});
@@ -923,19 +948,24 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_ID)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("user_id"), q.getColumns());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
 		}
 	}
 
+	private static final List<String> USER_COLUMNS =
+			List.of("user_id", "user_name", "has_password", "trust_level",
+					"locked", "disabled", "last_successful_login_timestamp",
+					"last_fail_timestamp", "openid_subject", "is_internal");
+
 	@Test
 	void getUserDetails() {
 		try (var q = c.query(GET_USER_DETAILS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(USER_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_USER));
 			});
 		}
@@ -946,7 +976,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_DETAILS_BY_NAME)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(USER_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
 		}
@@ -957,7 +987,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_DETAILS_BY_SUBJECT)) {
 			c.transaction(() -> {
 				assertEquals(List.of("openid_subject"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(USER_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
 		}
@@ -969,7 +999,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name", "group_name"),
 						q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("group_id"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME, NO_NAME));
 			});
 		}
@@ -980,7 +1010,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_GROUPS_AND_QUOTAS_OF_USER)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("group_id", "quota"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_NAME));
 			});
 		}
@@ -991,7 +1021,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(COUNT_MACHINE_THINGS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("board_count", "in_use", "num_jobs"),
+						q.getColumns());
 				var r = q.call1((row) -> Map.of(
 						"board_count", row.getInt("board_count"),
 						"in_use", row.getInt("in_use"),
@@ -1009,7 +1040,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(COUNT_POWERED_BOARDS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("c"), q.getColumns());
 				assertEquals(0, q.call1(integer("c"), NO_JOB).orElseThrow());
 			});
 		}
@@ -1020,7 +1051,10 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_LIVE_JOBS)) {
 			c.transaction(() -> {
 				assertEquals(List.of(), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("job_id", "machine_id", "create_timestamp",
+						"keepalive_interval", "job_state", "allocation_size",
+						"keepalive_host", "user_name", "machine_name"),
+						q.getColumns());
 				// No jobs right now
 				assertEquals(empty(), q.call1(Row::toString));
 			});
@@ -1032,7 +1066,9 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_LOCAL_USER_DETAILS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("user_name"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(
+						List.of("user_id", "user_name", "encrypted_password"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_USER));
 			});
 		}
@@ -1043,7 +1079,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(getReportedBoards)) {
 			c.transaction(() -> {
 				assertEquals(List.of("threshold"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("board_id", "num_reports", "x", "y", "z",
+						"address"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, 0));
 			});
 		}
@@ -1054,7 +1091,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(IS_BOARD_BLACKLIST_CURRENT)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("current"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -1065,7 +1102,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_BLACKLISTED_CHIPS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("x", "y", "notes"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -1076,7 +1113,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_BLACKLISTED_CORES)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("x", "y", "p", "notes"), q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -1087,7 +1124,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_BLACKLISTED_LINKS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(List.of("x", "y", "direction", "notes"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -1098,7 +1136,10 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_BLACKLIST_READS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(
+						List.of("op_id", "board_id", "bmp_serial_id",
+								"board_num", "cabinet", "frame"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE));
 			});
 		}
@@ -1109,7 +1150,10 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_BLACKLIST_WRITES)) {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_id"), q.getParameters());
-				assertEquals(List.of(), q.getColumns()); // FIXME
+				assertEquals(
+						List.of("op_id", "board_id", "bmp_serial_id",
+								"board_num", "cabinet", "frame", "data"),
+						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE));
 			});
 		}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -49,9 +49,53 @@ import uk.ac.manchester.spinnaker.machine.MachineDimensions;
 @TestInstance(PER_CLASS)
 @ActiveProfiles("unittest")
 class DQLTest extends SimpleDBTestBase {
+	private static final List<String> BASIC_USER_COLUMNS =
+			List.of("user_id", "user_name", "openid_subject");
+
+	/** Columns to inflate a BoardCoords. */
+	private static final List<String> BOARD_COLUMNS = List.of("board_id", "x",
+			"y", "z", "cabinet", "frame", "board_num", "address");
+
+	private static final List<String> FULL_BOARD_COLUMNS = List.of("board_id",
+			"x", "y", "z", "cabinet", "frame", "board_num", "address",
+			"machine_name", "bmp_serial_id", "physical_serial_id");
+
+	private static final List<String> LOCATED_BOARD = List.of("board_id",
+			"bmp_id", "job_id", "machine_name", "address", "x", "y", "z",
+			"cabinet", "frame", "board_num", "chip_x", "chip_y", "board_chip_x",
+			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
+
+	private static final List<String> LOCATED_BOARD_2 = List.of("board_id",
+			"address", "x", "y", "z", "job_id", "machine_name", "cabinet",
+			"frame", "board_num", "chip_x", "chip_y", "board_chip_x",
+			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
+
 	/** The columns to inflate a MachineImpl. */
 	private static final List<String> MACHINE_COLUMNS = List.of("machine_id",
 			"machine_name", "width", "height", "in_service");
+
+	/** Columns to inflate a JobImpl. */
+	private static final List<String> JOB_COLUMNS = List.of("job_id",
+			"machine_id", "machine_name", "width", "height", "depth", "root_id",
+			"job_state", "keepalive_timestamp", "keepalive_host",
+			"keepalive_interval", "create_timestamp", "death_reason",
+			"death_timestamp", "original_request", "owner");
+
+	// Not currently used due to MySQL connector bug
+	@SuppressWarnings("unused")
+	private static final List<String> MINI_JOB_COLUMNS =
+			List.of("job_id", "machine_id", "job_state", "keepalive_timestamp");
+
+	private static final List<String> USER_COLUMNS =
+			List.of("user_id", "user_name", "has_password", "trust_level",
+					"locked", "disabled", "last_successful_login_timestamp",
+					"last_fail_timestamp", "openid_subject", "is_internal");
+
+	private static final List<String> GROUP_COLUMNS =
+			List.of("group_id", "group_name", "quota", "group_type");
+
+	private static final List<String> MEMBER_COLUMNS = List.of("membership_id",
+			"user_id", "group_id", "user_name", "group_name");
 
 	@Test
 	void getAllMachines() {
@@ -128,9 +172,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	// private static final List<String> MINI_JOB_COLUMNS =
-	//		List.of("job_id", "machine_id", "job_state", "keepalive_timestamp");
-
 	@Test
 	void getJobIds() {
 		try (var q = c.query(GET_JOB_IDS)) {
@@ -156,13 +197,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	/** Columns to inflate a JobImpl. */
-	private static final List<String> JOB_COLUMNS = List.of("job_id",
-			"machine_id", "machine_name", "width", "height", "depth", "root_id",
-			"job_state", "keepalive_timestamp", "keepalive_host",
-			"keepalive_interval", "create_timestamp", "death_reason",
-			"death_timestamp", "original_request", "owner");
-
 	@Test
 	void getJob() {
 		try (var q = c.query(GET_JOB)) {
@@ -184,10 +218,6 @@ class DQLTest extends SimpleDBTestBase {
 			});
 		}
 	}
-
-	/** Columns to inflate a BoardCoords. */
-	private static final List<String> BOARD_COLUMNS = List.of("board_id", "x",
-			"y", "z", "cabinet", "frame", "board_num", "address");
 
 	@Test
 	void getJobBoardCoords() {
@@ -591,16 +621,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	private static final List<String> LOCATED_BOARD = List.of("board_id",
-			"bmp_id", "job_id", "machine_name", "address", "x", "y", "z",
-			"cabinet", "frame", "board_num", "chip_x", "chip_y", "board_chip_x",
-			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
-
-	private static final List<String> LOCATED_BOARD_2 = List.of("board_id",
-			"address", "x", "y", "z", "job_id", "machine_name", "cabinet",
-			"frame", "board_num", "chip_x", "chip_y", "board_chip_x",
-			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
-
 	@Test
 	void findBoardByGlobalChip() {
 		try (var q = c.query(findBoardByGlobalChip)) {
@@ -691,10 +711,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	private static final List<String> FULL_BOARD_COLUMNS = List.of("board_id",
-			"x", "y", "z", "cabinet", "frame", "board_num", "address",
-			"machine_name", "bmp_serial_id", "physical_serial_id");
-
 	@Test
 	void findBoardByNameAndXYZ() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_XYZ)) {
@@ -768,9 +784,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	private static final List<String> GROUP_COLUMNS =
-			List.of("group_id", "group_name", "quota", "group_type");
-
 	@Test
 	void listAllGroups() {
 		try (var q = c.query(LIST_ALL_GROUPS)) {
@@ -828,9 +841,6 @@ class DQLTest extends SimpleDBTestBase {
 			});
 		}
 	}
-
-	private static final List<String> MEMBER_COLUMNS = List.of("membership_id",
-			"user_id", "group_id", "user_name", "group_name");
 
 	@Test
 	void getMembership() {
@@ -927,9 +937,6 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
-	private static final List<String> BASIC_USER_COLUMNS =
-			List.of("user_id", "user_name", "openid_subject");
-
 	@Test
 	void listAllUsers() {
 		try (var q = c.query(LIST_ALL_USERS)) {
@@ -965,11 +972,6 @@ class DQLTest extends SimpleDBTestBase {
 			});
 		}
 	}
-
-	private static final List<String> USER_COLUMNS =
-			List.of("user_id", "user_name", "has_password", "trust_level",
-					"locked", "disabled", "last_successful_login_timestamp",
-					"last_fail_timestamp", "openid_subject", "is_internal");
 
 	@Test
 	void getUserDetails() {

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -409,7 +409,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findExpiredJobs() {
 		try (var q = c.query(FIND_EXPIRED_JOBS)) {
 			c.transaction(() -> {
-				assertEquals(List.of(), q.getParameters());
+				assertEquals(List.of("time_now"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, 0));
 			});
 		}
@@ -507,7 +507,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByGlobalChip() {
 		try (var q = c.query(findBoardByGlobalChip)) {
 			c.transaction(() -> {
-				assertEquals(List.of("machine_id", "chip_x", "chip_y"),
+				assertEquals(List.of("machine_id", "x", "y"),
 						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, -1, -1));
 			});
@@ -518,8 +518,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByJobChip() {
 		try (var q = c.query(findBoardByJobChip)) {
 			c.transaction(() -> {
-				assertEquals(
-						List.of("job_id", "root_board_id", "chip_x", "chip_y"),
+				assertEquals(List.of("job_id", "board_id", "x", "y"),
 						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_JOB, NO_BOARD, -1, -1));
@@ -1008,7 +1007,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_COMPLETED_BLACKLIST_OP)) {
 			c.transaction(() -> {
 				assertEquals(List.of("op_id"), q.getParameters());
-				assertEquals(List.of("board_id", "op", "data", "failure"),
+				assertEquals(
+						List.of("board_id", "op", "data", "failure", "failed"),
 						q.getResultSetColumnNames());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BLACKLIST_OP));
 			});

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -511,9 +511,9 @@ class DQLTest extends SimpleDBTestBase {
 	void findExpiredJobs() {
 		try (var q = c.query(FIND_EXPIRED_JOBS)) {
 			c.transaction(() -> {
-				assertEquals(List.of("time_now"), q.getParameters());
+				assertEquals(List.of(), q.getParameters());
 				assertEquals(List.of("job_id"), q.getColumns());
-				assertEquals(empty(), q.call1(Row::toString, 0));
+				assertEquals(empty(), q.call1(Row::toString));
 			});
 		}
 	}
@@ -690,10 +690,9 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobsWithChanges() {
 		try (var q = c.query(getJobsWithChanges)) {
 			c.transaction(() -> {
-				assertEquals(List.of("machine_id", "time_now"),
-						q.getParameters());
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(List.of("job_id"), q.getColumns());
-				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE, 0));
+				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -53,6 +53,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllMachines() {
 		try (var q = c.query(GET_ALL_MACHINES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("allow_out_of_service"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
 		}
@@ -62,6 +64,8 @@ class DQLTest extends SimpleDBTestBase {
 	void listMachineNames() {
 		try (var q = c.query(LIST_MACHINE_NAMES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("allow_out_of_service"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
 		}
@@ -71,6 +75,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineById() {
 		try (var q = c.query(GET_MACHINE_BY_ID)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "allow_out_of_service"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, false));
 			});
 		}
@@ -80,6 +86,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getNamedMachine() {
 		try (var q = c.query(GET_NAMED_MACHINE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_name", "allow_out_of_service"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, false));
 			});
 		}
@@ -89,6 +97,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineJobs() {
 		try (var q = c.query(GET_MACHINE_JOBS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -98,6 +107,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineReports() {
 		try (var q = c.query(GET_MACHINE_REPORTS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -107,6 +117,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobIds() {
 		try (var q = c.query(GET_JOB_IDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("limit", "offset"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, 0, 0));
 			});
 		}
@@ -116,6 +127,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getLiveJobIds() {
 		try (var q = c.query(GET_LIVE_JOB_IDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("limit", "offset"), q.getParameters());
 				q.call(Row.integer("job_id"), 0, 0);
 				// Must not throw
 			});
@@ -126,6 +138,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJob() {
 		try (var q = c.query(GET_JOB)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -135,6 +148,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobBoards() {
 		try (var q = c.query(GET_JOB_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -144,6 +158,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobBoardCoords() {
 		try (var q = c.query(GET_JOB_BOARD_COORDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -153,6 +168,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobChipDimensions() {
 		try (var q = c.query(GET_JOB_CHIP_DIMENSIONS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				var dims = q.call1(r -> new MachineDimensions(r.getInt("width"),
 						r.getInt("height")), NO_JOB).orElseThrow();
 				// These two are actually NULL when there's no job
@@ -166,6 +182,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootOfBoard() {
 		try (var q = c.query(GET_ROOT_OF_BOARD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -175,6 +192,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootBMPAddress() {
 		try (var q = c.query(GET_ROOT_BMP_ADDRESS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -184,6 +202,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getBMPAddress() {
 		try (var q = c.query(GET_BMP_ADDRESS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "cabinet", "frame"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0, 0));
 			});
 		}
@@ -193,6 +213,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardAddress() {
 		try (var q = c.query(GET_BOARD_ADDRESS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -202,6 +223,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardPowerInfo() {
 		try (var q = c.query(GET_BOARD_POWER_INFO)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -211,6 +233,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardJob() {
 		try (var q = c.query(GET_BOARD_JOB)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -220,6 +243,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardReports() {
 		try (var q = c.query(GET_BOARD_REPORTS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -229,6 +253,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardNumbers() {
 		try (var q = c.query(GET_BOARD_NUMBERS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -238,6 +263,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getBmpBoardNumbers() {
 		try (var q = c.query(GET_BMP_BOARD_NUMBERS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "cabinet", "frame"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0, 0));
 			});
 		}
@@ -247,6 +274,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getLiveBoards() {
 		try (var q = c.query(GET_LIVE_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -256,6 +284,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getDeadBoards() {
 		try (var q = c.query(GET_DEAD_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -265,6 +294,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllBoards() {
 		try (var q = c.query(GET_ALL_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -274,6 +304,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllBoardsOfAllMachines() {
 		try (var q = c.query(GET_ALL_BOARDS_OF_ALL_MACHINES)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				// As long as this doesn't throw, the test passes
 				return q.call1((row) -> 1).isPresent();
 			});
@@ -284,6 +315,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getDeadLinks() {
 		try (var q = c.query(getDeadLinks)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -293,6 +325,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAvailableBoardNumbers() {
 		try (var q = c.query(GET_AVAILABLE_BOARD_NUMBERS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -302,6 +335,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getTags() {
 		try (var q = c.query(GET_TAGS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -312,6 +346,7 @@ class DQLTest extends SimpleDBTestBase {
 		// This query always produces one row
 		try (var q = c.query(GET_SUM_BOARDS_POWERED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				var row = q.call1(integer("total_on"), NO_JOB).orElseThrow();
 				assertEquals(0, row);
 			});
@@ -322,6 +357,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardConnectInfo() {
 		try (var q = c.query(GET_BOARD_CONNECT_INFO)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -331,6 +367,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootCoords() {
 		try (var q = c.query(GET_ROOT_COORDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -340,6 +377,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllocationTasks() {
 		try (var q = c.query(getAllocationTasks)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_state"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, QUEUED));
 			});
 		}
@@ -349,6 +387,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findFreeBoard() {
 		try (var q = c.query(FIND_FREE_BOARD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -358,6 +397,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardByCoords() {
 		try (var q = c.query(GET_BOARD_BY_COORDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "x", "y", "z"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
@@ -368,6 +409,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findExpiredJobs() {
 		try (var q = c.query(FIND_EXPIRED_JOBS)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, 0));
 			});
 		}
@@ -377,6 +419,7 @@ class DQLTest extends SimpleDBTestBase {
 	void loadDirInfo() {
 		try (var q = c.query(LOAD_DIR_INFO)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				q.call((row) -> null);
 			});
 		}
@@ -386,6 +429,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getChanges() {
 		try (var q = c.query(GET_CHANGES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -395,6 +439,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findRectangle() {
 		try (var q = c.query(findRectangle)) {
 			c.transaction(() -> {
+				assertEquals(List.of("width", "height", "machine_id",
+						"max_dead_boards"), q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, -1, -1, NO_MACHINE, 0));
 			});
@@ -405,6 +451,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findRectangleAt() {
 		try (var q = c.query(findRectangleAt)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id", "width", "height",
+						"machine_id", "max_dead_boards"), q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_BOARD, -1, -1, NO_MACHINE, 0));
 			});
@@ -415,6 +463,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findLocation() {
 		try (var q = c.query(findLocation)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "board_id"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_MACHINE, NO_BOARD));
 			});
@@ -425,9 +475,10 @@ class DQLTest extends SimpleDBTestBase {
 	void countConnected() {
 		try (var q = c.query(countConnected)) {
 			c.transaction(() -> {
-				var row = q.call1(integer("connected_size"), NO_MACHINE, -1,
-						-1, -1, -1).orElseThrow();
-				assertEquals(0, row);
+				assertEquals(List.of("machine_id", "x", "y", "width", "height"),
+						q.getParameters());
+				assertEquals(0, q.call1(integer("connected_size"), NO_MACHINE,
+						-1, -1, -1, -1).orElseThrow());
 			});
 		}
 	}
@@ -436,8 +487,8 @@ class DQLTest extends SimpleDBTestBase {
 	void countPendingChanges() {
 		try (var q = c.query(COUNT_PENDING_CHANGES)) {
 			c.transaction(() -> {
-				var row = q.call1(integer("c")).orElseThrow();
-				assertEquals(0, row);
+				assertEquals(List.of(), q.getParameters());
+				assertEquals(0, q.call1(integer("c")).orElseThrow());
 			});
 		}
 	}
@@ -446,6 +497,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getPerimeterLinks() {
 		try (var q = c.query(getPerimeterLinks)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -455,6 +507,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByGlobalChip() {
 		try (var q = c.query(findBoardByGlobalChip)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "chip_x", "chip_y"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, -1, -1));
 			});
 		}
@@ -464,6 +518,9 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByJobChip() {
 		try (var q = c.query(findBoardByJobChip)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("job_id", "root_board_id", "chip_x", "chip_y"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_JOB, NO_BOARD, -1, -1));
 			});
@@ -474,6 +531,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByLogicalCoords() {
 		try (var q = c.query(findBoardByLogicalCoords)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "x", "y", "z"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
@@ -484,6 +543,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByPhysicalCoords() {
 		try (var q = c.query(findBoardByPhysicalCoords)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "cabinet", "frame", "board"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
@@ -494,6 +555,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByIPAddress() {
 		try (var q = c.query(findBoardByIPAddress)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "address"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_MACHINE, "127.0.0.1"));
 			});
@@ -504,6 +567,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobsWithChanges() {
 		try (var q = c.query(getJobsWithChanges)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "time_now"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0));
 			});
 		}
@@ -513,6 +578,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getConnectedBoards() {
 		try (var q = c.query(getConnectedBoards)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id", "x", "y", "z", "width",
+						"height", "depth"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, -1, -1,
 						-1, -1, -1, -1));
 			});
@@ -523,6 +590,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndXYZ() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_XYZ)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_name", "x", "y", "z"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, -1, -1, -1));
 			});
 		}
@@ -532,6 +601,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardById() {
 		try (var q = c.query(FIND_BOARD_BY_ID)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -541,6 +611,9 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndCFB() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_CFB)) {
 			c.transaction(() -> {
+				assertEquals(
+						List.of("machine_name", "cabinet", "frame", "board"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, -1, -1, -1));
 			});
 		}
@@ -550,6 +623,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndIPAddress() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_IP_ADDRESS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_name", "address"),
+						q.getParameters());
 				assertEquals(empty(),
 						q.call1((row) -> 1, NO_NAME, "256.256.256.256"));
 			});
@@ -560,6 +635,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getFunctioningField() {
 		try (var q = c.query(GET_FUNCTIONING_FIELD)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -569,6 +645,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupQuota() {
 		try (var q = c.query(GET_GROUP_QUOTA)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
@@ -578,6 +655,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listAllGroups() {
 		try (var q = c.query(LIST_ALL_GROUPS)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				// Not sure what default state is, but this should not error
 				assertNotNull(q.call((row) -> 1));
 			});
@@ -588,6 +666,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listAllGroupsOfType() {
 		try (var q = c.query(LIST_ALL_GROUPS_OF_TYPE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("type"), q.getParameters());
 				// Not sure what default state is, but this should not error
 				assertNotNull(q.call((row) -> 1, GroupType.INTERNAL));
 			});
@@ -598,6 +677,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupById() {
 		try (var q = c.query(GET_GROUP_BY_ID)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
@@ -607,6 +687,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupByName() {
 		try (var q = c.query(GET_GROUP_BY_NAME)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_name"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
@@ -616,6 +697,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUsersOfGroup() {
 		try (var q = c.query(GET_USERS_OF_GROUP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
@@ -625,6 +707,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMembership() {
 		try (var q = c.query(GET_MEMBERSHIP)) {
 			c.transaction(() -> {
+				assertEquals(List.of("membership_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MEMBER));
 			});
 		}
@@ -634,6 +717,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMembershipsOfUser() {
 		try (var q = c.query(GET_MEMBERSHIPS_OF_USER)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
@@ -643,6 +727,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserQuota() {
 		try (var q = c.query(GET_USER_QUOTA)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name"), q.getParameters());
 				// Still get a quota, it is just 0
 				assertNotEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
@@ -653,6 +738,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getCurrentUsage() {
 		try (var q = c.query(GET_CURRENT_USAGE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("group_id"), q.getParameters());
 				assertEquals(0, q.call1(integer("current_usage"), NO_GROUP)
 						.orElseThrow());
 			});
@@ -663,6 +749,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobUsageAndQuota() {
 		try (var q = c.query(GET_JOB_USAGE_AND_QUOTA)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
@@ -672,6 +759,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getConsolidationTargets() {
 		try (var q = c.query(GET_CONSOLIDATION_TARGETS)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				// Empty DB has no consolidation targets
 				assertEquals(empty(), q.call1((row) -> 1));
 			});
@@ -682,6 +770,7 @@ class DQLTest extends SimpleDBTestBase {
 	void isUserLocked() {
 		try (var q = c.query(IS_USER_LOCKED)) {
 			c.transaction(() -> {
+				assertEquals(List.of("username"), q.getParameters());
 				// Empty DB has no consolidation targets
 				assertEquals(empty(), q.call1((row) -> 1, ""));
 			});
@@ -692,6 +781,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserAuthorities() {
 		try (var q = c.query(GET_USER_AUTHORITIES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
@@ -701,6 +791,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listAllUsers() {
 		try (var q = c.query(LIST_ALL_USERS)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1((row) -> 1));
 			});
@@ -711,6 +802,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listAllUsersOfType() {
 		try (var q = c.query(LIST_ALL_USERS_OF_TYPE)) {
 			c.transaction(() -> {
+				assertEquals(List.of("internal"), q.getParameters());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
@@ -721,6 +813,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserId() {
 		try (var q = c.query(GET_USER_ID)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name"), q.getParameters());
 				// Testing DB has no users by default
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
@@ -731,6 +824,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetails() {
 		try (var q = c.query(GET_USER_DETAILS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
@@ -740,6 +834,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetailsByName() {
 		try (var q = c.query(GET_USER_DETAILS_BY_NAME)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
@@ -749,6 +844,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetailsBySubject() {
 		try (var q = c.query(GET_USER_DETAILS_BY_SUBJECT)) {
 			c.transaction(() -> {
+				assertEquals(List.of("openid_subject"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
@@ -758,6 +854,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupByNameAndMember() {
 		try (var q = c.query(GET_GROUP_BY_NAME_AND_MEMBER)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name", "group_name"),
+						q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, NO_NAME));
 			});
 		}
@@ -767,6 +865,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupsAndQuotasOfUser() {
 		try (var q = c.query(GET_GROUPS_AND_QUOTAS_OF_USER)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
@@ -776,6 +875,7 @@ class DQLTest extends SimpleDBTestBase {
 	void countMachineThings() {
 		try (var q = c.query(COUNT_MACHINE_THINGS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				var r = q.call1((row) -> Map.of(
 						"board_count", row.getInt("board_count"),
 						"in_use", row.getInt("in_use"),
@@ -792,6 +892,7 @@ class DQLTest extends SimpleDBTestBase {
 	void countPoweredBoards() {
 		try (var q = c.query(COUNT_POWERED_BOARDS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("job_id"), q.getParameters());
 				assertEquals(0, q.call1(integer("c"), NO_JOB).orElseThrow());
 			});
 		}
@@ -801,6 +902,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listLiveJobs() {
 		try (var q = c.query(LIST_LIVE_JOBS)) {
 			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
 				// No jobs right now
 				assertEquals(empty(), q.call1((row) -> 1));
 			});
@@ -811,6 +913,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getLocalUserDetails() {
 		try (var q = c.query(GET_LOCAL_USER_DETAILS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("user_name"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
@@ -820,6 +923,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getReportedBoards() {
 		try (var q = c.query(getReportedBoards)) {
 			c.transaction(() -> {
+				assertEquals(List.of("threshold"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, 0));
 			});
 		}
@@ -829,6 +933,7 @@ class DQLTest extends SimpleDBTestBase {
 	void isBoardBlacklistCurrent() {
 		try (var q = c.query(IS_BOARD_BLACKLIST_CURRENT)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -838,6 +943,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedChips() {
 		try (var q = c.query(GET_BLACKLISTED_CHIPS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -847,6 +953,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedCores() {
 		try (var q = c.query(GET_BLACKLISTED_CORES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -856,6 +963,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedLinks() {
 		try (var q = c.query(GET_BLACKLISTED_LINKS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
@@ -865,6 +973,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistReads() {
 		try (var q = c.query(GET_BLACKLIST_READS)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
@@ -874,6 +983,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistWrites() {
 		try (var q = c.query(GET_BLACKLIST_WRITES)) {
 			c.transaction(() -> {
+				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.manchester.spinnaker.alloc.db;
 
+import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static uk.ac.manchester.spinnaker.alloc.db.DBTestingUtils.NO_BLACKLIST_OP;
@@ -28,6 +29,7 @@ import static uk.ac.manchester.spinnaker.alloc.db.DBTestingUtils.NO_USER;
 import static uk.ac.manchester.spinnaker.alloc.db.Row.integer;
 import static uk.ac.manchester.spinnaker.alloc.model.JobState.QUEUED;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -886,7 +888,9 @@ class DQLTest extends SimpleDBTestBase {
 	void getSerialInfoReqs() {
 		try (var q = c.query(GET_SERIAL_INFO_REQS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(List.of(), q.getParameters());
+				assertEquals(List.of(), q.getResultSetColumnNames());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -53,7 +53,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllMachines() {
 		try (var q = c.query(GET_ALL_MACHINES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, false).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
 		}
 	}
@@ -62,7 +62,7 @@ class DQLTest extends SimpleDBTestBase {
 	void listMachineNames() {
 		try (var q = c.query(LIST_MACHINE_NAMES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, false).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
 		}
 	}
@@ -71,8 +71,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineById() {
 		try (var q = c.query(GET_MACHINE_BY_ID)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE,
-						false).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, false));
 			});
 		}
 	}
@@ -81,7 +80,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getNamedMachine() {
 		try (var q = c.query(GET_NAMED_MACHINE)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME, false).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, false));
 			});
 		}
 	}
@@ -90,7 +89,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineJobs() {
 		try (var q = c.query(GET_MACHINE_JOBS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -99,7 +98,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMachineReports() {
 		try (var q = c.query(GET_MACHINE_REPORTS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -108,7 +107,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobIds() {
 		try (var q = c.query(GET_JOB_IDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, 0, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, 0, 0));
 			});
 		}
 	}
@@ -127,7 +126,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJob() {
 		try (var q = c.query(GET_JOB)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -136,7 +135,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobBoards() {
 		try (var q = c.query(GET_JOB_BOARDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -145,7 +144,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobBoardCoords() {
 		try (var q = c.query(GET_JOB_BOARD_COORDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -167,7 +166,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootOfBoard() {
 		try (var q = c.query(GET_ROOT_OF_BOARD)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -176,7 +175,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootBMPAddress() {
 		try (var q = c.query(GET_ROOT_BMP_ADDRESS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -185,8 +184,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBMPAddress() {
 		try (var q = c.query(GET_BMP_ADDRESS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, 0,
-						0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0, 0));
 			});
 		}
 	}
@@ -195,7 +193,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardAddress() {
 		try (var q = c.query(GET_BOARD_ADDRESS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -204,7 +202,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardPowerInfo() {
 		try (var q = c.query(GET_BOARD_POWER_INFO)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -213,7 +211,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardJob() {
 		try (var q = c.query(GET_BOARD_JOB)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -222,7 +220,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardReports() {
 		try (var q = c.query(GET_BOARD_REPORTS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -231,7 +229,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardNumbers() {
 		try (var q = c.query(GET_BOARD_NUMBERS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -240,7 +238,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBmpBoardNumbers() {
 		try (var q = c.query(GET_BMP_BOARD_NUMBERS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, 0, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0, 0));
 			});
 		}
 	}
@@ -249,7 +247,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getLiveBoards() {
 		try (var q = c.query(GET_LIVE_BOARDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -258,7 +256,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getDeadBoards() {
 		try (var q = c.query(GET_DEAD_BOARDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -267,7 +265,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllBoards() {
 		try (var q = c.query(GET_ALL_BOARDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -286,7 +284,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getDeadLinks() {
 		try (var q = c.query(getDeadLinks)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -295,7 +293,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAvailableBoardNumbers() {
 		try (var q = c.query(GET_AVAILABLE_BOARD_NUMBERS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -304,7 +302,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getTags() {
 		try (var q = c.query(GET_TAGS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -324,7 +322,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardConnectInfo() {
 		try (var q = c.query(GET_BOARD_CONNECT_INFO)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -333,7 +331,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getRootCoords() {
 		try (var q = c.query(GET_ROOT_COORDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -342,7 +340,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getAllocationTasks() {
 		try (var q = c.query(getAllocationTasks)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, QUEUED).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, QUEUED));
 			});
 		}
 	}
@@ -351,7 +349,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findFreeBoard() {
 		try (var q = c.query(FIND_FREE_BOARD)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -360,8 +358,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getBoardByCoords() {
 		try (var q = c.query(GET_BOARD_BY_COORDS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, -1, -1,
-						-1).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
 		}
 	}
@@ -370,7 +368,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findExpiredJobs() {
 		try (var q = c.query(FIND_EXPIRED_JOBS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, 0));
 			});
 		}
 	}
@@ -388,7 +386,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getChanges() {
 		try (var q = c.query(GET_CHANGES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -397,8 +395,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findRectangle() {
 		try (var q = c.query(findRectangle)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, -1, -1, NO_MACHINE,
-						0).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, -1, -1, NO_MACHINE, 0));
 			});
 		}
 	}
@@ -407,8 +405,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findRectangleAt() {
 		try (var q = c.query(findRectangleAt)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD, -1, -1, NO_MACHINE,
-								0).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_BOARD, -1, -1, NO_MACHINE, 0));
 			});
 		}
 	}
@@ -417,8 +415,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findLocation() {
 		try (var q = c.query(findLocation)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE,
-						NO_BOARD).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_MACHINE, NO_BOARD));
 			});
 		}
 	}
@@ -448,7 +446,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getPerimeterLinks() {
 		try (var q = c.query(getPerimeterLinks)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -457,8 +455,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByGlobalChip() {
 		try (var q = c.query(findBoardByGlobalChip)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, -1,
-						-1).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, -1, -1));
 			});
 		}
 	}
@@ -467,8 +464,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByJobChip() {
 		try (var q = c.query(findBoardByJobChip)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB, NO_BOARD, -1,
-						-1).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_JOB, NO_BOARD, -1, -1));
 			});
 		}
 	}
@@ -477,8 +474,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByLogicalCoords() {
 		try (var q = c.query(findBoardByLogicalCoords)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, -1, -1,
-						-1).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
 		}
 	}
@@ -487,8 +484,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByPhysicalCoords() {
 		try (var q = c.query(findBoardByPhysicalCoords)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, -1, -1,
-						-1).isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_MACHINE, -1, -1, -1));
 			});
 		}
 	}
@@ -497,8 +494,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByIPAddress() {
 		try (var q = c.query(findBoardByIPAddress)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE,
-						"127.0.0.1").isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_MACHINE, "127.0.0.1"));
 			});
 		}
 	}
@@ -507,7 +504,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobsWithChanges() {
 		try (var q = c.query(getJobsWithChanges)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, 0));
 			});
 		}
 	}
@@ -516,8 +513,8 @@ class DQLTest extends SimpleDBTestBase {
 	void getConnectedBoards() {
 		try (var q = c.query(getConnectedBoards)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE, -1, -1, -1, -1, -1,
-						-1).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE, -1, -1,
+						-1, -1, -1, -1));
 			});
 		}
 	}
@@ -526,8 +523,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndXYZ() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_XYZ)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME, -1, -1, -1)
-						.isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, -1, -1, -1));
 			});
 		}
 	}
@@ -536,7 +532,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardById() {
 		try (var q = c.query(FIND_BOARD_BY_ID)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -545,8 +541,7 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndCFB() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_CFB)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME, -1, -1, -1)
-						.isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, -1, -1, -1));
 			});
 		}
 	}
@@ -555,8 +550,8 @@ class DQLTest extends SimpleDBTestBase {
 	void findBoardByNameAndIPAddress() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_IP_ADDRESS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME, "256.256.256.256")
-						.isPresent());
+				assertEquals(empty(),
+						q.call1((row) -> 1, NO_NAME, "256.256.256.256"));
 			});
 		}
 	}
@@ -565,7 +560,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getFunctioningField() {
 		try (var q = c.query(GET_FUNCTIONING_FIELD)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -574,7 +569,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupQuota() {
 		try (var q = c.query(GET_GROUP_QUOTA)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_GROUP).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
 	}
@@ -603,7 +598,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupById() {
 		try (var q = c.query(GET_GROUP_BY_ID)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_GROUP).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
 	}
@@ -612,7 +607,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupByName() {
 		try (var q = c.query(GET_GROUP_BY_NAME)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -621,7 +616,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUsersOfGroup() {
 		try (var q = c.query(GET_USERS_OF_GROUP)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_GROUP).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_GROUP));
 			});
 		}
 	}
@@ -630,7 +625,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMembership() {
 		try (var q = c.query(GET_MEMBERSHIP)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MEMBER).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MEMBER));
 			});
 		}
 	}
@@ -639,7 +634,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getMembershipsOfUser() {
 		try (var q = c.query(GET_MEMBERSHIPS_OF_USER)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_USER).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
 	}
@@ -649,7 +644,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_QUOTA)) {
 			c.transaction(() -> {
 				// Still get a quota, it is just 0
-				assertTrue(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertNotEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -668,7 +663,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getJobUsageAndQuota() {
 		try (var q = c.query(GET_JOB_USAGE_AND_QUOTA)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_JOB).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_JOB));
 			});
 		}
 	}
@@ -678,7 +673,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_CONSOLIDATION_TARGETS)) {
 			c.transaction(() -> {
 				// Empty DB has no consolidation targets
-				assertFalse(q.call1((row) -> 1).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1));
 			});
 		}
 	}
@@ -688,7 +683,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(IS_USER_LOCKED)) {
 			c.transaction(() -> {
 				// Empty DB has no consolidation targets
-				assertFalse(q.call1((row) -> 1, "").isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, ""));
 			});
 		}
 	}
@@ -697,7 +692,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserAuthorities() {
 		try (var q = c.query(GET_USER_AUTHORITIES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_USER).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
 	}
@@ -707,7 +702,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_ALL_USERS)) {
 			c.transaction(() -> {
 				// Testing DB has no users by default
-				assertFalse(q.call1((row) -> 1).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1));
 			});
 		}
 	}
@@ -717,7 +712,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_ALL_USERS_OF_TYPE)) {
 			c.transaction(() -> {
 				// Testing DB has no users by default
-				assertFalse(q.call1((row) -> 1, false).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, false));
 			});
 		}
 	}
@@ -727,7 +722,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_USER_ID)) {
 			c.transaction(() -> {
 				// Testing DB has no users by default
-				assertFalse(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -736,7 +731,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetails() {
 		try (var q = c.query(GET_USER_DETAILS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_USER).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
 	}
@@ -745,7 +740,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetailsByName() {
 		try (var q = c.query(GET_USER_DETAILS_BY_NAME)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -754,7 +749,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getUserDetailsBySubject() {
 		try (var q = c.query(GET_USER_DETAILS_BY_SUBJECT)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -763,7 +758,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupByNameAndMember() {
 		try (var q = c.query(GET_GROUP_BY_NAME_AND_MEMBER)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME, NO_NAME));
 			});
 		}
 	}
@@ -772,7 +767,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getGroupsAndQuotasOfUser() {
 		try (var q = c.query(GET_GROUPS_AND_QUOTAS_OF_USER)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_NAME).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_NAME));
 			});
 		}
 	}
@@ -807,7 +802,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(LIST_LIVE_JOBS)) {
 			c.transaction(() -> {
 				// No jobs right now
-				assertFalse(q.call1((row) -> 1).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1));
 			});
 		}
 	}
@@ -816,7 +811,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getLocalUserDetails() {
 		try (var q = c.query(GET_LOCAL_USER_DETAILS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_USER).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_USER));
 			});
 		}
 	}
@@ -825,7 +820,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getReportedBoards() {
 		try (var q = c.query(getReportedBoards)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, 0).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, 0));
 			});
 		}
 	}
@@ -834,7 +829,7 @@ class DQLTest extends SimpleDBTestBase {
 	void isBoardBlacklistCurrent() {
 		try (var q = c.query(IS_BOARD_BLACKLIST_CURRENT)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -843,7 +838,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedChips() {
 		try (var q = c.query(GET_BLACKLISTED_CHIPS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -852,7 +847,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedCores() {
 		try (var q = c.query(GET_BLACKLISTED_CORES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -861,7 +856,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistedLinks() {
 		try (var q = c.query(GET_BLACKLISTED_LINKS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BOARD).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BOARD));
 			});
 		}
 	}
@@ -870,7 +865,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistReads() {
 		try (var q = c.query(GET_BLACKLIST_READS)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -879,7 +874,7 @@ class DQLTest extends SimpleDBTestBase {
 	void getBlacklistWrites() {
 		try (var q = c.query(GET_BLACKLIST_WRITES)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_MACHINE).isPresent());
+				assertEquals(empty(), q.call1((row) -> 1, NO_MACHINE));
 			});
 		}
 	}
@@ -902,7 +897,10 @@ class DQLTest extends SimpleDBTestBase {
 	void getCompletedBlacklistOp() {
 		try (var q = c.query(GET_COMPLETED_BLACKLIST_OP)) {
 			c.transaction(() -> {
-				assertFalse(q.call1((row) -> 1, NO_BLACKLIST_OP).isPresent());
+				assertEquals(List.of("op_id"), q.getParameters());
+				assertEquals(List.of("board_id", "op", "data", "failure"),
+						q.getResultSetColumnNames());
+				assertEquals(empty(), q.call1((row) -> 1, NO_BLACKLIST_OP));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -121,22 +121,23 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(List.of("machine_id"), q.getParameters());
 				assertEquals(
 						List.of("board_id", "report_id", "reported_issue",
-								"reporter_name", "report_timestamp"),
+								"report_timestamp", "reporter_name"),
 						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_MACHINE));
 			});
 		}
 	}
 
-	private static final List<String> MINI_JOB_COLUMNS =
-			List.of("job_id", "machine_id", "job_state", "keepalive_timestamp");
+	// private static final List<String> MINI_JOB_COLUMNS =
+	//		List.of("job_id", "machine_id", "job_state", "keepalive_timestamp");
 
 	@Test
 	void getJobIds() {
 		try (var q = c.query(GET_JOB_IDS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("limit", "offset"), q.getParameters());
-				assertEquals(MINI_JOB_COLUMNS, q.getColumns());
+				// Disabled: https://bugs.mysql.com/bug.php?id=103437
+				// assertEquals(MINI_JOB_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, 0, 0));
 			});
 		}
@@ -147,7 +148,8 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(GET_LIVE_JOB_IDS)) {
 			c.transaction(() -> {
 				assertEquals(List.of("limit", "offset"), q.getParameters());
-				assertEquals(MINI_JOB_COLUMNS, q.getColumns());
+				// Disabled: https://bugs.mysql.com/bug.php?id=103437
+				// assertEquals(MINI_JOB_COLUMNS, q.getColumns());
 				q.call(Row.integer("job_id"), 0, 0);
 				// Must not throw
 			});
@@ -288,7 +290,7 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(List.of("board_id"), q.getParameters());
 				assertEquals(
 						List.of("board_id", "report_id", "reported_issue",
-								"reporter_name", "report_timestamp"),
+								"report_timestamp", "reporter_name"),
 						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
@@ -594,6 +596,11 @@ class DQLTest extends SimpleDBTestBase {
 			"cabinet", "frame", "board_num", "chip_x", "chip_y", "board_chip_x",
 			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
 
+	private static final List<String> LOCATED_BOARD_2 = List.of("board_id",
+			"address", "x", "y", "z", "job_id", "machine_name", "cabinet",
+			"frame", "board_num", "chip_x", "chip_y", "board_chip_x",
+			"board_chip_y", "job_root_chip_x", "job_root_chip_y");
+
 	@Test
 	void findBoardByGlobalChip() {
 		try (var q = c.query(findBoardByGlobalChip)) {
@@ -613,7 +620,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("job_id", "board_id", "x", "y"),
 						q.getParameters());
-				assertEquals(LOCATED_BOARD, q.getColumns());
+				assertEquals(LOCATED_BOARD_2, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_JOB, NO_BOARD, -1, -1));
 			});
@@ -684,13 +691,17 @@ class DQLTest extends SimpleDBTestBase {
 		}
 	}
 
+	private static final List<String> FULL_BOARD_COLUMNS = List.of("board_id",
+			"x", "y", "z", "cabinet", "frame", "board_num", "address",
+			"machine_name", "bmp_serial_id", "physical_serial_id");
+
 	@Test
 	void findBoardByNameAndXYZ() {
 		try (var q = c.query(FIND_BOARD_BY_NAME_AND_XYZ)) {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_name", "x", "y", "z"),
 						q.getParameters());
-				assertEquals(BOARD_COLUMNS, q.getColumns());
+				assertEquals(FULL_BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, -1, -1, -1));
 			});
@@ -702,7 +713,7 @@ class DQLTest extends SimpleDBTestBase {
 		try (var q = c.query(FIND_BOARD_BY_ID)) {
 			c.transaction(() -> {
 				assertEquals(List.of("board_id"), q.getParameters());
-				assertEquals(BOARD_COLUMNS, q.getColumns());
+				assertEquals(FULL_BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_BOARD));
 			});
 		}
@@ -715,7 +726,7 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(
 						List.of("machine_name", "cabinet", "frame", "board"),
 						q.getParameters());
-				assertEquals(BOARD_COLUMNS, q.getColumns());
+				assertEquals(FULL_BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, -1, -1, -1));
 			});
@@ -728,7 +739,7 @@ class DQLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("machine_name", "address"),
 						q.getParameters());
-				assertEquals(BOARD_COLUMNS, q.getColumns());
+				assertEquals(FULL_BOARD_COLUMNS, q.getColumns());
 				assertEquals(empty(),
 						q.call1(Row::toString, NO_NAME, "256.256.256.256"));
 			});

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
@@ -142,7 +142,7 @@ public abstract class StubJob implements Job {
 	@Override
 	public final boolean equals(Object other) {
 		if (other instanceof Job) {
-			Job j = (Job) other;
+			var j = (Job) other;
 			return getId() == j.getId();
 		}
 		return false;

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubMachine.java
@@ -130,7 +130,7 @@ public abstract class StubMachine implements Machine {
 	@Override
 	public final boolean equals(Object other) {
 		if (other instanceof Machine) {
-			Machine m = (Machine) other;
+			var m = (Machine) other;
 			return getId() == m.getId();
 		}
 		return false;


### PR DESCRIPTION
* Add code to get the result columns (except where that fails due to a [MySQL connector bug](https://bugs.mysql.com/bug.php?id=103437)...). This is intended for use in testing; it's not designed to be fast.
* Add code to get the list of parameters too. I've wanted that for a while! This is intended for use in testing; it's not designed to be fast.
* Augment the SQL-related tests to use those above operations where possible.
* Fix the declarations of some of the SQL queries so their annotations match reality.
* Use [`UNIX_TIMESTAMP()`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_unix-timestamp) instead of passing `Instant.now()` explicitly; I think we can count on the DB knowing when is now.
* Clean up a few assignments to be of `final` fields or to use `var`. While I was in the area.
