### PR TITLE
Better caching of node as it is large and inclined to go wrong

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: "Set up node cache"
-      uses: actions/cache@3.3.1
+      uses: actions/cache@v3.3.1
       with:
         path: '~/.m2/repository/com/github/eirslett/node'
         key: ${{ runner.os }}-node-${{ hashFiles('SpiNNaker-allocserv/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: "Set up node cache"
-      uses: actions/cache@3.3.1
+      uses: actions/cache@v3.3.1
       with:
         path: '~/.m2/repository/com/github/eirslett/node'
         key: ${{ runner.os }}-node-${{ hashFiles('SpiNNaker-allocserv/pom.xml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Set up node cache"
-        uses: actions/cache@3.3.1
+        uses: actions/cache@v3.3.1
         with:
           path: '~/.m2/repository/com/github/eirslett/node'
           key: ${{ runner.os }}-node-${{ hashFiles('SpiNNaker-allocserv/pom.xml') }}


### PR DESCRIPTION
Trying to reduce the rate at which we have build failures for stupid networking reasons. They *usually* show up when we're installing `node` (for running a typescript compiler) and I've not found a good way to conditionalise that on whether it's absent from the path, but what I can do is apply extra caching based on the knowledge that the version we have set doesn't change very often, nor does the file with that version number in.