### PR TITLE
Remove unique constraint from blacklist_ops

### DIFF
--- a/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
+++ b/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
@@ -413,7 +413,7 @@ CREATE TABLE IF NOT EXISTS pending_changes (
 -- STMT
 CREATE TABLE IF NOT EXISTS blacklist_ops (
 	op_id INTEGER PRIMARY KEY AUTO_INCREMENT,
-	board_id INTEGER UNIQUE NOT NULL,
+	board_id INTEGER NOT NULL,
 		FOREIGN KEY (board_id)
 		REFERENCES boards(board_id) ON DELETE RESTRICT,
 	op INTEGER NOT NULL,		-- What we plan to do (NonBootOperations ID)


### PR DESCRIPTION
It appears to be OK to remove the unique here; multiple operations for a single board can be queued after all!