### PR TITLE
Use right versioning scheme

### DIFF
--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-allocserv</artifactId>
 	<packaging>war</packaging>

--- a/SpiNNaker-comms/pom.xml
+++ b/SpiNNaker-comms/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-comms</artifactId>
 	<description>How to actually talk to a SpiNNaker machine and to Spalloc, the allocation service.</description>

--- a/SpiNNaker-front-end/pom.xml
+++ b/SpiNNaker-front-end/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-front-end</artifactId>
 	<properties>

--- a/SpiNNaker-machine/pom.xml
+++ b/SpiNNaker-machine/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-machine</artifactId>
 	<dependencies>

--- a/SpiNNaker-pacman/pom.xml
+++ b/SpiNNaker-pacman/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-pacman</artifactId>
 	<description>Implementation of the Partitioning and Configuration Manager (PACMAN).</description>

--- a/SpiNNaker-py2json/pom.xml
+++ b/SpiNNaker-py2json/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-py2json</artifactId>
 	<name>Python Configuration to JSON Converter</name>

--- a/SpiNNaker-storage/pom.xml
+++ b/SpiNNaker-storage/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-storage</artifactId>
 	<dependencies>

--- a/SpiNNaker-utils/pom.xml
+++ b/SpiNNaker-utils/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>SpiNNaker-utils</artifactId>
 	<description>General utilities for the SpiNNaker runtime.</description>

--- a/keycloak-management-client/pom.xml
+++ b/keycloak-management-client/pom.xml
@@ -22,7 +22,7 @@ limitations under the License.
 	<parent>
 		<groupId>uk.ac.manchester.spinnaker</groupId>
 		<artifactId>SpiNNaker</artifactId>
-		<version>7.1.0</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>keycloak-management-client</artifactId>
 	<name>Keycloak Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>uk.ac.manchester.spinnaker</groupId>
 	<artifactId>SpiNNaker</artifactId>
-	<version>7.1.0</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -31,8 +31,6 @@ limitations under the License.
 
 		<!-- What does the CheckForFIXME profile look for? -->
 		<forbidden.keywords.re>\bFIXME\b|Auto-generated method stub</forbidden.keywords.re>
-
-		<spinnaker.version>7.1.0</spinnaker.version>
 
 		<junit.version>5.9.3</junit.version>
 		<checkstyle.version>10.12.1</checkstyle.version>


### PR DESCRIPTION
Java/Maven has a different versioning scheme to Python; we've not released `7.1.0` so it has to be a `SNAPSHOT`.