### PR TITLE
A spell-checker... that ignores Javadoc?!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1251,5 +1251,33 @@ limitations under the License.
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>spellcheck</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.tomxiong</groupId>
+						<artifactId>spell-check-maven-plugin</artifactId>
+						<version>1.0.0</version>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<includes>
+								<include>**/*.java</include>
+							</includes>
+							<excludes>
+								<exclude>**/test/**</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
This is a spell-checker scheme for Java as a Maven plugin. It works... but scrupulously avoids looking at Javadoc for reasons I never understood, and which in turn make it be of extremely low value.

I'm putting it here so you know it exists, but I don't recommend it at all.

----

In writing this up, I found https://github.com/Jmcleodfoss/maven-javadoc-spellchecker which might be more relevant...

[EDIT]: That's a bust. I've investigated it further and it is really not packaged at all. Getting spell checking going properly for Javadoc seems to be a hard task and the pieces aren't joined up in the slightest; if I did the work to make it practical, I'd have the first such complete ensemble of tooling in the world as far as I can see because _nobody_ has assembled the pieces together right...