### PR TITLE
Skip down services when building truststore

### DIFF
--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -182,6 +182,8 @@ limitations under the License.
 								<server>${ebrains.wellknown.server}:443</server>
 								<server>${ebrains.wellknown.server.dev}:443</server>
 							</servers>
+							<!-- Skip things that are down -->
+							<retryDownloadOnFailure>false</retryDownloadOnFailure>
 						</configuration>
 					</execution>
 				</executions>

--- a/SpiNNaker-allocserv/pom.xml
+++ b/SpiNNaker-allocserv/pom.xml
@@ -180,10 +180,11 @@ limitations under the License.
 							<truststorePassword>${truststore.pass}</truststorePassword>
 							<servers>
 								<server>${ebrains.wellknown.server}:443</server>
+								<!-- Skip things that are down -->
+								<!--
 								<server>${ebrains.wellknown.server.dev}:443</server>
+								-->
 							</servers>
-							<!-- Skip things that are down -->
-							<retryDownloadOnFailure>false</retryDownloadOnFailure>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
If a development service is down, don't fail the build. The result might not work, but a failing build is bad and we don't want to be hostages to some other service in that respect.

The problem is that `iam-int.ebrains.eu` is down.