### PR TITLE
Remote spinnaker compat

### DIFF
--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/jobmanager/JobManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/jobmanager/JobManager.java
@@ -222,10 +222,18 @@ public class JobManager implements NMPIQueueListener, JobManagerInterface {
 
 	/**
 	 * Start the manager's worker threads.
+	 * @throws IOException If we get an error starting a job.
 	 */
 	@PostConstruct
-	private void startManager() {
+	private void startManager() throws IOException {
 		threadGroup = new ThreadGroup("NMPI");
+
+		// Get all jobs that are supposedly running or waiting and start them
+		// again
+		for (var job : queueManager.getJobs()) {
+			addJob((Job) job);
+		}
+
 		// Start the queue manager
 		queueManager.addListener(this);
 		new Thread(threadGroup, queueManager::processResponsesFromQueue,

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/jobmanager/JobManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/jobmanager/JobManager.java
@@ -228,10 +228,20 @@ public class JobManager implements NMPIQueueListener, JobManagerInterface {
 	private void startManager() throws IOException {
 		threadGroup = new ThreadGroup("NMPI");
 
+		// Start looking for jobs after the startup of the services
+		scheduler.schedule(() -> startJobs(), STATUS_UPDATE_PERIOD,
+				TimeUnit.SECONDS);
+	}
+
+	private void startJobs() {
 		// Get all jobs that are supposedly running or waiting and start them
 		// again
 		for (var job : queueManager.getJobs()) {
-			addJob((Job) job);
+			try {
+				addJob((Job) job);
+			} catch (IOException e) {
+				logger.error("Error adding job at startup", e);
+			}
 		}
 
 		// Start the queue manager

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/model/NMPILog.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/model/NMPILog.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2014 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.model;
+
+import static java.util.Objects.isNull;
+
+/**
+ * A Neuromorphic Platform Interface log core.
+ */
+public class NMPILog {
+	/**
+	 * The content of the log.
+	 */
+	private StringBuilder buffer;
+
+	public NMPILog(StringBuilder buffer) {
+		this.buffer = buffer;
+	}
+
+	/**
+	 * Gets the current log contents.
+	 *
+	 * @return The log contents, or {@code null} if the log is not yet
+	 *         initialised.
+	 */
+	public String getContent() {
+		if (isNull(buffer)) {
+			return null;
+		}
+		return buffer.toString();
+	}
+
+	/**
+	 * Set the content.
+	 *
+	 * @param content The content to set
+	 */
+	public void setContent(final String content) {
+		this.buffer = new StringBuilder(content);
+	}
+
+	/**
+	 * Append the string to the log.
+	 *
+	 * @param content
+	 *            The string to append.
+	 */
+	public void appendContent(final String content) {
+		if (isNull(this.buffer)) {
+			this.buffer = new StringBuilder(content);
+		} else {
+			this.buffer.append(content);
+		}
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/model/QueueJobCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/model/QueueJobCompat.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.model;
+
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
+
+/**
+ * A Job that is a response from the queue.
+ */
+public class QueueJobCompat extends Job implements QueueNextResponse {
+
+	public void setCollabId(String collabId) {
+		setCollab(collabId);
+	}
+
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
@@ -92,5 +92,5 @@ public interface NMPIQueueManager {
 	/**
 	 * Close the manager.
 	 */
-	public void close();
+	void close();
 }

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
@@ -32,9 +32,9 @@ public interface NMPIQueueManager {
 	 * @param listener
 	 *            The listener to register
 	 */
-	public void addListener(final NMPIQueueListener listener);
+	void addListener(NMPIQueueListener listener);
 
-	public void processResponsesFromQueue();
+	void processResponsesFromQueue();
 
 	/**
 	 * Appends log messages to the log.
@@ -44,7 +44,7 @@ public interface NMPIQueueManager {
 	 * @param logToAppend
 	 *            The messages to append
 	 */
-	public void appendJobLog(final int id, final String logToAppend);
+	void appendJobLog(int id, String logToAppend);
 
 	/**
 	 * Mark a job as running.
@@ -52,7 +52,7 @@ public interface NMPIQueueManager {
 	 * @param id
 	 *            The ID of the job.
 	 */
-	public void setJobRunning(final int id);
+	void setJobRunning(int id);
 
 	/**
 	 * Marks a job as finished successfully.
@@ -67,8 +67,8 @@ public interface NMPIQueueManager {
 	 * @param provenance
 	 *            JSON provenance information
 	 */
-	public void setJobFinished(final int id, final String logToAppend,
-			final List<DataItem> outputs, final ObjectNode provenance);
+	void setJobFinished(int id, String logToAppend,
+			List<DataItem> outputs, ObjectNode provenance);
 
 	/**
 	 * Marks a job as finished with an error.
@@ -85,9 +85,9 @@ public interface NMPIQueueManager {
 	 * @param provenance
 	 *            JSON provenance information
 	 */
-	public void setJobError(final int id, final String logToAppend,
-			final List<DataItem> outputs, final Throwable error,
-			final ObjectNode provenance);
+	void setJobError(int id, String logToAppend,
+			List<DataItem> outputs, Throwable error,
+			ObjectNode provenance);
 
 	/**
 	 * Close the manager.

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
@@ -20,11 +20,18 @@ import java.util.List;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
 
 /**
  * Manages the NMPI queue, receiving jobs and submitting them to be run.
  */
 public interface NMPIQueueManager {
+
+	/**
+	 * Get jobs that are marked as running or in progress in some form.
+	 * @return A list of jobs.
+	 */
+	List<? extends Job> getJobs();
 
 	/**
 	 * Register a listener against the manager for new jobs.
@@ -34,6 +41,9 @@ public interface NMPIQueueManager {
 	 */
 	void addListener(NMPIQueueListener listener);
 
+	/**
+	 * Process responses from the queue now.
+	 */
 	void processResponsesFromQueue();
 
 	/**

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManager.java
@@ -15,116 +15,16 @@
  */
 package uk.ac.manchester.spinnaker.nmpi.nmpi;
 
-import static java.util.Objects.nonNull;
-import static org.joda.time.DateTimeZone.UTC;
-import static org.slf4j.LoggerFactory.getLogger;
-import static uk.ac.manchester.spinnaker.nmpi.ThreadUtils.sleep;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.PostConstruct;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.WebApplicationException;
-
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
-import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
-import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
-import uk.ac.manchester.spinnaker.nmpi.model.QueueEmpty;
-import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
-import uk.ac.manchester.spinnaker.nmpi.rest.JobDone;
-import uk.ac.manchester.spinnaker.nmpi.rest.JobLogOnly;
-import uk.ac.manchester.spinnaker.nmpi.rest.JobStatusOnly;
-import uk.ac.manchester.spinnaker.nmpi.rest.NMPIQueue;
 
 /**
  * Manages the NMPI queue, receiving jobs and submitting them to be run.
  */
-public class NMPIQueueManager {
-
-	/**
-	 * Job status when finished.
-	 */
-	public static final String STATUS_FINISHED = "finished";
-
-	/**
-	 * Job status when in the queue but the executer hasn't started.
-	 */
-	public static final String STATUS_VALIDATED = "validated";
-
-	/**
-	 * Job status when running.
-	 */
-	public static final String STATUS_RUNNING = "running";
-
-	/**
-	 * Job status when in error.
-	 */
-	public static final String STATUS_ERROR = "error";
-
-	/**
-	 * The name of the repository for the service.
-	 */
-	private static final String REPOSITORY =
-			"SpiNNaker Manchester temporary storage";
-
-	/**
-	 * The amount of time to sleep when an empty queue is detected.
-	 */
-	private static final int EMPTY_QUEUE_SLEEP_MS = 10000;
-
-	/** The queue to get jobs from. */
-	private NMPIQueue queue;
-
-	/** Marker to indicate if the manager is done or not. */
-	private boolean done = false;
-
-	/** The set of listeners for this queue. */
-	private final Set<NMPIQueueListener> listeners = new HashSet<>();
-
-	/** A cache of jobs that have been received. */
-	private final Map<Integer, Job> jobCache = new HashMap<>();
-
-	/** The log of the job so far. */
-	private final Map<Integer, StringBuilder> jobLog = new HashMap<>();
-
-	/**
-	 * Logger.
-	 */
-	private static final Logger logger = getLogger(NMPIQueueManager.class);
-
-	/** The hardware identifier for the queue. */
-	@Value("${nmpi.hardware}")
-	private String hardware;
-
-	/** The URL from which to load the data. */
-	@Value("${nmpi.url}")
-	private URL nmpiUrl;
-
-	/** The API key to authenticate against the server. */
-	@Value("${nmpi.apiKey}")
-	private String nmpiApiKey;
-
-	/**
-	 * Initialise the client.
-	 */
-	@PostConstruct
-	private void initAPIClient() {
-		queue = NMPIQueue.createClient(nmpiUrl.toString());
-	}
+public interface NMPIQueueManager {
 
 	/**
 	 * Register a listener against the manager for new jobs.
@@ -132,79 +32,9 @@ public class NMPIQueueManager {
 	 * @param listener
 	 *            The listener to register
 	 */
-	public void addListener(final NMPIQueueListener listener) {
-		listeners.add(listener);
-	}
+	public void addListener(final NMPIQueueListener listener);
 
-	private void handleWebAppError(final WebApplicationException e,
-			final String action) {
-		var body = e.getResponse().readEntity(String.class);
-		logger.error("Error {} ({}), continuing: {}", action, e.getMessage(),
-				body);
-	}
-
-	public void processResponsesFromQueue() {
-		while (!done) {
-			try {
-				logger.debug("Getting next job");
-				QueueNextResponse response;
-				try {
-					response = queue.getNextJob(nmpiApiKey, hardware);
-				} catch (final NotFoundException e) {
-					response = new QueueEmpty();
-				}
-				processResponse(response);
-			} catch (final WebApplicationException e) {
-				handleWebAppError(e, "getting next job");
-				sleep(EMPTY_QUEUE_SLEEP_MS);
-			} catch (final Exception e) {
-				logger.error("Error in getting next job", e);
-				sleep(EMPTY_QUEUE_SLEEP_MS);
-			}
-		}
-	}
-
-	/**
-	 * Process the response from the service.
-	 *
-	 * @param response The response to process
-	 */
-	private void processResponse(final QueueNextResponse response) {
-		if (response instanceof QueueEmpty) {
-			sleep(EMPTY_QUEUE_SLEEP_MS);
-		} else if (response instanceof Job) {
-			processResponse((Job) response);
-		} else {
-			throw new IllegalStateException();
-		}
-	}
-
-	/**
-	 * Process the response of a Job.
-	 *
-	 * @param job The job to process
-	 */
-	private void processResponse(final Job job) {
-		synchronized (jobCache) {
-			jobCache.put(job.getId(), job);
-		}
-		logger.debug("Job {} received", job.getId());
-		try {
-			for (final var listener : listeners) {
-				listener.addJob(job);
-			}
-			logger.debug("Setting job status");
-			logger.debug("Updating job status on server");
-			queue.updateJobStatus(nmpiApiKey, job.getId(),
-					new JobStatusOnly(STATUS_VALIDATED));
-		} catch (final WebApplicationException e) {
-			handleWebAppError(e, "updating job");
-			setJobError(job.getId(), null, null, e, null);
-		} catch (final IOException e) {
-			logger.error("Error in updating job", e);
-			setJobError(job.getId(), null, null, e, null);
-		}
-	}
+	public void processResponsesFromQueue();
 
 	/**
 	 * Appends log messages to the log.
@@ -214,18 +44,7 @@ public class NMPIQueueManager {
 	 * @param logToAppend
 	 *            The messages to append
 	 */
-	public void appendJobLog(final int id, final String logToAppend) {
-		var existingLog = jobLog.computeIfAbsent(
-				id, ignored -> new StringBuilder());
-		existingLog.append(logToAppend);
-		logger.debug("Job {} log is being updated", id);
-		try {
-			queue.updateJobLog(nmpiApiKey, id,
-					new JobLogOnly(existingLog.toString()));
-		} catch (WebApplicationException e) {
-			handleWebAppError(e, "updating job log");
-		}
-	}
+	public void appendJobLog(final int id, final String logToAppend);
 
 	/**
 	 * Mark a job as running.
@@ -233,16 +52,7 @@ public class NMPIQueueManager {
 	 * @param id
 	 *            The ID of the job.
 	 */
-	public void setJobRunning(final int id) {
-		logger.debug("Job {} is running", id);
-		logger.debug("Updating job status on server");
-		try {
-			queue.updateJobStatus(nmpiApiKey, id,
-					new JobStatusOnly(STATUS_RUNNING));
-		} catch (WebApplicationException e) {
-			handleWebAppError(e, "setting job to running");
-		}
-	}
+	public void setJobRunning(final int id);
 
 	/**
 	 * Marks a job as finished successfully.
@@ -258,29 +68,7 @@ public class NMPIQueueManager {
 	 *            JSON provenance information
 	 */
 	public void setJobFinished(final int id, final String logToAppend,
-			final List<DataItem> outputs, final ObjectNode provenance) {
-		logger.debug("Job {} is finished", id);
-
-		if (nonNull(logToAppend)) {
-			appendJobLog(id, logToAppend);
-		}
-
-		final var outputData = new OutputData(REPOSITORY);
-		final var job = new JobDone(STATUS_FINISHED);
-		outputData.setFiles(outputs);
-		job.setOutputData(outputData);
-		job.setTimestampCompletion(new DateTime(UTC));
-		job.setProvenance(provenance);
-
-		try {
-			logger.debug("Updating job status on server");
-			queue.finishJob(nmpiApiKey, id, job);
-		} catch (WebApplicationException e) {
-			handleWebAppError(e, "finishing job");
-		}
-		jobLog.remove(id);
-		jobCache.remove(id);
-	}
+			final List<DataItem> outputs, final ObjectNode provenance);
 
 	/**
 	 * Marks a job as finished with an error.
@@ -299,43 +87,10 @@ public class NMPIQueueManager {
 	 */
 	public void setJobError(final int id, final String logToAppend,
 			final List<DataItem> outputs, final Throwable error,
-			final ObjectNode provenance) {
-		logger.debug("Job {} finished with an error", id);
-		final var errors = new StringWriter();
-		error.printStackTrace(new PrintWriter(errors));
-		final var logMessage = new StringBuilder();
-		if (nonNull(logToAppend)) {
-			logMessage.append(logToAppend);
-		}
-		if (jobLog.containsKey(id) || (logMessage.length() > 0)) {
-			logMessage.append("\n\n==================\n");
-		}
-		logMessage.append("Error:\n");
-		logMessage.append(errors.toString());
-		appendJobLog(id, logMessage.toString());
-
-		final var job = new JobDone(STATUS_ERROR);
-		final var outputData = new OutputData(REPOSITORY);
-		outputData.setFiles(outputs);
-		job.setTimestampCompletion(new DateTime(UTC));
-		job.setOutputData(outputData);
-		job.setProvenance(provenance);
-
-		try {
-			logger.debug("Updating job on server");
-			queue.finishJob(nmpiApiKey, id, job);
-		} catch (WebApplicationException e) {
-			handleWebAppError(e, "finishing job on error");
-		}
-
-		jobLog.remove(id);
-		jobCache.remove(id);
-	}
+			final ObjectNode provenance);
 
 	/**
 	 * Close the manager.
 	 */
-	public void close() {
-		done = true;
-	}
+	public void close();
 }

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
@@ -43,7 +43,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
 import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
 import uk.ac.manchester.spinnaker.nmpi.model.NMPILog;
-import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
 import uk.ac.manchester.spinnaker.nmpi.model.QueueEmpty;
 import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
 import uk.ac.manchester.spinnaker.nmpi.rest.JobDoneCompat;
@@ -74,12 +73,6 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 	 * Job status when in error.
 	 */
 	public static final String STATUS_ERROR = "error";
-
-	/**
-	 * The name of the repository for the service.
-	 */
-	private static final String REPOSITORY =
-			"SpiNNaker Manchester temporary storage";
 
 	/**
 	 * The amount of time to sleep when an empty queue is detected.
@@ -283,10 +276,8 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 			appendJobLog(id, logToAppend);
 		}
 
-		final var outputData = new OutputData(REPOSITORY);
 		final var job = new JobDoneCompat(id, STATUS_FINISHED);
-		outputData.setFiles(outputs);
-		job.setOutputData(outputData);
+		job.setOutputData(outputs);
 		job.setTimestampCompletion(new DateTime(UTC));
 		job.setProvenance(provenance);
 
@@ -334,10 +325,8 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 		appendJobLog(id, logMessage.toString());
 
 		final var job = new JobDoneCompat(id, STATUS_ERROR);
-		final var outputData = new OutputData(REPOSITORY);
-		outputData.setFiles(outputs);
 		job.setTimestampCompletion(new DateTime(UTC));
-		job.setOutputData(outputData);
+		job.setOutputData(outputs);
 		job.setProvenance(provenance);
 
 		try {

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
@@ -138,7 +138,8 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 	public List<? extends Job> getJobs() {
 		var val = queue.getJobs(nmpiAuthHeader, hardware, STATUS_VALIDATED);
 		var run = queue.getJobs(nmpiAuthHeader, hardware, STATUS_RUNNING);
-		return Stream.concat(val.stream(), run.stream())
+		return Stream
+				.concat(val.getObjects().stream(), run.getObjects().stream())
 				.collect(Collectors.toList());
 	}
 

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
@@ -29,6 +29,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.ws.rs.NotFoundException;
@@ -130,6 +132,14 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 	private void initAPIClient() {
 		queue = NMPIQueueCompat.createClient(nmpiUrl.toString());
 		nmpiAuthHeader = NMPI_AUTH + " " + nmpiUsername + ":" + nmpiApiKey;
+	}
+
+	@Override
+	public List<? extends Job> getJobs() {
+		var val = queue.getJobs(nmpiAuthHeader, hardware, STATUS_VALIDATED);
+		var run = queue.getJobs(nmpiAuthHeader, hardware, STATUS_RUNNING);
+		return Stream.concat(val.stream(), run.stream())
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2014 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.nmpi;
+
+import static java.util.Objects.nonNull;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.nmpi.ThreadUtils.sleep;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
+import uk.ac.manchester.spinnaker.nmpi.model.NMPILog;
+import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueEmpty;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
+import uk.ac.manchester.spinnaker.nmpi.rest.JobDoneCompat;
+import uk.ac.manchester.spinnaker.nmpi.rest.JobStatusOnlyCompat;
+import uk.ac.manchester.spinnaker.nmpi.rest.NMPIQueueCompat;
+
+/**
+ * Manages the NMPI queue, receiving jobs and submitting them to be run.
+ */
+public class NMPIQueueManagerCompat implements NMPIQueueManager {
+
+	/**
+	 * Job status when finished.
+	 */
+	public static final String STATUS_FINISHED = "finished";
+
+	/**
+	 * Job status when in the queue but the executer hasn't started.
+	 */
+	public static final String STATUS_VALIDATED = "validated";
+
+	/**
+	 * Job status when running.
+	 */
+	public static final String STATUS_RUNNING = "running";
+
+	/**
+	 * Job status when in error.
+	 */
+	public static final String STATUS_ERROR = "error";
+
+	/**
+	 * The name of the repository for the service.
+	 */
+	private static final String REPOSITORY =
+			"SpiNNaker Manchester temporary storage";
+
+	/**
+	 * The amount of time to sleep when an empty queue is detected.
+	 */
+	private static final int EMPTY_QUEUE_SLEEP_MS = 10000;
+
+	/**
+	 * Header for APIKey authentication.
+	 */
+	private static final String NMPI_AUTH = "ApiKey";
+
+	/** The queue to get jobs from. */
+	private NMPIQueueCompat queue;
+
+	/** Marker to indicate if the manager is done or not. */
+	private boolean done = false;
+
+	/** The set of listeners for this queue. */
+	private final Set<NMPIQueueListener> listeners = new HashSet<>();
+
+	/** A cache of jobs that have been received. */
+	private final Map<Integer, Job> jobCache = new HashMap<>();
+
+	/** The log of the job so far. */
+	private final Map<Integer, StringBuilder> jobLog = new HashMap<>();
+
+	/**
+	 * Logger.
+	 */
+	private static final Logger logger = getLogger(NMPIQueueManager.class);
+
+	/** The hardware identifier for the queue. */
+	@Value("${nmpi.hardware}")
+	private String hardware;
+
+	/** The URL from which to load the data. */
+	@Value("${nmpi.url}")
+	private URL nmpiUrl;
+
+	/** The API key to authenticate against the server. */
+	@Value("${nmpi.apiKey}")
+	private String nmpiApiKey;
+
+	@Value("${nmpi.username}")
+	private String nmpiUsername;
+
+	/** The authorization header to use **/
+	private String nmpiAuthHeader;
+
+	/**
+	 * Initialise the client.
+	 */
+	@PostConstruct
+	private void initAPIClient() {
+		queue = NMPIQueueCompat.createClient(nmpiUrl.toString());
+		nmpiAuthHeader = NMPI_AUTH + " " + nmpiUsername + ":" + nmpiApiKey;
+	}
+
+	/**
+	 * Register a listener against the manager for new jobs.
+	 *
+	 * @param listener
+	 *            The listener to register
+	 */
+	@Override
+	public void addListener(final NMPIQueueListener listener) {
+		listeners.add(listener);
+	}
+
+	private void handleWebAppError(final WebApplicationException e,
+			final String action) {
+		var body = e.getResponse().readEntity(String.class);
+		logger.error("Error {} ({}), continuing: {}", action, e.getMessage(),
+				body);
+	}
+
+	@Override
+	public void processResponsesFromQueue() {
+		while (!done) {
+			try {
+				logger.debug("Getting next job");
+				QueueNextResponse response;
+				try {
+					response = queue.getNextJob(nmpiAuthHeader, hardware);
+				} catch (final NotFoundException e) {
+					response = new QueueEmpty();
+				}
+				processResponse(response);
+			} catch (final WebApplicationException e) {
+				handleWebAppError(e, "getting next job");
+				sleep(EMPTY_QUEUE_SLEEP_MS);
+			} catch (final Exception e) {
+				logger.error("Error in getting next job", e);
+				sleep(EMPTY_QUEUE_SLEEP_MS);
+			}
+		}
+	}
+
+	/**
+	 * Process the response from the service.
+	 *
+	 * @param response The response to process
+	 */
+	private void processResponse(final QueueNextResponse response) {
+		if (response instanceof QueueEmpty) {
+			sleep(EMPTY_QUEUE_SLEEP_MS);
+		} else if (response instanceof Job) {
+			processResponse((Job) response);
+		} else {
+			throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Process the response of a Job.
+	 *
+	 * @param job The job to process
+	 */
+	private void processResponse(final Job job) {
+		synchronized (jobCache) {
+			jobCache.put(job.getId(), job);
+		}
+		logger.debug("Job {} received", job.getId());
+		try {
+			for (final var listener : listeners) {
+				listener.addJob(job);
+			}
+			logger.debug("Setting job status");
+			logger.debug("Updating job status on server");
+			queue.updateJobStatus(nmpiAuthHeader, job.getId(),
+					new JobStatusOnlyCompat(job.getId(), STATUS_VALIDATED));
+		} catch (final WebApplicationException e) {
+			handleWebAppError(e, "updating job");
+			setJobError(job.getId(), null, null, e, null);
+		} catch (final IOException e) {
+			logger.error("Error in updating job", e);
+			setJobError(job.getId(), null, null, e, null);
+		}
+	}
+
+	/**
+	 * Appends log messages to the log.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            The messages to append
+	 */
+	@Override
+	public void appendJobLog(final int id, final String logToAppend) {
+		var existingLog = jobLog.computeIfAbsent(
+				id, ignored -> new StringBuilder());
+		existingLog.append(logToAppend);
+		logger.debug("Job {} log is being updated", id);
+		try {
+			queue.updateJobLog(nmpiAuthHeader, id,
+					new NMPILog(existingLog));
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "updating job log");
+		}
+	}
+
+	/**
+	 * Mark a job as running.
+	 *
+	 * @param id
+	 *            The ID of the job.
+	 */
+	@Override
+	public void setJobRunning(final int id) {
+		logger.debug("Job {} is running", id);
+		logger.debug("Updating job status on server");
+		try {
+			queue.updateJobStatus(nmpiAuthHeader, id,
+					new JobStatusOnlyCompat(id, STATUS_RUNNING));
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "setting job to running");
+		}
+	}
+
+	/**
+	 * Marks a job as finished successfully.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            Any additional log messages to append to the existing log
+	 *            (null if none)
+	 * @param outputs
+	 *            The outputs of the job (null if none)
+	 * @param provenance
+	 *            JSON provenance information
+	 */
+	@Override
+	public void setJobFinished(final int id, final String logToAppend,
+			final List<DataItem> outputs, final ObjectNode provenance) {
+		logger.debug("Job {} is finished", id);
+
+		if (nonNull(logToAppend)) {
+			appendJobLog(id, logToAppend);
+		}
+
+		final var outputData = new OutputData(REPOSITORY);
+		final var job = new JobDoneCompat(id, STATUS_FINISHED);
+		outputData.setFiles(outputs);
+		job.setOutputData(outputData);
+		job.setTimestampCompletion(new DateTime(UTC));
+		job.setProvenance(provenance);
+
+		try {
+			logger.debug("Updating job status on server");
+			queue.finishJob(nmpiAuthHeader, id, job);
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "finishing job");
+		}
+		jobLog.remove(id);
+		jobCache.remove(id);
+	}
+
+	/**
+	 * Marks a job as finished with an error.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            Any additional log messages to append to the existing log
+	 *            (null if none)
+	 * @param outputs
+	 *            Any outputs generated, or null if none
+	 * @param error
+	 *            The error details
+	 * @param provenance
+	 *            JSON provenance information
+	 */
+	@Override
+	public void setJobError(final int id, final String logToAppend,
+			final List<DataItem> outputs, final Throwable error,
+			final ObjectNode provenance) {
+		logger.debug("Job {} finished with an error", id);
+		final var errors = new StringWriter();
+		error.printStackTrace(new PrintWriter(errors));
+		final var logMessage = new StringBuilder();
+		if (nonNull(logToAppend)) {
+			logMessage.append(logToAppend);
+		}
+		if (jobLog.containsKey(id) || (logMessage.length() > 0)) {
+			logMessage.append("\n\n==================\n");
+		}
+		logMessage.append("Error:\n");
+		logMessage.append(errors.toString());
+		appendJobLog(id, logMessage.toString());
+
+		final var job = new JobDoneCompat(id, STATUS_ERROR);
+		final var outputData = new OutputData(REPOSITORY);
+		outputData.setFiles(outputs);
+		job.setTimestampCompletion(new DateTime(UTC));
+		job.setOutputData(outputData);
+		job.setProvenance(provenance);
+
+		try {
+			logger.debug("Updating job on server");
+			queue.finishJob(nmpiAuthHeader, id, job);
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "finishing job on error");
+		}
+
+		jobLog.remove(id);
+		jobCache.remove(id);
+	}
+
+	/**
+	 * Close the manager.
+	 */
+	@Override
+	public void close() {
+		done = true;
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerCompat.java
@@ -123,10 +123,11 @@ public class NMPIQueueManagerCompat implements NMPIQueueManager {
 	@Value("${nmpi.apiKey}")
 	private String nmpiApiKey;
 
+	/** The API username to authenticate against the server. */
 	@Value("${nmpi.username}")
 	private String nmpiUsername;
 
-	/** The authorization header to use **/
+	/** The authorization header to use. **/
 	private String nmpiAuthHeader;
 
 	/**

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerV3.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerV3.java
@@ -126,6 +126,12 @@ public class NMPIQueueManagerV3 implements NMPIQueueManager {
 		queue = NMPIQueue.createClient(nmpiUrl.toString());
 	}
 
+	@Override
+	public List<? extends Job> getJobs() {
+		return queue.getJobs(nmpiApiKey, hardware,
+				List.of(STATUS_VALIDATED, STATUS_RUNNING));
+	}
+
 	/**
 	 * Register a listener against the manager for new jobs.
 	 *

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerV3.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/nmpi/NMPIQueueManagerV3.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2014 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.nmpi;
+
+import static java.util.Objects.nonNull;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.slf4j.LoggerFactory.getLogger;
+import static uk.ac.manchester.spinnaker.nmpi.ThreadUtils.sleep;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.Job;
+import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueEmpty;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
+import uk.ac.manchester.spinnaker.nmpi.rest.JobDone;
+import uk.ac.manchester.spinnaker.nmpi.rest.JobLogOnly;
+import uk.ac.manchester.spinnaker.nmpi.rest.JobStatusOnly;
+import uk.ac.manchester.spinnaker.nmpi.rest.NMPIQueue;
+
+/**
+ * Manages the NMPI queue, receiving jobs and submitting them to be run.
+ */
+public class NMPIQueueManagerV3 implements NMPIQueueManager {
+
+	/**
+	 * Job status when finished.
+	 */
+	public static final String STATUS_FINISHED = "finished";
+
+	/**
+	 * Job status when in the queue but the executer hasn't started.
+	 */
+	public static final String STATUS_VALIDATED = "validated";
+
+	/**
+	 * Job status when running.
+	 */
+	public static final String STATUS_RUNNING = "running";
+
+	/**
+	 * Job status when in error.
+	 */
+	public static final String STATUS_ERROR = "error";
+
+	/**
+	 * The name of the repository for the service.
+	 */
+	private static final String REPOSITORY =
+			"SpiNNaker Manchester temporary storage";
+
+	/**
+	 * The amount of time to sleep when an empty queue is detected.
+	 */
+	private static final int EMPTY_QUEUE_SLEEP_MS = 10000;
+
+	/** The queue to get jobs from. */
+	private NMPIQueue queue;
+
+	/** Marker to indicate if the manager is done or not. */
+	private boolean done = false;
+
+	/** The set of listeners for this queue. */
+	private final Set<NMPIQueueListener> listeners = new HashSet<>();
+
+	/** A cache of jobs that have been received. */
+	private final Map<Integer, Job> jobCache = new HashMap<>();
+
+	/** The log of the job so far. */
+	private final Map<Integer, StringBuilder> jobLog = new HashMap<>();
+
+	/**
+	 * Logger.
+	 */
+	private static final Logger logger = getLogger(NMPIQueueManager.class);
+
+	/** The hardware identifier for the queue. */
+	@Value("${nmpi.hardware}")
+	private String hardware;
+
+	/** The URL from which to load the data. */
+	@Value("${nmpi.url}")
+	private URL nmpiUrl;
+
+	/** The API key to authenticate against the server. */
+	@Value("${nmpi.apiKey}")
+	private String nmpiApiKey;
+
+	/**
+	 * Initialise the client.
+	 */
+	@PostConstruct
+	private void initAPIClient() {
+		queue = NMPIQueue.createClient(nmpiUrl.toString());
+	}
+
+	/**
+	 * Register a listener against the manager for new jobs.
+	 *
+	 * @param listener
+	 *            The listener to register
+	 */
+	@Override
+	public void addListener(final NMPIQueueListener listener) {
+		listeners.add(listener);
+	}
+
+	private void handleWebAppError(final WebApplicationException e,
+			final String action) {
+		var body = e.getResponse().readEntity(String.class);
+		logger.error("Error {} ({}), continuing: {}", action, e.getMessage(),
+				body);
+	}
+
+	@Override
+	public void processResponsesFromQueue() {
+		while (!done) {
+			try {
+				logger.debug("Getting next job");
+				QueueNextResponse response;
+				try {
+					response = queue.getNextJob(nmpiApiKey, hardware);
+				} catch (final NotFoundException e) {
+					response = new QueueEmpty();
+				}
+				processResponse(response);
+			} catch (final WebApplicationException e) {
+				handleWebAppError(e, "getting next job");
+				sleep(EMPTY_QUEUE_SLEEP_MS);
+			} catch (final Exception e) {
+				logger.error("Error in getting next job", e);
+				sleep(EMPTY_QUEUE_SLEEP_MS);
+			}
+		}
+	}
+
+	/**
+	 * Process the response from the service.
+	 *
+	 * @param response The response to process
+	 */
+	private void processResponse(final QueueNextResponse response) {
+		if (response instanceof QueueEmpty) {
+			sleep(EMPTY_QUEUE_SLEEP_MS);
+		} else if (response instanceof Job) {
+			processResponse((Job) response);
+		} else {
+			throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Process the response of a Job.
+	 *
+	 * @param job The job to process
+	 */
+	private void processResponse(final Job job) {
+		synchronized (jobCache) {
+			jobCache.put(job.getId(), job);
+		}
+		logger.debug("Job {} received", job.getId());
+		try {
+			for (final var listener : listeners) {
+				listener.addJob(job);
+			}
+			logger.debug("Setting job status");
+			logger.debug("Updating job status on server");
+			queue.updateJobStatus(nmpiApiKey, job.getId(),
+					new JobStatusOnly(STATUS_VALIDATED));
+		} catch (final WebApplicationException e) {
+			handleWebAppError(e, "updating job");
+			setJobError(job.getId(), null, null, e, null);
+		} catch (final IOException e) {
+			logger.error("Error in updating job", e);
+			setJobError(job.getId(), null, null, e, null);
+		}
+	}
+
+	/**
+	 * Appends log messages to the log.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            The messages to append
+	 */
+	@Override
+	public void appendJobLog(final int id, final String logToAppend) {
+		var existingLog = jobLog.computeIfAbsent(
+				id, ignored -> new StringBuilder());
+		existingLog.append(logToAppend);
+		logger.debug("Job {} log is being updated", id);
+		try {
+			queue.updateJobLog(nmpiApiKey, id,
+					new JobLogOnly(existingLog.toString()));
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "updating job log");
+		}
+	}
+
+	/**
+	 * Mark a job as running.
+	 *
+	 * @param id
+	 *            The ID of the job.
+	 */
+	@Override
+	public void setJobRunning(final int id) {
+		logger.debug("Job {} is running", id);
+		logger.debug("Updating job status on server");
+		try {
+			queue.updateJobStatus(nmpiApiKey, id,
+					new JobStatusOnly(STATUS_RUNNING));
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "setting job to running");
+		}
+	}
+
+	/**
+	 * Marks a job as finished successfully.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            Any additional log messages to append to the existing log
+	 *            (null if none)
+	 * @param outputs
+	 *            The outputs of the job (null if none)
+	 * @param provenance
+	 *            JSON provenance information
+	 */
+	@Override
+	public void setJobFinished(final int id, final String logToAppend,
+			final List<DataItem> outputs, final ObjectNode provenance) {
+		logger.debug("Job {} is finished", id);
+
+		if (nonNull(logToAppend)) {
+			appendJobLog(id, logToAppend);
+		}
+
+		final var outputData = new OutputData(REPOSITORY);
+		final var job = new JobDone(STATUS_FINISHED);
+		outputData.setFiles(outputs);
+		job.setOutputData(outputData);
+		job.setTimestampCompletion(new DateTime(UTC));
+		job.setProvenance(provenance);
+
+		try {
+			logger.debug("Updating job status on server");
+			queue.finishJob(nmpiApiKey, id, job);
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "finishing job");
+		}
+		jobLog.remove(id);
+		jobCache.remove(id);
+	}
+
+	/**
+	 * Marks a job as finished with an error.
+	 *
+	 * @param id
+	 *            The ID of the job
+	 * @param logToAppend
+	 *            Any additional log messages to append to the existing log
+	 *            (null if none)
+	 * @param outputs
+	 *            Any outputs generated, or null if none
+	 * @param error
+	 *            The error details
+	 * @param provenance
+	 *            JSON provenance information
+	 */
+	@Override
+	public void setJobError(final int id, final String logToAppend,
+			final List<DataItem> outputs, final Throwable error,
+			final ObjectNode provenance) {
+		logger.debug("Job {} finished with an error", id);
+		final var errors = new StringWriter();
+		error.printStackTrace(new PrintWriter(errors));
+		final var logMessage = new StringBuilder();
+		if (nonNull(logToAppend)) {
+			logMessage.append(logToAppend);
+		}
+		if (jobLog.containsKey(id) || (logMessage.length() > 0)) {
+			logMessage.append("\n\n==================\n");
+		}
+		logMessage.append("Error:\n");
+		logMessage.append(errors.toString());
+		appendJobLog(id, logMessage.toString());
+
+		final var job = new JobDone(STATUS_ERROR);
+		final var outputData = new OutputData(REPOSITORY);
+		outputData.setFiles(outputs);
+		job.setTimestampCompletion(new DateTime(UTC));
+		job.setOutputData(outputData);
+		job.setProvenance(provenance);
+
+		try {
+			logger.debug("Updating job on server");
+			queue.finishJob(nmpiApiKey, id, job);
+		} catch (WebApplicationException e) {
+			handleWebAppError(e, "finishing job on error");
+		}
+
+		jobLog.remove(id);
+		jobCache.remove(id);
+	}
+
+	/**
+	 * Close the manager.
+	 */
+	@Override
+	public void close() {
+		done = true;
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobDoneCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobDoneCompat.java
@@ -15,13 +15,15 @@
  */
 package uk.ac.manchester.spinnaker.nmpi.rest;
 
+import java.util.List;
+
 import org.joda.time.DateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import uk.ac.manchester.spinnaker.nmpi.model.DateTimeSerialiser;
-import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
+import uk.ac.manchester.spinnaker.nmpi.model.job.nmpi.DataItem;
 
 /**
  * A Job where only the parts required for completion are set.
@@ -35,7 +37,7 @@ public class JobDoneCompat {
 	@JsonSerialize(using = DateTimeSerialiser.class)
 	private DateTime timestampCompletion;
 
-	private OutputData outputData;
+	private List<DataItem> outputData;
 
 	private ObjectNode provenance;
 
@@ -92,7 +94,7 @@ public class JobDoneCompat {
 	 *
 	 * @return the outputData
 	 */
-	public OutputData getOutputData() {
+	public List<DataItem> getOutputData() {
 		return outputData;
 	}
 
@@ -101,7 +103,7 @@ public class JobDoneCompat {
 	 *
 	 * @param outputDataParam the outputData to set
 	 */
-	public void setOutputData(final OutputData outputDataParam) {
+	public void setOutputData(final List<DataItem> outputDataParam) {
 		this.outputData = outputDataParam;
 	}
 

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobDoneCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobDoneCompat.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.rest;
+
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import uk.ac.manchester.spinnaker.nmpi.model.DateTimeSerialiser;
+import uk.ac.manchester.spinnaker.nmpi.model.OutputData;
+
+/**
+ * A Job where only the parts required for completion are set.
+ */
+public class JobDoneCompat {
+
+	private int id;
+
+	private String status;
+
+	@JsonSerialize(using = DateTimeSerialiser.class)
+	private DateTime timestampCompletion;
+
+	private OutputData outputData;
+
+	private ObjectNode provenance;
+
+	/**
+	 * Create a job with only a status.
+	 *
+	 * @param id The job id.
+	 * @param status The status to set.
+	 */
+	public JobDoneCompat(int id, String status) {
+		this.id = id;
+		this.status = status;
+	}
+
+	/**
+	 * Get the status.
+	 *
+	 * @return The status
+	 */
+	public String getStatus() {
+		return status;
+	}
+
+	/**
+	 * Set the status.
+	 *
+	 * @param status The status to set
+	 */
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	/**
+	 * Get the timestampCompletion.
+	 *
+	 * @return the timestampCompletion
+	 */
+	public DateTime getTimestampCompletion() {
+		return timestampCompletion;
+	}
+
+	/**
+	 * Sets the timestampCompletion.
+	 *
+	 * @param timestampCompletionParam the timestampCompletion to set
+	 */
+	public void setTimestampCompletion(
+			final DateTime timestampCompletionParam) {
+		this.timestampCompletion = timestampCompletionParam;
+	}
+
+	/**
+	 * Get the outputData.
+	 *
+	 * @return the outputData
+	 */
+	public OutputData getOutputData() {
+		return outputData;
+	}
+
+	/**
+	 * Sets the outputData.
+	 *
+	 * @param outputDataParam the outputData to set
+	 */
+	public void setOutputData(final OutputData outputDataParam) {
+		this.outputData = outputDataParam;
+	}
+
+	/**
+	 * Get the provenance.
+	 *
+	 * @return the provenance
+	 */
+	public ObjectNode getProvenance() {
+		return provenance;
+	}
+
+	/**
+	 * Sets the provenance.
+	 *
+	 * @param provenanceParam the provenance to set
+	 */
+	public void setProvenance(final ObjectNode provenanceParam) {
+		this.provenance = provenanceParam;
+	}
+
+	/**
+	 * Get the id.
+	 *
+	 * @return The id
+	 */
+	public int getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id.
+	 *
+	 * @param id The id
+	 */
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobListCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobListCompat.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.rest;
+
+import java.util.List;
+
+import uk.ac.manchester.spinnaker.nmpi.model.QueueJobCompat;
+
+/**
+ * A list of Jobs.
+ */
+public class JobListCompat {
+
+	private List<QueueJobCompat> objects;
+
+	/**
+	 * @return the jobs
+	 */
+	public List<QueueJobCompat> getObjects() {
+		return objects;
+	}
+
+	/**
+	 * @param objects the jobs to set
+	 */
+	public void setObjects(List<QueueJobCompat> objects) {
+		this.objects = objects;
+	}
+
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobStatusOnlyCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/JobStatusOnlyCompat.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.rest;
+
+/**
+ * A Job where only the status is set (to allow log updates).
+ */
+public class JobStatusOnlyCompat {
+
+	private int id;
+
+	private String status;
+
+	/**
+	 * Create a job with only a status.
+	 *
+	 * @param id The job id.
+	 * @param status The status to set.
+	 */
+	public JobStatusOnlyCompat(int id, String status) {
+		this.id = id;
+		this.status = status;
+	}
+
+	/**
+	 * Get the status.
+	 *
+	 * @return The status
+	 */
+	public String getStatus() {
+		return status;
+	}
+
+	/**
+	 * Set the status.
+	 *
+	 * @param status The status to set
+	 */
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	/**
+	 * Get the id.
+	 *
+	 * @return The id
+	 */
+	public int getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id.
+	 *
+	 * @param id The id
+	 */
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueue.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueue.java
@@ -47,9 +47,10 @@ public interface NMPIQueue {
 
 	/**
 	 * Gets all jobs in the queue.
-	 * @param apiKey
-	 *            The API key to use.
-	 * @return
+	 * @param apiKey The API key to use.
+	 * @param hardware The hardware to request the jobs for.
+	 * @param status List of accepted statuses.
+	 * @return The list of jobs that meet the criteria.
 	 */
 	@GET
 	@Path("jobs/")

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueue.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueue.java
@@ -26,6 +26,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import uk.ac.manchester.spinnaker.nmpi.model.QueueEmpty;
 import uk.ac.manchester.spinnaker.nmpi.model.QueueJob;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueJobCompat;
 import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
 import uk.ac.manchester.spinnaker.nmpi.rest.utils.CustomJacksonJsonProvider;
 import uk.ac.manchester.spinnaker.nmpi.rest.utils.PropertyBasedDeserialiser;
@@ -42,6 +44,20 @@ import uk.ac.manchester.spinnaker.nmpi.rest.utils.PropertyBasedDeserialiser;
  * The REST API for the HBP Neuromorphic Platform Interface queue.
  */
 public interface NMPIQueue {
+
+	/**
+	 * Gets all jobs in the queue.
+	 * @param apiKey
+	 *            The API key to use.
+	 * @return
+	 */
+	@GET
+	@Path("jobs/")
+	@Produces("application/json")
+	List<QueueJobCompat> getJobs(
+			@HeaderParam("x-api-key") String apiKey,
+			@QueryParam("hardware") String hardware,
+			@QueryParam("status") List<String> status);
 
 	/**
 	 * Get the next queue item for a specific hardware system.

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
@@ -55,7 +55,7 @@ public interface NMPIQueueCompat {
 	@GET
 	@Path("queue/")
 	@Produces("application/json")
-	List<QueueJobCompat> getJobs(
+	JobListCompat getJobs(
 			@HeaderParam("Authorization") String authHeader,
 			@QueryParam("hardware") String hardware,
 			@QueryParam("status") String status);

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
@@ -48,8 +48,10 @@ public interface NMPIQueueCompat {
 
 	/**
 	 * Gets all jobs in the queue.
-	 * @param authHeader
-	 *            The authorization header.
+	 * @param authHeader The authorization header.
+	 * @param hardware The hardware to request the jobs for.
+	 * @param status The accepted status.
+	 * @return The list of jobs that meet the criteria.
 	 * @return
 	 */
 	@GET

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
@@ -26,6 +26,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 
@@ -44,6 +45,20 @@ import uk.ac.manchester.spinnaker.nmpi.rest.utils.PropertyBasedDeserialiser;
  */
 @Path("/api/v2")
 public interface NMPIQueueCompat {
+
+	/**
+	 * Gets all jobs in the queue.
+	 * @param authHeader
+	 *            The authorization header.
+	 * @return
+	 */
+	@GET
+	@Path("queue/")
+	@Produces("application/json")
+	List<QueueJobCompat> getJobs(
+			@HeaderParam("Authorization") String authHeader,
+			@QueryParam("hardware") String hardware,
+			@QueryParam("status") String status);
 
 	/**
 	 * Get the next queue item for a specific hardware system.

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/rest/NMPIQueueCompat.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2014 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.nmpi.rest;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE;
+import static uk.ac.manchester.spinnaker.nmpi.rest.NMPIQueue.createProvider;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.ac.manchester.spinnaker.nmpi.model.NMPILog;
+import uk.ac.manchester.spinnaker.nmpi.model.QueueNextResponse;
+
+/**
+ * The REST API for the HBP Neuromorphic Platform Interface queue.
+ */
+@Path("/api/v2")
+public interface NMPIQueueCompat {
+
+	/**
+	 * Get the next queue item for a specific hardware system.
+	 *
+	 * @param authHeader
+	 *            The authorization header.
+	 * @param hardware
+	 *            The hardware ID.
+	 * @return The queue item.
+	 */
+	@GET
+	@Path("queue/submitted/next/{hardware}/")
+	@Produces("application/json")
+	QueueNextResponse getNextJob(
+			@HeaderParam("Authorization") String authHeader,
+			@PathParam("hardware") String hardware);
+
+	/**
+	 * Update the log of a job.
+	 *
+	 * @param authHeader
+	 *            The authorization header.
+	 * @param id
+	 *            The queue ID
+	 * @param log
+	 *            the Job Log.
+	 */
+	@PUT
+	@Path("log/{id}")
+	@Consumes("application/json")
+	void updateJobLog(@HeaderParam("Authorization") String authHeader,
+			@PathParam("id") int id, NMPILog log);
+
+	/**
+	 * Update the status of a job.
+	 *
+	 * @param authHeader
+	 *            The authorization header.
+	 * @param id
+	 *            The queue ID
+	 * @param status
+	 *            the Job Status.
+	 */
+	@PUT
+	@Path("queue/{id}")
+	@Consumes("application/json")
+	void updateJobStatus(@HeaderParam("Authorization") String authHeader,
+			@PathParam("id") int id, JobStatusOnlyCompat status);
+
+	/**
+	 * Set a job when done.
+	 *
+	 * @param authHeader
+	 *            The authorization header.
+	 * @param id
+	 *            The queue ID
+	 * @param job
+	 *            The details to update
+	 */
+	@PUT
+	@Path("jobs/{id}")
+	@Consumes("application/json")
+	void finishJob(@HeaderParam("Authorization") String authHeader,
+			@PathParam("id") int id, JobDoneCompat job);
+
+	/**
+	 * Get a client for the API.
+	 * @param url The URL to connect to.
+	 * @return A proxy of the API.
+	 */
+	static NMPIQueueCompat createClient(String url) {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.setPropertyNamingStrategy(SNAKE_CASE);
+		return JAXRSClientFactory.create(url, NMPIQueueCompat.class,
+				List.of(createProvider()));
+	}
+}

--- a/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/web/RemoteSpinnakerBeans.java
+++ b/SpiNNaker-nmpiserv/src/main/java/uk/ac/manchester/spinnaker/nmpi/web/RemoteSpinnakerBeans.java
@@ -48,6 +48,8 @@ import uk.ac.manchester.spinnaker.nmpi.machinemanager.SpallocJavaMachineManagerI
 import uk.ac.manchester.spinnaker.nmpi.machinemanager.SpallocMachineManagerImpl;
 import uk.ac.manchester.spinnaker.nmpi.model.machine.SpinnakerMachine;
 import uk.ac.manchester.spinnaker.nmpi.nmpi.NMPIQueueManager;
+import uk.ac.manchester.spinnaker.nmpi.nmpi.NMPIQueueManagerV3;
+import uk.ac.manchester.spinnaker.nmpi.nmpi.NMPIQueueManagerCompat;
 import uk.ac.manchester.spinnaker.nmpi.rest.OutputManager;
 import uk.ac.manchester.spinnaker.nmpi.rest.utils.NullExceptionMapper;
 import uk.ac.manchester.spinnaker.nmpi.status.Icinga2StatusMonitorManagerImpl;
@@ -174,6 +176,9 @@ public class RemoteSpinnakerBeans {
 	@Value("${status.update.type}")
 	private StatusServiceType statusType;
 
+	@Value("${nmpi.compat}")
+	private boolean compatNmpi;
+
 	/**
 	 * The machine manager; direct or via spalloc.
 	 *
@@ -197,7 +202,10 @@ public class RemoteSpinnakerBeans {
 	 */
 	@Bean
 	public NMPIQueueManager queueManager() {
-		return new NMPIQueueManager();
+		if (compatNmpi) {
+			return new NMPIQueueManagerCompat();
+		}
+		return new NMPIQueueManagerV3();
 	}
 
 	/**

--- a/SpiNNaker-nmpiserv/src/test/resources/nmpi.properties
+++ b/SpiNNaker-nmpiserv/src/test/resources/nmpi.properties
@@ -19,6 +19,7 @@ nmpi.url = https://localhost/
 # nmpi.username = uman
 nmpi.apiKey = None
 nmpi.hardware = SpiNNaker
+nmpi.compat = False
 results.directory = /tmp
 baseserver.url = http://localhost
 localbaseserver.url = http://localhost


### PR DESCRIPTION
Makes this version of RemoteSpiNNaker compatible with the old API which is still in use.  This lets us use docker with the old API which is easier to manage at the same time as supporting the new API.
