### PR TITLE
Fix section titles in Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,10 +486,6 @@ limitations under the License.
 								<packages>uk.ac.manchester.spinnaker.connections*:uk.ac.manchester.spinnaker.alloc.client:uk.ac.manchester.spinnaker.messages*:uk.ac.manchester.spinnaker.transceiver*:uk.ac.manchester.spinnaker.spalloc*</packages>
 							</group>
 							<group>
-								<title>Storage Management</title>
-								<packages>uk.ac.manchester.spinnaker.storage*</packages>
-							</group>
-							<group>
 								<title>Front-End System</title>
 								<packages>uk.ac.manchester.spinnaker.front_end*</packages>
 							</group>

--- a/pom.xml
+++ b/pom.xml
@@ -486,8 +486,8 @@ limitations under the License.
 								<packages>uk.ac.manchester.spinnaker.connections*:uk.ac.manchester.spinnaker.alloc.client:uk.ac.manchester.spinnaker.messages*:uk.ac.manchester.spinnaker.transceiver*:uk.ac.manchester.spinnaker.spalloc*</packages>
 							</group>
 							<group>
-								<title>Data Management</title>
-								<packages>uk.ac.manchester.spinnaker.data_spec*:uk.ac.manchester.spinnaker.storage</packages>
+								<title>Storage Management</title>
+								<packages>uk.ac.manchester.spinnaker.storage*</packages>
 							</group>
 							<group>
 								<title>Front-End System</title>


### PR DESCRIPTION
Now dataspec is gone, the title of a section should change
