### PR TITLE
Order connected boards correctly

### DIFF
--- a/SpiNNaker-allocserv/src/main/resources/queries/connected_boards_at_coords.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/connected_boards_at_coords.sql
@@ -36,12 +36,19 @@ WITH RECURSIVE
 		FROM args, xrange, yrange, zrange, m
 		ORDER BY x, y, z),
 	-- Boards on the machine in the rectangle of interest
-	bs(board_id, x, y, z) AS (
-		SELECT boards.board_id, boards.x, boards.y, boards.z FROM boards
-		JOIN args USING (machine_id)
-		JOIN rect ON boards.x = rect.x AND boards.y = rect.y and boards.z = rect.z
+	bs(board_id, x, y, z, job_x, job_y, job_z) AS (
+		SELECT
+			boards.board_id, boards.x, boards.y, boards.z
+			(boards.x - args.x) % machines.width,
+			(boards.y - args.y) % machines.height,
+			(boards.z - args.z) % machines.depth
+		FROM boards
+			JOIN args USING (machine_id)
+			JOIN rect ON boards.x = rect.x AND boards.y = rect.y
+				AND boards.z = rect.z
+			JOIN machines USING (machine_id)
 		WHERE may_be_allocated
-		ORDER BY 2, 3, 4),
+		ORDER BY 5, 6, 7),
 	-- Links between boards of interest
 	ls(b1, b2) AS (SELECT board_1, board_2 FROM links
 		WHERE board_1 IN (SELECT board_id FROM bs)
@@ -59,4 +66,4 @@ WITH RECURSIVE
 SELECT
 	bs.board_id
 FROM bs JOIN connected ON bs.board_id = connected.b
-ORDER BY bs.x ASC, bs.y ASC, bs.z ASC;
+ORDER BY bs.job_x ASC, bs.job_y ASC, bs.job_z ASC;


### PR DESCRIPTION
The query to discover the connected boards at a candidate root coordinate and list them in order (so the root comes first) was wrong; it was ordering by the global coordinates, yet that's wrong when the candidate allocation is wrapped. Need to order by the (candidate) job-local coordinates instead.

The upshot of this was that some branches of the tools became very confused as to what was the root board and didn't work as a result.