### PR TITLE
Sometimes, definitely want the proper mock client

### DIFF
--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/MockConnectedClient.java
@@ -161,13 +161,18 @@ public class MockConnectedClient extends SpallocClient {
 
 	@MustBeClosed
 	public MockConnectedClient(int timeout) {
+		this(timeout, true);
+	}
+
+	@MustBeClosed
+	public MockConnectedClient(int timeout, boolean actual) {
 		// Main
 		//super("spinnaker.cs.man.ac.uk", 22244, timeout);
 		// Spin2
 		super("spinnaker.cs.man.ac.uk", PORT, timeout);
 		// Bad
 		// super("127.0.0.0", 22244, timeout);
-		actual = true;
+		this.actual = actual;
 	}
 
 	@Override

--- a/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
+++ b/SpiNNaker-comms/src/test/java/uk/ac/manchester/spinnaker/spalloc/TestMockClient.java
@@ -62,7 +62,7 @@ public class TestMockClient {
 	@BeforeAll
 	@SuppressWarnings("MustBeClosed")
 	static void makeMockClient() {
-		client = new MockConnectedClient(timeout);
+		client = new MockConnectedClient(timeout, false);
 	}
 
 	@AfterAll


### PR DESCRIPTION
A mock class was sometimes running in the wrong mode. Not quite sure why, but allowing selection of the mode during mock creation fixes it. This fixes faults seen in compilation on several branches.