### PR TITLE
Add two branches to the list that dependabot will keep updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,27 @@ updates:
     reviewers:
       - "Christian-B"
       - "rowleya"
+  # The next two are branches that need to be kept current
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "bug"
+      - "dependabot"
+    target-branch: "java-17"
+    assignees:
+      - "dkfellows"
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "bug"
+      - "dependabot"
+    target-branch: "spring-6"
+    assignees:
+      - "dkfellows"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Because #651 and #658 aren't about to be merged but need to be kept up to scratch.
