### PR TITLE
Test reliability fixes

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/admin/MachineStateControl.java
@@ -80,6 +80,8 @@ import uk.ac.manchester.spinnaker.utils.validation.IPAddress;
  */
 @Service
 public class MachineStateControl extends DatabaseAwareBean {
+	private static final int SHORT_WAIT = 500;
+
 	private static final Logger log = getLogger(MachineStateControl.class);
 
 	@Autowired
@@ -802,13 +804,18 @@ public class MachineStateControl extends DatabaseAwareBean {
 		@MustBeClosed
 		Op(@CompileTimeConstant final String operation, Object... args) {
 			boardId = (Integer) args[0];
-			epoch = epochs.getBlacklistEpoch(boardId);
+			var e = epochs.getBlacklistEpoch(boardId);
 			op = execute(conn -> {
 				try (var readReq = conn.update(operation)) {
 					return readReq.key(args);
 				}
 			}).orElseThrow(() -> new BlacklistException(
 					"could not create blacklist request"));
+			if (!e.isValid()) {
+				log.warn("early board epoch invalidation");
+				e = epochs.getBlacklistEpoch(boardId);
+			}
+			epoch = e;
 		}
 
 		/**
@@ -831,6 +838,7 @@ public class MachineStateControl extends DatabaseAwareBean {
 				throws InterruptedException, BlacklistException,
 				DataAccessException {
 			var end = now().plus(props.getBlacklistTimeout());
+			boolean once = false;
 			while (end.isAfter(now())) {
 				var result = executeRead(conn -> {
 					try (var getResult =
@@ -842,8 +850,17 @@ public class MachineStateControl extends DatabaseAwareBean {
 				if (result.isPresent()) {
 					return result;
 				}
-				log.debug("Waiting for blacklist change");
-				epoch.waitForChange(props.getBlacklistPoll());
+				if (!epoch.isValid()) {
+					// Things are going wonky; fall back on regular polling
+					if (!once) {
+						log.warn("epoch invalid for board {}?", boardId);
+						once = true;
+					}
+					Thread.sleep(SHORT_WAIT);
+				} else {
+					log.debug("Waiting for blacklist change");
+					epoch.waitForChange(props.getBlacklistPoll());
+				}
 			}
 			return Optional.empty();
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -891,7 +891,11 @@ public class AllocatorTask extends DatabaseAwareBean
 			// Inserts into pending_changes; these run after job is dead
 			var bmps = setPower(sql, id, OFF, DESTROYED);
 			sql.killAlloc.call(id);
-			sql.markAsDestroyed.call(reason, id);
+			int rows = sql.markAsDestroyed.call(reason, id);
+			if (rows != 1) {
+				log.warn("unexpected number of database rows affected: {}",
+						rows);
+			}
 			log.info("job {} marked as destroyed", id);
 			return bmps;
 		} finally {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -148,15 +148,17 @@ public class AllocatorTask extends DatabaseAwareBean
 	/**
 	 * Perform update on a job now as a result of a change.
 	 *
-	 * @param jobId The job to update.
-	 * @param sourceState The change source state.
-	 * @param targetState The change target state.
+	 * @param jobId
+	 *            The job to update.
+	 * @param sourceState
+	 *            The change source state.
+	 * @param targetState
+	 *            The change target state.
 	 */
 	public void updateJob(int jobId, JobState sourceState,
 			JobState targetState) {
-		scheduler.schedule(() -> {
-			updateJobNow(jobId, sourceState, targetState);
-		}, Instant.now());
+		scheduler.schedule(() -> updateJobNow(jobId, sourceState, targetState),
+				Instant.now());
 	}
 
 	private void updateJobNow(int jobId, JobState sourceState,

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -881,6 +881,7 @@ public class AllocatorTask extends DatabaseAwareBean
 		try (var sql = new DestroySQL(conn)) {
 			if (sql.getJob.call1(enumerate("job_state", JobState.class), id)
 					.orElse(DESTROYED) == DESTROYED) {
+				log.info("job {} already destroyed", id);
 				/*
 				 * Don't do anything if the job doesn't exist or is already
 				 * destroyed
@@ -891,6 +892,7 @@ public class AllocatorTask extends DatabaseAwareBean
 			var bmps = setPower(sql, id, OFF, DESTROYED);
 			sql.killAlloc.call(id);
 			sql.markAsDestroyed.call(reason, id);
+			log.info("job {} marked as destroyed", id);
 			return bmps;
 		} finally {
 			quotaManager.finishJob(id);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/PowerController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/PowerController.java
@@ -45,6 +45,8 @@ public interface PowerController {
 	 * @param targetState
 	 *            What state are we aiming to put the job into once the power
 	 *            has been switched. Should be {@link JobState#READY} or
+	 *            {@link JobState#QUEUED}. <strong>NB:</strong> Use
+	 *            {@link #destroyJob(int, String)} to move to
 	 *            {@link JobState#DESTROYED}.
 	 * @return Whether any change has been requested.
 	 */

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/QuotaManager.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/QuotaManager.java
@@ -50,7 +50,6 @@ import uk.ac.manchester.spinnaker.alloc.nmpi.NMPIv3API;
 import uk.ac.manchester.spinnaker.alloc.nmpi.ResourceUsage;
 import uk.ac.manchester.spinnaker.alloc.nmpi.SessionRequest;
 import uk.ac.manchester.spinnaker.alloc.nmpi.SessionResourceUpdate;
-import uk.ac.manchester.spinnaker.alloc.nmpi.SessionResponse;
 
 /**
  * Manages user quotas.
@@ -86,7 +85,7 @@ public class QuotaManager extends DatabaseAwareBean {
 
 	@PostConstruct
 	public void createProxy() {
-		String nmpiUrl = quotaProps.getNMPIUrl();
+		var nmpiUrl = quotaProps.getNMPIUrl();
 		if (!nmpiUrl.isEmpty()) {
 			nmpiProxy = NMPIv3API.createClient(quotaProps.getNMPIUrl());
 		}
@@ -351,7 +350,7 @@ public class QuotaManager extends DatabaseAwareBean {
 
 		// Update quota in group for collab from NMPI
 		try (var c = getConnection();
-				Update setQuota = c.update(SET_COLLAB_QUOTA)) {
+				var setQuota = c.update(SET_COLLAB_QUOTA)) {
 			setQuota.call(totalBoardSeconds, collab);
 		}
 
@@ -363,12 +362,12 @@ public class QuotaManager extends DatabaseAwareBean {
 
 	void associateNMPISession(int jobId, String user, String collab,
 			String quotaUnits) {
-		SessionRequest request = new SessionRequest();
+		var request = new SessionRequest();
 		request.setCollab(collab);
 		request.setHardwarePlatform(quotaProps.getNMPIPlaform());
 		request.setUserId(user);
-		SessionResponse session = nmpiProxy.createSession(
-				quotaProps.getNMPIApiKey(), request);
+		var session =
+				nmpiProxy.createSession(quotaProps.getNMPIApiKey(), request);
 
 		// Associate NMPI session with Job in the database
 		try (var c = getConnection();
@@ -384,11 +383,11 @@ public class QuotaManager extends DatabaseAwareBean {
 		// If it is possible to run this job, we need to associate the user
 		// with it because only special users can run jobs like this.
 		try (var c = getConnection();
-				Query getUserByName = c.query(GET_USER_DETAILS_BY_NAME);
-				Query getGroupByName = c.query(GET_GROUP_BY_NAME);
-				Update createUser = c.update(CREATE_USER);
-				Update createGroup = c.update(CREATE_GROUP_IF_NOT_EXISTS);
-				Update addUserToGroup = c.update(ADD_USER_TO_GROUP)) {
+				var getUserByName = c.query(GET_USER_DETAILS_BY_NAME);
+				var getGroupByName = c.query(GET_GROUP_BY_NAME);
+				var createUser = c.update(CREATE_USER);
+				var createGroup = c.update(CREATE_GROUP_IF_NOT_EXISTS);
+				var addUserToGroup = c.update(ADD_USER_TO_GROUP)) {
 			createGroup.call(job.getCollab(), 0.0, COLLABRATORY);
 			var userId = getUserByName.call1(r -> r.getInt("user_id"), user);
 
@@ -442,44 +441,37 @@ public class QuotaManager extends DatabaseAwareBean {
 				var getSession = c.query(GET_JOB_SESSION);
 				var getNMPIJob = c.query(GET_JOB_NMPI_JOB);
 				var getUsage = c.query(GET_JOB_USAGE_AND_QUOTA)) {
-
 			// Get the quota used
 			var quota = getUsage.call1(
 					r -> r.getLong("quota_used"), jobId);
 			// If job has associated session, update quota in session
-			getSession.call1(
-					r -> new Session(r), jobId).ifPresent(
-					session -> {
-							try {
-								var update = new SessionResourceUpdate();
-								update.setStatus("finished");
-								update.setResourceUsage(getResourceUsage(
-										quota.get(), session.quotaUnits));
-								nmpiProxy.setSessionStatusAndResources(
-										quotaProps.getNMPIApiKey(), session.id,
-										update);
-							} catch (BadRequestException e) {
-								log.error(e.getResponse().readEntity(
-										String.class));
-								throw e;
-							}
-						});
+			getSession.call1(Session::new, jobId).ifPresent(session -> {
+				try {
+					var update = new SessionResourceUpdate();
+					update.setStatus("finished");
+					update.setResourceUsage(
+							getResourceUsage(quota.get(), session.quotaUnits));
+					nmpiProxy.setSessionStatusAndResources(
+							quotaProps.getNMPIApiKey(), session.id, update);
+				} catch (BadRequestException e) {
+					log.error(e.getResponse().readEntity(String.class));
+					throw e;
+				}
+			});
 
 			// If job has associated NMPI job, update quota on NMPI job
-			getNMPIJob.call1(r -> new NMPIJob(r), jobId).ifPresent(
-					nmpiJob -> {
-						try {
-							var update = new JobResourceUpdate();
-							update.setResourceUsage(getResourceUsage(
-									quota.get(), nmpiJob.quotaUnits));
-							nmpiProxy.setJobResources(
-									quotaProps.getNMPIApiKey(), nmpiJob.id,
-									update);
-						} catch (BadRequestException e) {
-							log.error(e.getResponse().readEntity(String.class));
-							throw e;
-						}
-					});
+			getNMPIJob.call1(NMPIJob::new, jobId).ifPresent(nmpiJob -> {
+				try {
+					var update = new JobResourceUpdate();
+					update.setResourceUsage(
+							getResourceUsage(quota.get(), nmpiJob.quotaUnits));
+					nmpiProxy.setJobResources(quotaProps.getNMPIApiKey(),
+							nmpiJob.id, update);
+				} catch (BadRequestException e) {
+					log.error(e.getResponse().readEntity(String.class));
+					throw e;
+				}
+			});
 		}
 	}
 
@@ -507,21 +499,23 @@ public class QuotaManager extends DatabaseAwareBean {
 
 	private static ResourceUsage getResourceUsage(long boardSeconds,
 			String units) {
-		ResourceUsage resourceUsage = new ResourceUsage();
+		var resourceUsage = new ResourceUsage();
 		resourceUsage.setUnits(units);
 		if (units.equals(BOARD_SECONDS)) {
 			resourceUsage.setValue(boardSeconds);
 		} else if (units.equals(CORE_HOURS)) {
 			resourceUsage.setValue(toCoreHours(boardSeconds));
 		} else {
-			throw new RuntimeException("Unknown units " + units);
+			throw new IllegalArgumentException("Unknown units " + units);
 		}
 		return resourceUsage;
 	}
 
 	/**
 	 * Convert board-seconds to core-hours (approximately).
-	 * @param boardSeconds The number of board-seconds to convert.
+	 *
+	 * @param boardSeconds
+	 *            The number of board-seconds to convert.
 	 * @return The number of board-hours, which may have fractional values.
 	 */
 	private static double toCoreHours(long boardSeconds) {
@@ -531,7 +525,9 @@ public class QuotaManager extends DatabaseAwareBean {
 
 	/**
 	 * Convert core-hours to board-seconds (approximately).
-	 * @param coreHours The number of core-hours to convert.
+	 *
+	 * @param coreHours
+	 *            The number of core-hours to convert.
 	 * @return The integer number of board seconds.
 	 */
 	private static long toBoardSeconds(double coreHours) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/QuotaManager.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/QuotaManager.java
@@ -24,6 +24,7 @@ import static uk.ac.manchester.spinnaker.alloc.nmpi.ResourceUsage.CORE_HOURS;
 import static uk.ac.manchester.spinnaker.alloc.model.GroupRecord.GroupType.COLLABRATORY;
 import static uk.ac.manchester.spinnaker.alloc.security.TrustLevel.USER;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
@@ -45,8 +46,10 @@ import uk.ac.manchester.spinnaker.alloc.db.DatabaseAPI.Query;
 import uk.ac.manchester.spinnaker.alloc.db.DatabaseAPI.Update;
 import uk.ac.manchester.spinnaker.alloc.db.DatabaseAwareBean;
 import uk.ac.manchester.spinnaker.alloc.db.Row;
+import uk.ac.manchester.spinnaker.alloc.nmpi.Job;
 import uk.ac.manchester.spinnaker.alloc.nmpi.JobResourceUpdate;
 import uk.ac.manchester.spinnaker.alloc.nmpi.NMPIv3API;
+import uk.ac.manchester.spinnaker.alloc.nmpi.Project;
 import uk.ac.manchester.spinnaker.alloc.nmpi.ResourceUsage;
 import uk.ac.manchester.spinnaker.alloc.nmpi.SessionRequest;
 import uk.ac.manchester.spinnaker.alloc.nmpi.SessionResourceUpdate;
@@ -81,13 +84,14 @@ public class QuotaManager extends DatabaseAwareBean {
 	@Autowired
 	private QuotaProperties quotaProps;
 
-	private NMPIv3API nmpiProxy = null;
+	/** The wrapped NMPI proxy, bound to the API key. */
+	private NMPI nmpi;
 
 	@PostConstruct
 	public void createProxy() {
 		var nmpiUrl = quotaProps.getNMPIUrl();
 		if (!nmpiUrl.isEmpty()) {
-			nmpiProxy = NMPIv3API.createClient(quotaProps.getNMPIUrl());
+			nmpi = new NMPI(quotaProps);
 		}
 	}
 
@@ -301,11 +305,11 @@ public class QuotaManager extends DatabaseAwareBean {
 		}
 
 		private class Target {
-			Object quotaUsed;
+			final Object quotaUsed;
 
-			int groupId;
+			final int groupId;
 
-			int jobId;
+			final int jobId;
 
 			Target(Row row) {
 				quotaUsed = row.getObject("quota_used");
@@ -315,90 +319,161 @@ public class QuotaManager extends DatabaseAwareBean {
 		}
 	}
 
-	Optional<String> mayCreateNMPISession(String collab) {
-		// Read collab from NMPI; fail if not there
-		var projects = nmpiProxy.getProjects(quotaProps.getNMPIApiKey(),
-				STATUS_ACCEPTED, collab);
-		String quotaUnits = null;
-		long totalBoardSeconds = 0L;
+	private static class QuotaInfo {
+		/** The size of quota remaining, in board-seconds. */
+		final long quota;
+
+		/** The units that the quota was measured in on the NMPI. */
+		final String units;
+
+		QuotaInfo(long quota, String units) {
+			this.quota = quota;
+			this.units = units;
+		}
+	}
+
+	private QuotaInfo parseQuotaData(List<Project> projects) {
+		String units = null;
+		long total = 0;
 		for (var project : projects) {
 			for (var quota : project.getQuotas()) {
-				if (quota.getPlatform().equals(quotaProps.getNMPIPlaform())) {
-					if (quotaUnits == null) {
-						quotaUnits = quota.getUnits();
-					} else if (quotaUnits != quota.getUnits()) {
-						throw new RuntimeException(
-								"Quotas have multiple units!");
-					}
+				if (!quota.getPlatform().equals(quotaProps.getNMPIPlaform())) {
+					continue;
+				}
+				if (units == null) {
+					units = quota.getUnits();
+				} else if (units != quota.getUnits()) {
+					throw new RuntimeException("Quotas have multiple units!");
+				}
 
-					long limitBoardSeconds = (long) quota.getLimit();
-					long usageBoardSeconds = (long) quota.getUsage();
-					if (quota.getUnits().equals(CORE_HOURS)) {
-						limitBoardSeconds = toBoardSeconds(quota.getLimit());
-						usageBoardSeconds = toBoardSeconds(quota.getUsage());
-					} else if (!quota.getUnits().equals(BOARD_SECONDS)) {
-						throw new RuntimeException("Unknown Quota units: "
-								+ quota.getUnits());
-					}
-					totalBoardSeconds += limitBoardSeconds - usageBoardSeconds;
+				switch (quota.getUnits()) {
+				case BOARD_SECONDS:
+					total += (long) (quota.getLimit() - quota.getUsage());
+					break;
+				case CORE_HOURS:
+					total += toBoardSeconds(quota.getLimit())
+							- toBoardSeconds(quota.getUsage());
+					break;
+				default:
+					throw new RuntimeException(
+							"Unknown Quota units: " + quota.getUnits());
 				}
 			}
 		}
+		return new QuotaInfo(total, units);
+	}
 
-		log.debug("Setting quota of collab {} to {}", collab,
-				totalBoardSeconds);
+	final Optional<String> mayCreateNMPISession(String collab) {
+		// Read collab from NMPI; fail if not there
+		var projects = nmpi.getProjects(STATUS_ACCEPTED, collab);
+		var info = parseQuotaData(projects);
+
+		log.debug("Setting quota of collab {} to {}", collab, info.quota);
 
 		// Update quota in group for collab from NMPI
 		try (var c = getConnection();
 				var setQuota = c.update(SET_COLLAB_QUOTA)) {
-			setQuota.call(totalBoardSeconds, collab);
+			c.transaction(() -> setQuota.call(info.quota, collab));
 		}
 
-		if (totalBoardSeconds > 0) {
-			return Optional.of(quotaUnits);
+		if (info.quota > 0) {
+			return Optional.of(info.units);
 		}
 		return Optional.empty();
 	}
 
 	void associateNMPISession(int jobId, String user, String collab,
 			String quotaUnits) {
-		var request = new SessionRequest();
-		request.setCollab(collab);
-		request.setHardwarePlatform(quotaProps.getNMPIPlaform());
-		request.setUserId(user);
-		var session =
-				nmpiProxy.createSession(quotaProps.getNMPIApiKey(), request);
+		var sessionId = nmpi.createSession(collab, user);
 
 		// Associate NMPI session with Job in the database
 		try (var c = getConnection();
 				var setSession = c.update(SET_JOB_SESSION)) {
-			setSession.call(jobId, session.getId(), quotaUnits);
+			c.transaction(
+					() -> setSession.call(jobId, sessionId, quotaUnits));
 		}
 	}
 
-	Optional<NMPIJobQuotaDetails> mayUseNMPIJob(String user, int nmpiJobId) {
+	private final class InflateUser extends AbstractSQL {
+		private final Query getUserByName =
+				conn.query(GET_USER_DETAILS_BY_NAME);
+
+		private final Query getGroupByName = conn.query(GET_GROUP_BY_NAME);
+
+		private final Update createUser = conn.update(CREATE_USER);
+
+		private final Update createGroup =
+				conn.update(CREATE_GROUP_IF_NOT_EXISTS);
+
+		private final Update addUserToGroup = conn.update(ADD_USER_TO_GROUP);
+
+		@Override
+		public void close() {
+			getUserByName.close();
+			getGroupByName.close();
+			createUser.close();
+			createGroup.close();
+			addUserToGroup.close();
+			super.close();
+		}
+
+		private Optional<Integer> getUserByName(String user) {
+			return getUserByName.call1(r -> r.getInt("user_id"), user);
+		}
+
+		private Optional<Integer> getGroupByName(String group) {
+			return getGroupByName.call1(r -> r.getInt("group_id"), group);
+		}
+
+		private boolean createUser(String user) {
+			return createUser.call(user, null, USER, false, null) > 0;
+		}
+
+		private boolean createGroup(String group) {
+			return createGroup.call(group, 0.0, COLLABRATORY) > 0;
+		}
+
+		private boolean addUserToGroup(int userId, Optional<Integer> groupId) {
+			return addUserToGroup.call(userId, groupId) > 0;
+		}
+
+		/**
+		 * Construct the user and group records if necessary and associate them.
+		 *
+		 * @param user
+		 *            The user name.
+		 * @param job
+		 *            The NMPI job details containing the collabratory (group)
+		 *            name.
+		 */
+		void inflateUser(String user, Job job) {
+			var userId = getUserByName(user).or(() -> {
+				/*
+				 * The user has never logged in directly, so we have to create
+				 * them.
+				 */
+				if (!createUser(user)) {
+					log.warn("failed to make user: {}", user);
+				}
+				return getUserByName(user);
+			});
+
+			createGroup(job.getCollab());
+			var groupId = getGroupByName(job.getCollab());
+			addUserToGroup(userId.orElseThrow(() -> new IllegalStateException(
+					"failed to find or create user")), groupId);
+		}
+	}
+
+	final Optional<NMPIJobQuotaDetails> mayUseNMPIJob(String user,
+			int nmpiJobId) {
 		// Read job from NMPI to get collab ID
-		var job = nmpiProxy.getJob(quotaProps.getNMPIApiKey(), nmpiJobId);
+		var job = nmpi.getJob(nmpiJobId);
 
 		// If it is possible to run this job, we need to associate the user
 		// with it because only special users can run jobs like this.
-		try (var c = getConnection();
-				var getUserByName = c.query(GET_USER_DETAILS_BY_NAME);
-				var getGroupByName = c.query(GET_GROUP_BY_NAME);
-				var createUser = c.update(CREATE_USER);
-				var createGroup = c.update(CREATE_GROUP_IF_NOT_EXISTS);
-				var addUserToGroup = c.update(ADD_USER_TO_GROUP)) {
-			createGroup.call(job.getCollab(), 0.0, COLLABRATORY);
-			var userId = getUserByName.call1(r -> r.getInt("user_id"), user);
-
-			// The user has never logged in directly, so we have to create them
-			if (!userId.isPresent()) {
-				createUser.call(user, null, USER, false, null);
-				userId = getUserByName.call1(r -> r.getInt("user_id"), user);
-			}
-			var groupId = getGroupByName.call1(r -> r.getInt("group_id"),
-					job.getCollab());
-			addUserToGroup.call(userId.get(), groupId);
+		try (var sql = new InflateUser()) {
+			sql.transaction(() -> sql.inflateUser(user, job));
 		}
 
 		// This is now a collab so check there instead
@@ -411,15 +486,11 @@ public class QuotaManager extends DatabaseAwareBean {
 				new NMPIJobQuotaDetails(job.getCollab(), quotaUnits.get()));
 	}
 
-	final class NMPIJobQuotaDetails {
-		/**
-		 * The collaboratory ID.
-		 */
+	static final class NMPIJobQuotaDetails {
+		/** The collaboratory ID. */
 		final String collabId;
 
-		/**
-		 * The units of the Quota.
-		 */
+		/** The units of the Quota. */
 		final String quotaUnits;
 
 		private NMPIJobQuotaDetails(String collabId, String quotaUnits) {
@@ -432,50 +503,70 @@ public class QuotaManager extends DatabaseAwareBean {
 		// Associate NMPI Job with job in database
 		try (var c = getConnection();
 				var setNMPIJob = c.update(SET_JOB_NMPI_JOB)) {
-			setNMPIJob.call(jobId, nmpiJobId, quotaUnits);
+			c.transaction(() -> setNMPIJob.call(jobId, nmpiJobId, quotaUnits));
 		}
 	}
 
-	void finishJob(int jobId) {
+	/** Results of database queries. */
+	private static final class FinishInfo {
+		Optional<Long> quota;
+
+		Optional<Session> session;
+
+		Optional<NMPIJob> job;
+	}
+
+	private FinishInfo getFinishingInfo(int jobId) {
 		try (var c = getConnection();
 				var getSession = c.query(GET_JOB_SESSION);
 				var getNMPIJob = c.query(GET_JOB_NMPI_JOB);
 				var getUsage = c.query(GET_JOB_USAGE_AND_QUOTA)) {
 			// Get the quota used
-			var quota = getUsage.call1(
-					r -> r.getLong("quota_used"), jobId);
-			// If job has associated session, update quota in session
-			getSession.call1(Session::new, jobId).ifPresent(session -> {
-				try {
-					var update = new SessionResourceUpdate();
-					update.setStatus("finished");
-					update.setResourceUsage(
-							getResourceUsage(quota.get(), session.quotaUnits));
-					nmpiProxy.setSessionStatusAndResources(
-							quotaProps.getNMPIApiKey(), session.id, update);
-				} catch (BadRequestException e) {
-					log.error(e.getResponse().readEntity(String.class));
-					throw e;
-				}
-			});
-
-			// If job has associated NMPI job, update quota on NMPI job
-			getNMPIJob.call1(NMPIJob::new, jobId).ifPresent(nmpiJob -> {
-				try {
-					var update = new JobResourceUpdate();
-					update.setResourceUsage(
-							getResourceUsage(quota.get(), nmpiJob.quotaUnits));
-					nmpiProxy.setJobResources(quotaProps.getNMPIApiKey(),
-							nmpiJob.id, update);
-				} catch (BadRequestException e) {
-					log.error(e.getResponse().readEntity(String.class));
-					throw e;
-				}
+			return c.transaction(false, () -> {
+				var i = new FinishInfo();
+				i.quota = getUsage.call1(r -> r.getLong("quota_used"), jobId);
+				i.session = getSession.call1(Session::new, jobId);
+				i.job = getNMPIJob.call1(NMPIJob::new, jobId);
+				return i;
 			});
 		}
 	}
 
-	private final class Session {
+	final void finishJob(int jobId) {
+		// Get the information about the job from the DB
+		var info = getFinishingInfo(jobId);
+
+		// From here on, we don't touch the DB but we do touch the network
+
+		if (!info.quota.isPresent()) {
+			// No quota? No update!
+			return;
+		}
+
+		// If job has associated session, update quota in session
+		info.session.ifPresent(session -> {
+			try {
+				nmpi.setSessionStatusAndResources(session.id, "finished",
+						getResourceUsage(info.quota.get(), session.quotaUnits));
+			} catch (BadRequestException e) {
+				log.error(e.getResponse().readEntity(String.class));
+				throw e;
+			}
+		});
+
+		// If job has associated NMPI job, update quota on NMPI job
+		info.job.ifPresent(nmpiJob -> {
+			try {
+				nmpi.setJobResources(nmpiJob.id,
+						getResourceUsage(info.quota.get(), nmpiJob.quotaUnits));
+			} catch (BadRequestException e) {
+				log.error(e.getResponse().readEntity(String.class));
+				throw e;
+			}
+		});
+	}
+
+	private static final class Session {
 		private int id;
 
 		private String quotaUnits;
@@ -486,7 +577,7 @@ public class QuotaManager extends DatabaseAwareBean {
 		}
 	}
 
-	private final class NMPIJob {
+	private static final class NMPIJob {
 		private int id;
 
 		private String quotaUnits;
@@ -567,5 +658,55 @@ public class QuotaManager extends DatabaseAwareBean {
 				QuotaManager.this.doConsolidate(c);
 			}
 		};
+	}
+}
+
+/**
+ * Wrapper round the proxy and its API key. Does a bit of wrapping and
+ * unwrapping of arguments and results.
+ *
+ * @author Donal Fellows
+ */
+final class NMPI {
+	private final NMPIv3API proxy;
+
+	private final String apiKey;
+
+	private final String platform;
+
+	NMPI(QuotaProperties quotaProps) {
+		proxy = NMPIv3API.createClient(quotaProps.getNMPIUrl());
+		apiKey = quotaProps.getNMPIApiKey();
+		platform = quotaProps.getNMPIPlaform();
+	}
+
+	Job getJob(int jobId) {
+		return proxy.getJob(apiKey, jobId);
+	}
+
+	void setJobResources(int jobId, ResourceUsage resources) {
+		var wrapper = new JobResourceUpdate();
+		wrapper.setResourceUsage(resources);
+		proxy.setJobResources(apiKey, jobId, wrapper);
+	}
+
+	List<Project> getProjects(String status, String collab) {
+		return proxy.getProjects(apiKey, status, collab);
+	}
+
+	int createSession(String collab, String user) {
+		var request = new SessionRequest();
+		request.setCollab(collab);
+		request.setHardwarePlatform(platform);
+		request.setUserId(user);
+		return proxy.createSession(apiKey, request).getId();
+	}
+
+	void setSessionStatusAndResources(int sessionId, String status,
+			ResourceUsage resources) {
+		var wrapper = new SessionResourceUpdate();
+		wrapper.setStatus(status);
+		wrapper.setResourceUsage(resources);
+		proxy.setSessionStatusAndResources(apiKey, sessionId, wrapper);
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -21,6 +21,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.alloc.Constants.TRIAD_CHIP_SIZE;
 import static uk.ac.manchester.spinnaker.alloc.Constants.TRIAD_DEPTH;
@@ -46,7 +47,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -300,12 +300,12 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			if (deleted) {
 				try (var jobs = conn.query(GET_JOB_IDS)) {
 					return new JobCollection(
-							jobs.call((row) -> makeJob(row), limit,	start));
+							jobs.call(this::makeJob, limit, start));
 				}
 			} else {
 				try (var jobs = conn.query(GET_LIVE_JOB_IDS)) {
-					return new JobCollection(jobs.call((row) -> makeJob(row),
-							limit, start));
+					return new JobCollection(
+							jobs.call(this::makeJob, limit, start));
 				}
 			}
 		});
@@ -1122,15 +1122,18 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 
 	private final class JobCollection implements Jobs {
 		@JsonIgnore
-		private Epoch epoch;
+		private final Epoch epoch;
 
-		private List<Job> jobs = new ArrayList<>();
+		private final List<Job> jobs;
 
 		private JobCollection(List<Job> jobs) {
 			this.jobs = jobs;
-			this.epoch = epochs.getJobsEpoch(
-					jobs.stream().map(j -> j.getId())
-					.collect(Collectors.toList()));
+			if (jobs.isEmpty()) {
+				epoch = null;
+			} else {
+				epoch = epochs.getJobsEpoch(
+						jobs.stream().map(Job::getId).collect(toList()));
+			}
 		}
 
 		@Override
@@ -1149,20 +1152,20 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		/**
 		 * Get the set of jobs changed.
 		 *
-		 * @param timeout The timeout to wait for until something happens.
+		 * @param timeout
+		 *            The timeout to wait for until something happens.
 		 * @return The set of changed job identifiers.
 		 */
+		@Override
 		public Collection<Integer> getChanged(Duration timeout) {
 			if (isNull(epoch)) {
-				return jobs.stream().map(
-						j -> j.getId()).collect(Collectors.toSet());
+				return jobs.stream().map(Job::getId).collect(toSet());
 			}
 			try {
 				return epoch.getChanged(timeout);
 			} catch (InterruptedException interrupted) {
 				currentThread().interrupt();
-				return jobs.stream().map(
-						j -> j.getId()).collect(Collectors.toSet());
+				return jobs.stream().map(Job::getId).collect(toSet());
 			}
 		}
 
@@ -1316,6 +1319,8 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 
 		private boolean partial;
 
+		private MachineImpl cachedMachine;
+
 		JobImpl(int id, int machineId) {
 			this.epoch = epochs.getJobsEpoch(id);
 			this.id = id;
@@ -1355,8 +1360,6 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 
 			this.epoch = epochs.getJobsEpoch(id);
 		}
-
-		private MachineImpl cachedMachine;
 
 		/**
 		 * Get the machine that this job is running on. May used a cached value.
@@ -1487,7 +1490,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 				for (var m : report.boards.stream()
 						.map(b -> q.getNamedMachine.call1(
 								r -> r.getInt("machine_id"), b.machine, true))
-						.collect(Collectors.toSet())) {
+						.collect(toSet())) {
 					if (m.isPresent()) {
 						epochs.machineChanged(m.get());
 					}
@@ -1669,6 +1672,12 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		@Override
 		public int hashCode() {
 			return id;
+		}
+
+		@Override
+		public String toString() {
+			return format("Job(id=%s,dims=(%s,%s,%s),start=%s,finish=%s)", id,
+					width, height, depth, startTime, finishTime);
 		}
 
 		private final class SubMachineImpl implements SubMachine {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -583,6 +583,7 @@ public class BMPController extends DatabaseAwareBean {
 		 * @throws InterruptedException
 		 *             If interrupted.
 		 */
+		@Override
 		boolean tryProcessRequest(SpiNNakerControl controller)
 				throws InterruptedException {
 			boolean ok = bmpAction(() -> {
@@ -809,6 +810,7 @@ public class BMPController extends DatabaseAwareBean {
 		 * @throws InterruptedException
 		 *             If interrupted.
 		 */
+		@Override
 		boolean tryProcessRequest(SpiNNakerControl controller)
 				throws InterruptedException {
 			return bmpAction(() -> {
@@ -988,6 +990,7 @@ public class BMPController extends DatabaseAwareBean {
 		/**
 		 * Periodically call to update, or trigger externally.
 		 */
+		@Override
 		public synchronized void run() {
 			log.trace("Searching for changes on BMP {}", bmpId);
 
@@ -1051,7 +1054,6 @@ public class BMPController extends DatabaseAwareBean {
 	 */
 	@ForTestingOnly
 	public interface TestAPI {
-
 		/**
 		 * Ensure things are set up after a database change that updates the
 		 * BMPs in the system.

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/Utils.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/Utils.java
@@ -85,8 +85,6 @@ abstract class Utils {
 					while (!interrupted()) {
 						notifier.waitAndNotify();
 					}
-				} catch (UnknownIOException e) {
-					// Nothing useful we can do here
 				} catch (DataAccessException e) {
 					log.error("SQL failure", e);
 				} catch (IOException e) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/compat/V1CompatTask.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.InetSocketAddress;
@@ -53,6 +52,7 @@ import org.slf4j.Logger;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import uk.ac.manchester.spinnaker.alloc.model.PowerState;
@@ -105,7 +105,7 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 	 * Note that synchronisation will be performed on this object.
 	 */
 	@GuardedBy("itself")
-	private final PrintWriter out;
+	private final Writer out;
 
 	/**
 	 * Make an instance that wraps a socket.
@@ -126,8 +126,7 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 		sock.setSoTimeout((int) getProperties().getReceiveTimeout().toMillis());
 
 		in = buffer(new InputStreamReader(sock.getInputStream(), UTF_8));
-		out = new PrintWriter(
-				new OutputStreamWriter(sock.getOutputStream(), UTF_8));
+		out = new OutputStreamWriter(sock.getOutputStream(), UTF_8);
 	}
 
 	/**
@@ -145,7 +144,7 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 		super(srv);
 		this.sock = null;
 		this.in = buffer(in);
-		this.out = new PrintWriter(out);
+		this.out = out;
 	}
 
 	final void handleConnection() {
@@ -160,15 +159,6 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 			if (interrupted()) {
 				log.debug("Shutdown on interrupt");
 			}
-		} catch (UnknownIOException e) {
-			/*
-			 * Nothing useful to do in this case except close.
-			 *
-			 * This happens when the problem is detected by a PrintWriter, but
-			 * the problem with PrintWriters is they swallow exceptions and
-			 * throw the information away. I'm not going to fix that.
-			 */
-			log.error("Something went wrong in comms", e);
 		} catch (InterruptedException | InterruptedIOException interrupted) {
 			log.debug("interrupted", interrupted);
 		} catch (IOException e) {
@@ -276,10 +266,10 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 				throw e;
 			}
 		}
+		if (currentThread().isInterrupted()) {
+			throw new InterruptedException();
+		}
 		if (isNull(line) || line.isBlank()) {
-			if (currentThread().isInterrupted()) {
-				throw new InterruptedException();
-			}
 			return Optional.empty();
 		}
 		var c = parseCommand(line);
@@ -304,10 +294,8 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 		log.debug("about to send message: {}", data);
 		// Synch so we definitely don't interleave bits of messages
 		synchronized (out) {
-			out.println(data);
-			if (out.checkError()) {
-				throw new UnknownIOException();
-			}
+			out.write(data + "\r\n");
+			out.flush();
 		}
 	}
 
@@ -407,6 +395,10 @@ public abstract class V1CompatTask extends V1CompatService.Aware {
 			log.trace("timeout");
 			// Message was not read by time timeout expired
 			return !currentThread().isInterrupted();
+		} catch (MismatchedInputException e) {
+			log.error("Error on message reception: {}", e.getMessage());
+			writeException(e);
+			return true;
 		} catch (JsonMappingException | JsonParseException e) {
 			log.error("Error on message reception", e);
 			writeException(e);
@@ -871,13 +863,5 @@ final class Oops extends RuntimeException {
 
 	Oops(String msg) {
 		super(msg);
-	}
-}
-
-final class UnknownIOException extends IOException {
-	private static final long serialVersionUID = -852489744228393668L;
-
-	UnknownIOException() {
-		super("unknown error writing message");
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -558,6 +558,13 @@ public abstract class SQLQueries {
 					+ "death_timestamp = UNIX_TIMESTAMP() "
 					+ "WHERE job_id = :job_id AND job_state != 4";
 
+	/** Record the reason for a job being destroyed. */
+	@Parameter("death_reason")
+	@Parameter("job_id")
+	protected static final String NOTE_DESTROY_REASON =
+			"UPDATE jobs SET death_reason = :death_reason "
+					+ "WHERE job_id = :job_id";
+
 	/**
 	 * Get the number of boards that are allocated to a job that are switched
 	 * on.

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -771,7 +771,6 @@ public abstract class SQLQueries {
 	 * @see AllocatorTask
 	 */
 	@Parameter("num_pending")
-	@Parameter("time_now")
 	@Parameter("job_id")
 	protected static final String SET_STATE_DESTROYED =
 			"UPDATE jobs SET job_state = 4, "

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/TestSupport.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/TestSupport.java
@@ -481,6 +481,15 @@ public abstract class TestSupport extends SQLQueries implements SupportQueries {
 		}
 	}
 
+	/** Sleep for one second. */
+	protected static void snooze5s() {
+		try {
+			Thread.sleep(DELAY_MS * 5);
+		} catch (InterruptedException e) {
+			assumeTrue(false, "sleep() was interrupted");
+		}
+	}
+
 	/** Capability provided by {@link #inContext(InC)} to what it guards. */
 	public interface C {
 		/**

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/TestSupport.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/TestSupport.java
@@ -20,6 +20,7 @@ import static java.time.Instant.now;
 import static java.time.Instant.ofEpochMilli;
 import static java.time.Instant.ofEpochSecond;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.spinnaker.alloc.db.Row.string;
@@ -38,7 +39,7 @@ import java.util.Set;
 import java.util.function.IntConsumer;
 import java.util.function.ObjIntConsumer;
 
-
+import org.junit.jupiter.api.parallel.Execution;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -60,6 +61,7 @@ import uk.ac.manchester.spinnaker.alloc.security.Permit;
 @SuppressWarnings({
 	"checkstyle:ParameterNumber", "checkstyle:VisibilityModifier"
 })
+@Execution(SAME_THREAD)
 public abstract class TestSupport extends SQLQueries implements SupportQueries {
 	/** Bring in the application Spring configuration that we're testing. */
 	@Configuration

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
@@ -566,6 +566,8 @@ class SpallocCoreTest extends TestSupport {
 
 				j.destroy("foo bar");
 
+				snooze1s(); // Time for internals to process
+
 				// reread
 				var j2 = spalloc.getJob(p, jobId).orElseThrow();
 				assertEquals(DESTROYED, j2.getState());

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
@@ -571,13 +571,12 @@ class SpallocCoreTest extends TestSupport {
 				assertEquals(Optional.empty(), j.getReason());
 				var ts0 = Instant.now().truncatedTo(SECONDS);
 				snooze1s();
-				log.info("pre-termination: {}", j);
 
 				j.destroy("foo bar");
 
 				snooze1s(); // Time for internals to process
 				try {
-					bmpTester.processRequests(1000, Set.of(BMP));
+					bmpTester.processRequests(1000);
 				} catch (Exception e) {
 					log.warn("exception processing BMP requests", e);
 				}
@@ -585,7 +584,6 @@ class SpallocCoreTest extends TestSupport {
 
 				// reread
 				var j2 = spalloc.getJob(p, jobId).orElseThrow();
-				log.info("post-termination: {}", j2);
 				assertEquals(DESTROYED, j2.getState());
 				var ts1 = j2.getFinishTime().orElseThrow();
 				assertFalse(ts0.isAfter(ts1));

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
@@ -24,17 +24,12 @@ import static uk.ac.manchester.spinnaker.alloc.model.PowerState.OFF;
 import static uk.ac.manchester.spinnaker.machine.ChipLocation.ZERO_ZERO;
 
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -63,7 +58,6 @@ import uk.ac.manchester.spinnaker.machine.board.PhysicalCoords;
 import uk.ac.manchester.spinnaker.machine.board.TriadCoords;
 import uk.ac.manchester.spinnaker.spalloc.messages.BoardCoordinates;
 import uk.ac.manchester.spinnaker.spalloc.messages.BoardPhysicalCoordinates;
-import uk.ac.manchester.spinnaker.utils.ValueHolder;
 
 @SpringBootTest
 @SpringJUnitWebConfig(TestSupport.Config.class)
@@ -84,16 +78,6 @@ class SpallocCoreTest extends TestSupport {
 		killDB();
 		setupDB1();
 		bmpTester = bmpController.getTestAPI();
-	}
-
-	private static void threadDump() {
-		var threadDump = new StringBuilder(System.lineSeparator());
-		var threadMXBean = ManagementFactory.getThreadMXBean();
-		for (var threadInfo : threadMXBean.dumpAllThreads(true,
-				true)) {
-			threadDump.append(threadInfo);
-		}
-		log.warn("thread dump for long termination " + threadDump);
 	}
 
 	// The actual tests
@@ -438,18 +422,6 @@ class SpallocCoreTest extends TestSupport {
 	@Nested
 	@DisplayName("Spalloc.Job")
 	class SpallocJobTest {
-		private ScheduledExecutorService exe;
-
-		@BeforeEach
-		void makeExecutor() {
-			exe = Executors.newScheduledThreadPool(1);
-		}
-
-		@AfterEach
-		void stopExecutor() {
-			exe.shutdown();
-		}
-
 		@Test
 		void getId() {
 			withStandardAllocatedJob((p, jobId) -> {
@@ -590,12 +562,6 @@ class SpallocCoreTest extends TestSupport {
 		@Timeout(15)
 		void termination() {
 			// Don't hold an allocation for this
-			var done = new ValueHolder<>(false);
-			var f = exe.schedule(() -> {
-				if (!done.getValue()) {
-					threadDump();
-				}
-			}, 1100, TimeUnit.MILLISECONDS);
 			inContext(c -> withJob(jobId -> {
 				var p = c.setAuth(USER_NAME);
 
@@ -624,9 +590,7 @@ class SpallocCoreTest extends TestSupport {
 				var ts1 = j2.getFinishTime().orElseThrow();
 				assertFalse(ts0.isAfter(ts1));
 				assertEquals(Optional.of("foo bar"), j2.getReason());
-				done.setValue(true);
 			}));
-			f.cancel(false);
 		}
 
 		@Test

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocCoreTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -45,6 +46,8 @@ import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.CreateDimensions;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.CreateDimensionsAt;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.CreateNumBoards;
 import uk.ac.manchester.spinnaker.alloc.allocator.SpallocAPI.Machine;
+import uk.ac.manchester.spinnaker.alloc.bmp.BMPController;
+import uk.ac.manchester.spinnaker.alloc.bmp.BMPController.TestAPI;
 import uk.ac.manchester.spinnaker.alloc.model.BoardCoords;
 import uk.ac.manchester.spinnaker.alloc.model.ConnectionInfo;
 import uk.ac.manchester.spinnaker.alloc.web.IssueReportRequest;
@@ -66,11 +69,15 @@ class SpallocCoreTest extends TestSupport {
 	@Autowired
 	private SpallocAPI spalloc;
 
+	private TestAPI bmpTester;
+
+	@SuppressWarnings("deprecation")
 	@BeforeEach
-	void checkSetup() throws IOException {
+	void checkSetup(@Autowired BMPController bmpController) throws IOException {
 		assumeTrue(db != null, "spring-configured DB engine absent");
 		killDB();
 		setupDB1();
+		bmpTester = bmpController.getTestAPI();
 	}
 
 	// The actual tests
@@ -552,6 +559,7 @@ class SpallocCoreTest extends TestSupport {
 		}
 
 		@Test
+		@Timeout(15)
 		void termination() {
 			// Don't hold an allocation for this
 			inContext(c -> withJob(jobId -> {
@@ -563,13 +571,21 @@ class SpallocCoreTest extends TestSupport {
 				assertEquals(Optional.empty(), j.getReason());
 				var ts0 = Instant.now().truncatedTo(SECONDS);
 				snooze1s();
+				log.info("pre-termination: {}", j);
 
 				j.destroy("foo bar");
 
 				snooze1s(); // Time for internals to process
+				try {
+					bmpTester.processRequests(1000, Set.of(BMP));
+				} catch (Exception e) {
+					log.warn("exception processing BMP requests", e);
+				}
+				snooze1s();
 
 				// reread
 				var j2 = spalloc.getJob(p, jobId).orElseThrow();
+				log.info("post-termination: {}", j2);
 				assertEquals(DESTROYED, j2.getState());
 				var ts1 = j2.getFinishTime().orElseThrow();
 				assertFalse(ts0.isAfter(ts1));

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
@@ -99,11 +99,16 @@ class BlacklistCommsTest extends TestSupport {
 	 * A faked up running of the BMP worker thread because the main schedule is
 	 * disabled.
 	 *
+	 * @param bmps
+	 *            The IDs of the BMPs to process information for.
+	 * @param count
+	 *            The number of times to run the processing loop.
 	 * @return The future to wait for as part of shutting down. The value is
 	 *         meaningless, but the exceptions potentially thrown are not.
-	 * @throws InterruptedException If interrupted.
+	 * @throws InterruptedException
+	 *             If interrupted.
 	 */
-	private Future<String> bmpWorker(Collection<Integer> bmps)
+	private Future<String> bmpWorker(Collection<Integer> bmps, int count)
 			throws InterruptedException {
 		var ready = new OneShotEvent();
 		var future = exec.submit(() -> {
@@ -121,7 +126,7 @@ class BlacklistCommsTest extends TestSupport {
 	@Timeout(TEST_TIMEOUT)
 	public void getSerialNumber() throws Exception {
 		var bs = stateCtrl.findId(BOARD).orElseThrow();
-		var future = bmpWorker(Set.of(bs.bmpId));
+		var future = bmpWorker(Set.of(bs.bmpId), 1);
 
 		var serialNumber = stateCtrl.getSerialNumber(bs);
 
@@ -133,7 +138,7 @@ class BlacklistCommsTest extends TestSupport {
 	@Timeout(TEST_TIMEOUT)
 	public void readBlacklistFromMachine() throws Exception {
 		var bs = stateCtrl.findId(BOARD).orElseThrow();
-		var future = bmpWorker(Set.of(bs.bmpId));
+		var future = bmpWorker(Set.of(bs.bmpId), 1);
 
 		var bl = stateCtrl.readBlacklistFromMachine(bs).orElseThrow();
 
@@ -145,7 +150,7 @@ class BlacklistCommsTest extends TestSupport {
 	@Timeout(TEST_TIMEOUT)
 	public void writeBlacklistToMachine() throws Exception {
 		var bs = stateCtrl.findId(BOARD).orElseThrow();
-		var future = bmpWorker(Set.of(bs.bmpId));
+		var future = bmpWorker(Set.of(bs.bmpId), 2);
 		assertNotEquals(WRITE_BASELINE, txrxFactory.getCurrentBlacklist());
 
 		stateCtrl.writeBlacklistToMachine(bs,

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -162,6 +162,18 @@ class DMLTest extends SimpleDBTestBase {
 	}
 
 	@Test
+	void noteDestroyReason() {
+		assumeWritable(c);
+		try (var u = c.update(NOTE_DESTROY_REASON)) {
+			c.transaction(() -> {
+				assertEquals(List.of("death_reason", "job_id"),
+						u.getParameters());
+				assertEquals(0, u.call("anything", NO_JOB));
+			});
+		}
+	}
+
+	@Test
 	void deleteTask() {
 		assumeWritable(c);
 		try (var u = c.update(DELETE_TASK)) {

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/SimpleDBTestBase.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/SimpleDBTestBase.java
@@ -16,11 +16,13 @@
 package uk.ac.manchester.spinnaker.alloc.db;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import uk.ac.manchester.spinnaker.alloc.TestSupport;
@@ -36,6 +38,7 @@ import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
  * Subclasses should be annotated with {@link SpringBootTest}.
  */
 @UsedInJavadocOnly(SpringBootTest.class)
+@Execution(SAME_THREAD)
 public abstract class SimpleDBTestBase extends TestSupport {
 	/**
 	 * The DB connection. Only valid in a test. <em>Must not</em> be modified by

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/SimpleDBTestBase.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/SimpleDBTestBase.java
@@ -16,13 +16,11 @@
 package uk.ac.manchester.spinnaker.alloc.db;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import uk.ac.manchester.spinnaker.alloc.TestSupport;
@@ -38,7 +36,6 @@ import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
  * Subclasses should be annotated with {@link SpringBootTest}.
  */
 @UsedInJavadocOnly(SpringBootTest.class)
-@Execution(SAME_THREAD)
 public abstract class SimpleDBTestBase extends TestSupport {
 	/**
 	 * The DB connection. Only valid in a test. <em>Must not</em> be modified by

--- a/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ThreadUtils.java
+++ b/SpiNNaker-utils/src/main/java/uk/ac/manchester/spinnaker/utils/ThreadUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.utils;
+
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+import java.lang.management.ThreadInfo;
+
+/**
+ * Utilities for working with threads.
+ */
+public abstract class ThreadUtils {
+	/**
+	 * Produce a dump of what all threads are doing. Useful for debugging as it
+	 * means you can get a dump of threads programmatically at the time when the
+	 * problem is likely to be on some thread's stack.
+	 *
+	 * @return The dump, as a multi-line string.
+	 */
+	public static String threadDump() {
+		return stream(getThreadMXBean().dumpAllThreads(true, true))
+				.map(ThreadInfo::toString).collect(joining());
+	}
+}


### PR DESCRIPTION
Fixes several things that were severely impacting test reliability.

1. Tests that touch the DB *must* be single threaded, especially if they either insert entries with known IDs or delete entries. Without this, JUnit/Maven may decide to run things in parallel and that causes essentially random failures. This has been the cause of so much pain!
2. Tests with timeouts set must not complete with their thread's interrupted flag set or they'll blow up later... when the timeout occurs. I've filed a bug report with JUnit over this one; it should be at least documented, but dashed if I can find it.
3. Any use of a `PrintWriter` (except for `System.out` and `System.err`) is probably a bug waiting to happen due to how it swallows errors and loses the information about what went wrong.

The above changes were originally developed on the `java-17` branch.

4. Corrects handling of epochs. (From #995)
5. Ensures that all job destruction sets the timestamp and reason correctly, as other parts of the code (including the quota system) are critically dependent on that. There is now a transient state where the reason for destruction is set but the state has not yet changed; that is less harmful.