### PR TITLE
Second attempt to fix the download reliability problem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,10 @@ env:
   SETTINGS_FILE: .github/settings.xml
   # Workaround for occasional unreliable downloads.
   # See https://stackoverflow.com/q/55899091/301832 for details
+  # Except Maven doesn't use Wagon any more, but Aether.
+  # https://maven.apache.org/resolver/configuration.html
   MAVEN_OPTS: >
-    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-    -Dmaven.wagon.http.retryHandler.count=3
+    -Daether.connector.http.connectionMaxTtl=25
 
 jobs:
   compile:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,14 @@ on:
   schedule:
     - cron: '31 6 * * 0'
 
+env:
+  # Workaround for occasional unreliable downloads.
+  # See https://stackoverflow.com/q/55899091/301832 for details
+  # Except Maven doesn't use Wagon any more, but Aether.
+  # https://maven.apache.org/resolver/configuration.html
+  MAVEN_OPTS: >
+    -Daether.connector.http.connectionMaxTtl=25
+
 jobs:
   analyze:
     name: Analyze
@@ -73,12 +81,6 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-      env:
-        # Workaround for occasional unreliable downloads.
-        # See https://stackoverflow.com/q/55899091/301832 for details
-        MAVEN_OPTS: >
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-          -Dmaven.wagon.http.retryHandler.count=3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/publish-pkgs.yml
+++ b/.github/workflows/publish-pkgs.yml
@@ -21,9 +21,10 @@ env:
   SETTINGS_FILE: .github/settings.xml
   # Workaround for occasional unreliable downloads.
   # See https://stackoverflow.com/q/55899091/301832 for details
+  # Except Maven doesn't use Wagon any more, but Aether.
+  # https://maven.apache.org/resolver/configuration.html
   MAVEN_OPTS: >
-    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-    -Dmaven.wagon.http.retryHandler.count=3
+    -Daether.connector.http.connectionMaxTtl=25
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,10 @@ env:
   SETTINGS_FILE: .github/settings.xml
   # Workaround for occasional unreliable downloads.
   # See https://stackoverflow.com/q/55899091/301832 for details
+  # Except Maven doesn't use Wagon any more, but Aether.
+  # https://maven.apache.org/resolver/configuration.html
   MAVEN_OPTS: >
-    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-    -Dmaven.wagon.http.retryHandler.count=3
+    -Daether.connector.http.connectionMaxTtl=25
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ limitations under the License.
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 
 		<!-- What does the CheckForFIXME profile look for? -->
-		<forbidden.keywords.re>FIXME|Auto-generated method stub</forbidden.keywords.re>
+		<forbidden.keywords.re>\bFIXME\b|Auto-generated method stub</forbidden.keywords.re>
 
 		<spinnaker.version>7.0.0-SNAPSHOT</spinnaker.version>
 


### PR DESCRIPTION
Maven was ignoring the setting I was using in #786. This other approach ought to work, provided the config is right. The documentation of this is very poor and confusing!

The only place this setting is documented is on [this page](https://maven.apache.org/resolver/configuration.html), and that says *nothing* about the correct way to convey the setting into the point that reads it. I've had to guess that it is a system property.