### PR TITLE
Add dependency submission action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,9 @@ jobs:
         name: spinnaker-exe.jar
         path: SpiNNaker-front-end/target/spinnaker-exe.jar
         retention-days: 5
+    - name: Submit Dependency Snapshot
+      if: matrix.java == 11
+      uses: advanced-security/maven-dependency-submission-action@v3
 
   validate:
     needs: compile


### PR DESCRIPTION
Suggested by Github, adds [maven-dependency-tree-dependency-submission action](https://github.com/marketplace/actions/maven-dependency-tree-dependency-submission). Apparently it handles dependencies of dependencies better than the standard scanner.