### PR TITLE
Do not fail when non-critical workflow steps fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,11 @@ jobs:
         name: spinnaker-exe.jar
         path: SpiNNaker-front-end/target/spinnaker-exe.jar
         retention-days: 5
+      continue-on-error: true
     - name: Submit Dependency Snapshot
       if: matrix.java == 11
       uses: advanced-security/maven-dependency-submission-action@v3
+      continue-on-error: true
 
   validate:
     needs: compile


### PR DESCRIPTION
Some workflow stages are non-critical. They can fail for various reasons (such as complexities of credentials for bots) and yet aren't actually very important if they don't run successfully for a particular workflow job. This marks them as something that the workflow can keep going after. (Coverage reporting already was such a stage.)

This was causing dependabot-submitted jobs to fail (e.g., #1012).