### PR TITLE
Fix logged errors in testing of compat code

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
@@ -30,6 +30,7 @@ import static uk.ac.manchester.spinnaker.alloc.model.PowerState.ON;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
@@ -168,10 +169,10 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 			 * throw the information away. I'm not going to fix that.
 			 */
 			log.error("Something went wrong in comms", e);
+		} catch (InterruptedException | InterruptedIOException interrupted) {
+			log.debug("interrupted", interrupted);
 		} catch (IOException e) {
 			log.error("problem with socket {}", sock, e);
-		} catch (InterruptedException interrupted) {
-			log.error("Interrupted Exception!", interrupted);
 		} finally {
 			log.debug("closing down connection from {}", sock);
 			closeNotifiers();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
@@ -275,7 +275,7 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 				throw e;
 			}
 		}
-		if (isNull(line)) {
+		if (isNull(line) || line.isBlank()) {
 			if (currentThread().isInterrupted()) {
 				throw new InterruptedException();
 			}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTest.java
@@ -84,9 +84,7 @@ class V1CompatTest extends TestSupport {
 				act.accept(new PrintWriter(to),
 						new NonThrowingLineReader(from));
 			} finally {
-				if (!f.cancel(true)) {
-					log.error("cancel failed?");
-				}
+				log.debug("task cancel failed; probably already finished");
 			}
 		}
 	}


### PR DESCRIPTION
Don't know why there are empty strings being parsed (and failing) during the running of V1CompatTest, but this turns those into EOFs.
