### PR TITLE
Reduce timeout on cached HTTP connections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ on:
     - cron: "40 4 * * *"
 env:
   SETTINGS_FILE: .github/settings.xml
+  # Workaround for occasional unreliable downloads.
+  # See https://stackoverflow.com/q/55899091/301832 for details
+  MAVEN_OPTS: >
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+    -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
   compile:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,6 +73,12 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+      env:
+        # Workaround for occasional unreliable downloads.
+        # See https://stackoverflow.com/q/55899091/301832 for details
+        MAVEN_OPTS: >
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+          -Dmaven.wagon.http.retryHandler.count=3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/publish-pkgs.yml
+++ b/.github/workflows/publish-pkgs.yml
@@ -16,6 +16,15 @@ name: Publish package to GitHub Packages
 on:
   release:
     types: [created]
+
+env:
+  SETTINGS_FILE: .github/settings.xml
+  # Workaround for occasional unreliable downloads.
+  # See https://stackoverflow.com/q/55899091/301832 for details
+  MAVEN_OPTS: >
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+    -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -29,6 +38,6 @@ jobs:
           java-version: '11'
           distribution: 'zulu'
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: mvn deploy --batch-mode --settings $SETTINGS_FILE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,14 @@ on: #[push]
   push:
     branches: [ master ]
 
+env:
+  SETTINGS_FILE: .github/settings.xml
+  # Workaround for occasional unreliable downloads.
+  # See https://stackoverflow.com/q/55899091/301832 for details
+  MAVEN_OPTS: >
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+    -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,7 +33,6 @@ jobs:
       matrix:
         java: [14]
     env:
-      SETTINGS_FILE: .github/settings.xml
       SITE_DIR: target/staging
 
     steps:


### PR DESCRIPTION
The underlying problem is that Azure is a fairly hostile network environment by comparison with elsewhere; silent failures of sockets left open are extremely likely. This matters especially with the codeql analysis builds whenever the POM was updated (because that flushes caches and is a somewhat longer build than others use). If we preemptively close long-inactive sockets earlier, we don't hit the failure mode.

See https://stackoverflow.com/q/55899091/301832 for details and know that we've been seeing these occasionally.

