### PR TITLE
Update the version of checkstyle to 10.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
 		<spinnaker.version>7.0.0-SNAPSHOT</spinnaker.version>
 
 		<junit.version>5.9.3</junit.version>
-		<checkstyle.version>10.3.3</checkstyle.version>
+		<checkstyle.version>10.12.0</checkstyle.version>
 		<javadoc.version>3.5.0</javadoc.version>
 		<testing.version>3.1.0</testing.version>
 


### PR DESCRIPTION
Not sure why dependabot wasn't picking this up. I suspect there's a suppression, but I'm not sure; some parts of dependabot configs are very obscure (they already know about that; I can't remember what their issue number is).