### PR TITLE
Dead links between allocated boards weren't being turned off

### DIFF
--- a/SpiNNaker-allocserv/src/main/resources/queries/perimeter.sql
+++ b/SpiNNaker-allocserv/src/main/resources/queries/perimeter.sql
@@ -17,10 +17,8 @@ WITH
 	bs AS (SELECT board_id FROM boards WHERE allocated_job = :job_id)
 SELECT board_1 AS board_id, dir_1 AS direction FROM links
 	WHERE board_1 IN (SELECT board_id FROM bs)
-	AND live
-	AND NOT board_2 IN (SELECT board_id FROM bs)
+	AND NOT (live AND board_2 IN (SELECT board_id FROM bs))
 UNION
 SELECT board_2 AS board_id, dir_2 AS direction FROM links
 	WHERE board_2 IN (SELECT board_id FROM bs)
-	AND live
-	AND NOT board_1 IN (SELECT board_id FROM bs);
+	AND NOT (live AND board_1 IN (SELECT board_id FROM bs));


### PR DESCRIPTION
I'd forgotten about the case where two boards have a dead link between them when computing the "perimeter"; that link should be in the perimeter (i.e., links which are disabled by spalloc before handing the powered board set to the user). Oops!

(I added the case in and then used De Morgan's laws to simplify to this.)