### PR TITLE
Handle bmp errors

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -1598,6 +1598,9 @@ public class SpallocProperties {
 		 * @param dummy
 		 *            Whether to use a dummy transceiver. Useful for testing
 		 *            only.
+		 * @param offWaitTime
+		 *            How long to wait between powering off and powering on
+		 *            a board.
 		 */
 		public TxrxProperties(@DefaultValue("10s") Duration period,
 				@DefaultValue("15s") Duration probeInterval,

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -1574,6 +1574,9 @@ public class SpallocProperties {
 		/** Whether to use a dummy transceiver. Useful for testing only. */
 		private boolean dummy;
 
+		/** The time a board has to be off before it can be powered on. */
+		private Duration offWaitTime;
+
 		/**
 		 * @param period
 		 *            How long between when we send requests to the BMP control
@@ -1602,7 +1605,8 @@ public class SpallocProperties {
 				@DefaultValue("3") int fpgaAttempts,
 				@DefaultValue("false") boolean fpgaReload,
 				@DefaultValue("5") int buildAttempts,
-				@DefaultValue("false") boolean dummy) {
+				@DefaultValue("false") boolean dummy,
+				@DefaultValue("30s") Duration offWaitTime) {
 			this.period = period;
 			this.probeInterval = probeInterval;
 			this.powerAttempts = powerAttempts;
@@ -1610,6 +1614,7 @@ public class SpallocProperties {
 			this.fpgaReload = fpgaReload;
 			this.buildAttempts = buildAttempts;
 			this.dummy = dummy;
+			this.offWaitTime = offWaitTime;
 		}
 
 		/**
@@ -1631,6 +1636,11 @@ public class SpallocProperties {
 		@NotNull
 		public Duration getProbeInterval() {
 			return probeInterval;
+		}
+
+		@NotNull
+		public Duration getOffWaitTime() {
+			return offWaitTime;
 		}
 
 		void setProbeInterval(Duration probeInterval) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -618,7 +618,7 @@ public class AllocatorTask extends DatabaseAwareBean
 		}
 
 		void updateBMPs() {
-			if (!bmps.isEmpty()) {
+			if (!bmps.isEmpty() && bmpController != null) {
 				// Poke the BMP controller to start looking!
 				log.debug("Triggering BMPs {}", bmps);
 				bmpController.triggerSearch(bmps);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -328,7 +328,12 @@ public class AllocatorTask extends DatabaseAwareBean
 
 		ChangeStatus(Row row) {
 			nChanges = row.getInt("n_changes");
-			nErrors = row.getInt("n_errors");
+			Integer errors = row.getInteger("n_errors");
+			if (errors == null) {
+				nErrors = 0;
+			} else {
+				nErrors = errors;
+			}
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -185,12 +185,12 @@ public class AllocatorTask extends DatabaseAwareBean
 
 	private boolean update(int jobId, JobState sourceState,
 			JobState targetState, Connection c) {
-		try (var getNTasks = c.query(COUNT_CHANGES_FOR_JOB);
+		try (var getChangeStatus = c.query(COUNT_CHANGES_FOR_JOB);
 				var setJobState = c.update(SET_STATE_PENDING);
 				var setJobDestroyed = c.update(SET_STATE_DESTROYED);
 				var deleteChanges = c.update(DELETE_PENDING)) {
 			// Count pending changes for this state change
-			var status = getNTasks.call1(ChangeStatus::new,
+			var status = getChangeStatus.call1(ChangeStatus::new,
 					jobId, sourceState, targetState).orElseThrow(
 							() -> new RuntimeException(
 									"Error counting job tasks"));
@@ -207,7 +207,7 @@ public class AllocatorTask extends DatabaseAwareBean
 				deleteChanges.call(jobId, sourceState, targetState);
 
 				// If we are going to destroyed, we can mostly ignore errors,
-				// and similary if we are going to queue it again anyway
+				// and similarly if we are going to queue it again anyway
 				if (targetState == DESTROYED || targetState == QUEUED) {
 					return true;
 				}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -103,6 +103,9 @@ public class AllocatorTask extends DatabaseAwareBean
 	 */
 	private static final Integer NUMBER_OF_JOBS_TO_QUOTA_CHECK = 100000;
 
+	private static final String DESTROY_ON_POWER_ERROR =
+			"Error changing power state!  Please contact an administrator.";
+
 	@Autowired
 	private Epochs epochs;
 
@@ -184,30 +187,63 @@ public class AllocatorTask extends DatabaseAwareBean
 			JobState targetState, Connection c) {
 		try (var getNTasks = c.query(COUNT_CHANGES_FOR_JOB);
 				var setJobState = c.update(SET_STATE_PENDING);
-				var setJobDestroyed = c.update(SET_STATE_DESTROYED)) {
+				var setJobDestroyed = c.update(SET_STATE_DESTROYED);
+				var deleteChanges = c.update(DELETE_PENDING)) {
 			// Count pending changes for this state change
-			var n = getNTasks.call1(row -> row.getInteger("n_changes"),
+			var status = getNTasks.call1(ChangeStatus::new,
 					jobId, sourceState, targetState).orElseThrow(
 							() -> new RuntimeException(
 									"Error counting job tasks"));
 
-			log.debug("Job {} has {} changes remaining", jobId, n);
+			log.debug("Job {} has {} changes remaining", jobId,
+					status.nChanges);
 
-			// If there are no more pending changes, set the job state to
-			// the target state
-			if (n == 0) {
-				log.debug("Job {} moving to state {}", jobId, targetState);
-				if (targetState == DESTROYED) {
-					int rows = setJobDestroyed.call(0, jobId);
-					if (rows != 1) {
-						log.warn("unexpected number of rows affected by "
-								+ "destroy in state update: {}", rows);
-					}
-					return rows > 0;
+			// If the remaining things are errors, react (if there are errors,
+			// eventually non-errors will be deleted)
+			if (status.nErrors > 0 && (status.nErrors == status.nChanges)) {
+				log.info("Job {} changes resulted in errors.", jobId);
+
+				// We can delete the changes now as we know the issues
+				deleteChanges.call(jobId, sourceState, targetState);
+
+				// If we are going to destroyed, we can mostly ignore errors,
+				// and similary if we are going to queue it again anyway
+				if (targetState == DESTROYED || targetState == QUEUED) {
+					return true;
 				}
-				return setJobState.call(targetState, 0, jobId) > 0;
+
+				// If the job was ready before we tried to do this, we have to
+				// destroy the job with an error!
+				if (sourceState == READY) {
+					destroyJob(c, jobId, DESTROY_ON_POWER_ERROR);
+					return true;
+				}
+
+				// If the job was not ready, we need to re-queue and reallocate
+				// boards
+				scheduler.schedule(() -> setPower(jobId, OFF, QUEUED),
+						Instant.now());
+				return false;
+			} else if (status.nChanges > 0) {
+				// There are still changes happening - let them finish first
+				// even if there are errors as safer to do once everything
+				// is done.
+				return false;
 			}
-			return false;
+
+			// If there are no more pending changes and no errors,
+			// set the job state to the target state
+			log.debug("Job {} moving to state {}", jobId, targetState);
+			if (targetState == DESTROYED) {
+				int rows = setJobDestroyed.call(jobId);
+				if (rows != 1) {
+					log.warn("unexpected number of rows affected by "
+							+ "destroy in state update: {}", rows);
+				}
+				return rows > 0;
+			}
+
+			return setJobState.call(targetState, jobId) > 0;
 		}
 	}
 
@@ -282,6 +318,17 @@ public class AllocatorTask extends DatabaseAwareBean
 		Perimeter(Row row) {
 			boardId = row.getInt("board_id");
 			direction = row.getEnum("direction", Direction.class);
+		}
+	}
+
+	private class ChangeStatus {
+		private final int nChanges;
+
+		private final int nErrors;
+
+		public ChangeStatus(Row row) {
+			nChanges = row.getInt("n_changes");
+			nErrors = row.getInt("n_errors");
 		}
 	}
 
@@ -1174,17 +1221,6 @@ public class AllocatorTask extends DatabaseAwareBean
 		return setPower(sql, jobId, ON, READY);
 	}
 
-	/**
-	 * Reset a job after a failure on a BMP.
-	 *
-	 * @param jobId
-	 *            The identifier of the job to reset.
-	 */
-	@SuppressWarnings("FutureReturnValueIgnored")
-	public void resetPowerOnFailure(int jobId) {
-		scheduler.schedule(() -> setPower(jobId, OFF, QUEUED), Instant.now());
-	}
-
 	@Override
 	public boolean setPower(int jobId, PowerState power, JobState targetState) {
 		if (targetState == DESTROYED) {
@@ -1273,7 +1309,7 @@ public class AllocatorTask extends DatabaseAwareBean
 		if (targetState == DESTROYED) {
 			log.debug("num changes for {} in destroy: {}", jobId, numPending);
 			log.info("destroying job {} after power change", jobId);
-			int rows = sql.setStateDestroyed.call(numPending, jobId);
+			int rows = sql.setStateDestroyed.call(jobId);
 			if (rows != 1) {
 				log.warn("unexpected number of jobs marked destroyed: {}",
 						rows);
@@ -1281,8 +1317,7 @@ public class AllocatorTask extends DatabaseAwareBean
 		} else {
 			log.debug("Num changes for target {}: {}", targetState, numPending);
 			sql.setStatePending.call(
-				numPending > 0 ? POWER : targetState,
-				numPending, jobId);
+				numPending > 0 ? POWER : targetState, jobId);
 		}
 
 		return bmps;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -326,7 +326,7 @@ public class AllocatorTask extends DatabaseAwareBean
 
 		private final int nErrors;
 
-		public ChangeStatus(Row row) {
+		ChangeStatus(Row row) {
 			nChanges = row.getInt("n_changes");
 			nErrors = row.getInt("n_errors");
 		}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -328,12 +328,7 @@ public class AllocatorTask extends DatabaseAwareBean
 
 		ChangeStatus(Row row) {
 			nChanges = row.getInt("n_changes");
-			Integer errors = row.getInteger("n_errors");
-			if (errors == null) {
-				nErrors = 0;
-			} else {
-				nErrors = errors;
-			}
+			nErrors = row.getInt("n_errors");
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -1399,7 +1399,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 
 		@Override
 		public void setPower(boolean power) {
-			powerController.setPower(id, power?ON:OFF, READY);
+			powerController.setPower(id, power ? ON : OFF, READY);
 		}
 
 		@Override

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -1399,7 +1399,7 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 
 		@Override
 		public void setPower(boolean power) {
-			powerController.setPower(id, power? ON: OFF, READY);
+			powerController.setPower(id, power?ON:OFF, READY);
 		}
 
 		@Override

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -1398,6 +1398,11 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 		}
 
 		@Override
+		public void setPower(boolean power) {
+			powerController.setPower(id, power? ON: OFF, READY);
+		}
+
+		@Override
 		public boolean waitForChange(Duration timeout) {
 			if (isNull(epoch)) {
 				return true;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
@@ -843,6 +843,13 @@ public interface SpallocAPI {
 		void destroy(String reason);
 
 		/**
+		 * Power a job on or off.
+		 *
+		 * @param power True for on, False for off
+		 */
+		void setPower(boolean power);
+
+		/**
 		 * @return The state of the job.
 		 */
 		JobState getState();

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -1105,7 +1105,7 @@ public class BMPController extends DatabaseAwareBean {
 						var canDoNow = waitedLongEnough(change);
 						while (!powerChanges.isEmpty()
 								&& change.isSameJob(powerChanges.peek())) {
-							canDoNow |= waitedLongEnough(powerChanges.peek());
+							canDoNow &= waitedLongEnough(powerChanges.peek());
 							jobChanges.add(powerChanges.poll());
 						}
 						if (!jobChanges.isEmpty() && canDoNow) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -1020,7 +1020,11 @@ public class BMPController extends DatabaseAwareBean {
 			offLinks = List.of(Direction.values()).stream().filter(
 					link -> !row.getBoolean(link.columnName)).collect(
 							Collectors.toList());
-			powerOffTime = row.getInstant("power_off_timestamp");
+			Instant powerOff = row.getInstant("power_off_timestamp");
+			if (powerOff == null) {
+				powerOff = Instant.EPOCH;
+			}
+			powerOffTime = powerOff;
 		}
 
 		boolean isSameJob(PowerChange p) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -809,7 +809,8 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("change_id")
 	protected static final String ERROR_PENDING =
-			"UPDATE pending_changes SET is_error=1 WHERE change_id = :change_id";
+			"UPDATE pending_changes SET is_error=1 "
+			+ "WHERE change_id = :change_id";
 
 	/**
 	 * Get descriptions of how to move from a board to its neighbours.
@@ -862,7 +863,7 @@ public abstract class SQLQueries {
 	@ResultColumn("n_errors")
 	protected static final String COUNT_CHANGES_FOR_JOB =
 			"SELECT COUNT(change_id) as n_changes, "
-					+ "COALESCE(SUM(is_error), 0) as n_errors "
+					+ "SUM(is_error) as n_errors "
 					+ "FROM pending_changes "
 					+ "WHERE job_id = :job_id AND from_state = :from_state "
 					+ "AND to_state = :to_state";

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -809,7 +809,7 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("change_id")
 	protected static final String ERROR_PENDING =
-			"UPDATE pending_changes SET error=1 WHERE change_id = :change_id";
+			"UPDATE pending_changes SET is_error=1 WHERE change_id = :change_id";
 
 	/**
 	 * Get descriptions of how to move from a board to its neighbours.
@@ -862,7 +862,7 @@ public abstract class SQLQueries {
 	@ResultColumn("n_errors")
 	protected static final String COUNT_CHANGES_FOR_JOB =
 			"SELECT COUNT(change_id) as n_changes, "
-					+ "COALESCE(SUM(error), 0) as n_errors "
+					+ "COALESCE(SUM(is_error), 0) as n_errors "
 					+ "FROM pending_changes "
 					+ "WHERE job_id = :job_id AND from_state = :from_state "
 					+ "AND to_state = :to_state";

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -809,8 +809,7 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("change_id")
 	protected static final String ERROR_PENDING =
-			"UPDATE pending_changes SET is_error=1 "
-			+ "WHERE change_id = :change_id";
+			"UPDATE pending_changes SET is_error=1 WHERE change_id = :change_id";
 
 	/**
 	 * Get descriptions of how to move from a board to its neighbours.
@@ -863,7 +862,7 @@ public abstract class SQLQueries {
 	@ResultColumn("n_errors")
 	protected static final String COUNT_CHANGES_FOR_JOB =
 			"SELECT COUNT(change_id) as n_changes, "
-					+ "SUM(is_error) as n_errors "
+					+ "COALESCE(SUM(is_error), 0) as n_errors "
 					+ "FROM pending_changes "
 					+ "WHERE job_id = :job_id AND from_state = :from_state "
 					+ "AND to_state = :to_state";

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -809,7 +809,8 @@ public abstract class SQLQueries {
 	 */
 	@Parameter("change_id")
 	protected static final String ERROR_PENDING =
-			"UPDATE pending_changes SET is_error=1 WHERE change_id = :change_id";
+			"UPDATE pending_changes SET is_error=1 "
+			+ "WHERE change_id = :change_id";
 
 	/**
 	 * Get descriptions of how to move from a board to its neighbours.

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/JobListEntryRecord.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/model/JobListEntryRecord.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.manchester.spinnaker.alloc.model;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 
 import java.net.URI;
@@ -280,5 +281,13 @@ public class JobListEntryRecord {
 	/** @return the original request to create the job */
 	public Optional<byte[]> getOriginalRequest() {
 		return Optional.ofNullable(originalRequest);
+	}
+
+	/** @return the original request as a string */
+	public String getRequest() {
+		if (originalRequest == null) {
+			return "";
+		}
+		return new String(originalRequest, UTF_8);
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SystemController.java
@@ -142,6 +142,23 @@ public interface SystemController {
 			@RequestParam("reason") String reason);
 
 	/**
+	 * Set the power of a job.
+	 *
+	 * @param id
+	 *            Which job is being deleted
+	 * @param power
+	 *            Whether to power on or off
+	 * @return View ({@code jobdetails.jsp}) and model (based on
+	 *         {@link JobDescription})
+	 */
+	@PostMapping("/power_job/{id}")
+	@PreAuthorize(MAY_SEE_JOB_DETAILS)
+	@UsedInJavadocOnly(JobDescription.class)
+	ModelAndView powerJob(@PathVariable("id") int id,
+			@RequestParam("power") boolean power);
+
+
+	/**
 	 * Get the view and model for the password change form.
 	 *
 	 * @param principal

--- a/SpiNNaker-allocserv/src/main/resources/application.yml
+++ b/SpiNNaker-allocserv/src/main/resources/application.yml
@@ -197,6 +197,8 @@ spalloc:
     build-attempts: 5
     # Whether to use dummy BMPs; GREAT for testing!
     dummy: false
+    # Time between powering off and powering on boards
+    off-wait-time: 30s
   sqlite:
     # How long to wait to get a DB lock
     timeout: 1s

--- a/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
+++ b/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
@@ -248,7 +248,6 @@ CREATE TABLE IF NOT EXISTS jobs (
 	death_reason TEXT,
 	death_timestamp INTEGER,	-- timestamp; set by trigger
 	original_request BLOB,		-- Stores it, but doesn't otherwise care
-	num_pending INTEGER NOT NULL DEFAULT (0),
 	allocation_timestamp INTEGER, -- timestamp; set by trigger
 	allocation_size INTEGER,
 	allocated_root INTEGER,		-- set by trigger
@@ -399,8 +398,8 @@ CREATE TABLE IF NOT EXISTS pending_changes (
 		CONSTRAINT pending_changes_fpga_nw CHECK (fpga_nw IN (0, 1)),
 	fpga_se INTEGER NOT NULL	-- Whether to switch the southeast FPGA on
 		CONSTRAINT pending_changes_fpga_se CHECK (fpga_se IN (0, 1)),
-	in_progress INTEGER NOT NULL DEFAULT (0)
-		CONSTRAINT pending_changes_in_progress CHECK (in_progress IN (0, 1)),
+	error INTEGER NOT NULL DEFAULT (0)
+		CONSTRAINT pending_changes_error CHECK (error IN (0, 1)),
 	from_state INTEGER NOT NULL DEFAULT (0),
 		FOREIGN KEY (from_state)
 		REFERENCES job_states(id) ON DELETE RESTRICT,

--- a/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
+++ b/SpiNNaker-allocserv/src/main/resources/spalloc-mysql.sql
@@ -398,8 +398,8 @@ CREATE TABLE IF NOT EXISTS pending_changes (
 		CONSTRAINT pending_changes_fpga_nw CHECK (fpga_nw IN (0, 1)),
 	fpga_se INTEGER NOT NULL	-- Whether to switch the southeast FPGA on
 		CONSTRAINT pending_changes_fpga_se CHECK (fpga_se IN (0, 1)),
-	error INTEGER NOT NULL DEFAULT (0)
-		CONSTRAINT pending_changes_error CHECK (error IN (0, 1)),
+	is_error INTEGER NOT NULL DEFAULT (0)
+		CONSTRAINT pending_changes_error CHECK (is_error IN (0, 1)),
 	from_state INTEGER NOT NULL DEFAULT (0),
 		FOREIGN KEY (from_state)
 		REFERENCES job_states(id) ON DELETE RESTRICT,

--- a/SpiNNaker-allocserv/src/main/typescript/spinnaker.ts
+++ b/SpiNNaker-allocserv/src/main/typescript/spinnaker.ts
@@ -886,6 +886,29 @@ function prettyDuration(elementId: string) {
 }
 
 /**
+ * Get the owner of a job that might be a compatible job.
+ *
+ * @param sourceElementId
+ *      The ID of the element containing the RAW original request
+ *      probably hidden)
+ * @param targetElementId
+ *      The ID of the element to append the compatible owner to
+ */
+function getJobOwner(sourceElementId: string, targetElementId: string) {
+	const sourceElement = document.getElementById(sourceElementId);
+	const content = sourceElement?.textContent;
+	if (content === null || content == undefined) {
+		return;
+	}
+	const json = JSON.parse(content);
+	if (json.hasOwnProperty("kwargs")) {
+		const owner = json["kwargs"]["owner"];
+		const targetElement = document.getElementById(targetElementId);
+		targetElement!.textContent += " (" + owner + ")";
+	}
+}
+
+/**
  * Load temperature data from a URL.
  *
  * @param sourceUri

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
@@ -9,7 +9,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+	https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -143,6 +143,10 @@ limitations under the License.
 		<c:choose>
 			<c:when test="${ not empty job.boards }">
 				${ job.powered ? 'on' : 'off' }
+				<form method="POST" action="${ powerUri }">
+					<input type="hidden" name="power" value="${ !job.powered }" />
+					<input type="submit" value="Toggle Power" />
+				</form>
 			</c:when>
 			<c:otherwise>Not currently allocated</c:otherwise>
 		</c:choose>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
@@ -142,10 +142,10 @@ limitations under the License.
 	<td>
 		<c:choose>
 			<c:when test="${ not empty job.boards }">
-				${ job.powered ? 'on' : 'off' }
 				<form method="POST" action="${ powerUri }">
+					<sec:csrfInput />
 					<input type="hidden" name="power" value="${ !job.powered }" />
-					<input type="submit" value="Toggle Power" />
+					${ job.powered ? 'on' : 'off' } <input type="submit" value="Toggle Power" />
 				</form>
 			</c:when>
 			<c:otherwise>Not currently allocated</c:otherwise>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
@@ -138,8 +138,10 @@ limitations under the License.
 			<c:when test="${ not empty job.boards }">
 				<form method="POST" action="${ powerUri }">
 					<sec:csrfInput />
-					<input type="hidden" name="power" value="${ !job.powered }" />
-					${ job.powered ? 'on' : 'off' } <input type="submit" value="Toggle Power" />
+					<c:when test="${ job.state == 'READY'}">
+						<input type="hidden" name="power" value="${ !job.powered }" />
+						${ job.powered ? 'on' : 'off' } <input type="submit" value="Toggle Power" />
+					</c:when>
 				</form>
 			</c:when>
 			<c:otherwise>Not currently allocated</c:otherwise>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
@@ -138,10 +138,10 @@ limitations under the License.
 			<c:when test="${ not empty job.boards }">
 				<form method="POST" action="${ powerUri }">
 					<sec:csrfInput />
-					<c:when test="${ job.state == 'READY'}">
+					<c:if test="${ job.state == 'READY'}">
 						<input type="hidden" name="power" value="${ !job.powered }" />
 						${ job.powered ? 'on' : 'off' } <input type="submit" value="Toggle Power" />
-					</c:when>
+					</c:if>
 				</form>
 			</c:when>
 			<c:otherwise>Not currently allocated</c:otherwise>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/jobdetails.jsp
@@ -37,7 +37,7 @@ limitations under the License.
 </tr>
 <tr>
 	<th class="lineTitle">Owner:</th>
-	<td>
+	<td id="owner">
 		<spring:eval htmlEscape="true"
 				expression="job.owner.orElse('[SHROUDED]')" />
 	</td>
@@ -68,19 +68,13 @@ limitations under the License.
 	<td id="keepAlive">${ job.keepAlive }</td>
 </tr>
 <tr>
-	<th class="lineTitle">Owner host:</th>
-	<td>
-		<spring:eval expression="job.ownerHost.orElse('[SHROUDED]')"
-				htmlEscape="true" />
-	</td>
-</tr>
-<tr>
 	<th class="lineTitle">Raw request:</th>
 	<td><details><summary><em>Click to show</em></summary>
 	<c:if test="${ not empty job.request }">
 		<pre id="rawRequest"><c:out escapeXml="true"
 				value="${ job.request }" /></pre>
 		<script defer="defer">
+			getJobOwner("rawRequest", "owner");
 			prettyJson("rawRequest");
 		</script>
 	</c:if>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
@@ -89,7 +89,7 @@ limitations under the License.
 							${ job.request }
 						</td>
 						<script defer="defer">
-							getJobOwner("request-${ job.id }", "owner-${ job.id });
+							getJobOwner("request-${ job.id }", "owner-${ job.id }");
 						</script>
 					</tr>
 				</c:forEach>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+	https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,16 +75,22 @@ limitations under the License.
 							</script>
 							<code id="alive-${ job.id }">${ job.keepaliveInterval }</code>
 						</td>
-						<td class="textColumn">
+						<td class="textColumn" id="owner-${ job.id }">
 							<c:if test="${ job.owner.present }">
 								<spring:eval htmlEscape="true"
 										expression="job.owner.get()" />
 							</c:if>
-							<c:if test="${ job.host.present }">
+							<c:if test="${ job.host.present and job.host != '127.0.0.1'}">
 								(<spring:eval htmlEscape="true"
 										expression="job.host.get()" />)
 							</c:if>
 						</td>
+						<td class="textColumn" hidden id="request-${ job.id }">
+							${ job.request }
+						</td>
+						<script defer="defer">
+							getJobOwner("request-${ job.id }", "owner-${ job.id });
+						</script>
 					</tr>
 				</c:forEach>
 			</tbody>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
@@ -37,7 +37,7 @@ limitations under the License.
 					<th>Machine</th>
 					<th>Created at</th>
 					<th>Keepalive</th>
-					<th>Owner (Host)</th>
+					<th>Owner</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
+++ b/SpiNNaker-allocserv/src/main/webapp/WEB-INF/views/listjobs.jsp
@@ -80,10 +80,6 @@ limitations under the License.
 								<spring:eval htmlEscape="true"
 										expression="job.owner.get()" />
 							</c:if>
-							<c:if test="${ job.host.present and job.host != '127.0.0.1'}">
-								(<spring:eval htmlEscape="true"
-										expression="job.host.get()" />)
-							</c:if>
 						</td>
 						<td class="textColumn" hidden id="request-${ job.id }">
 							${ job.request }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -226,9 +226,9 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_STATE_PENDING)) {
 			c.transaction(() -> {
-				assertEquals(List.of("job_state", "num_pending", "job_id"),
+				assertEquals(List.of("job_state", "job_id"),
 						u.getParameters());
-				assertEquals(0, u.call(JobState.UNKNOWN, 0, NO_JOB));
+				assertEquals(0, u.call(JobState.UNKNOWN, NO_JOB));
 			});
 		}
 	}
@@ -238,9 +238,8 @@ class DMLTest extends SimpleDBTestBase {
 		assumeWritable(c);
 		try (var u = c.update(SET_STATE_DESTROYED)) {
 			c.transaction(() -> {
-				assertEquals(List.of("num_pending", "job_id"),
-						u.getParameters());
-				assertEquals(0, u.call(0, NO_JOB));
+				assertEquals(List.of("job_id"),	u.getParameters());
+				assertEquals(0, u.call(NO_JOB));
 			});
 		}
 	}
@@ -314,6 +313,18 @@ class DMLTest extends SimpleDBTestBase {
 			c.transaction(() -> {
 				assertEquals(List.of("change_id"), u.getParameters());
 				assertEquals(0, u.call(NO_CHANGE));
+			});
+		}
+	}
+
+	@Test
+	void deletePending() {
+		assumeWritable(c);
+		try (var u = c.update(DELETE_PENDING)) {
+			c.transaction(() -> {
+				assertEquals(List.of("job_id", "from_state", "to_state"),
+						u.getParameters());
+				assertEquals(0, u.call(NO_JOB, 0, 0));
 			});
 		}
 	}

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -1276,7 +1276,7 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(List.of("job_id", "from_state", "to_state"),
 						q.getParameters());
 				assertEquals(
-						List.of("n_changes"),
+						List.of("n_changes", "n_errors"),
 						q.getColumns());
 				assertEquals(0, q.call1(integer("n_changes"), -1, 0, 0)
 						.orElseThrow());

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -553,7 +553,7 @@ class DQLTest extends SimpleDBTestBase {
 				assertEquals(List.of("change_id", "job_id", "board_id", "power",
 						"fpga_n", "fpga_s", "fpga_e", "fpga_w", "fpga_se",
 						"fpga_nw", "from_state", "to_state",
-						"board_num", "bmp_id"),
+						"board_num", "bmp_id", "power_off_timestamp"),
 						q.getColumns());
 				assertEquals(empty(), q.call1(Row::toString, NO_JOB));
 			});

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/web/StubJob.java
@@ -55,6 +55,11 @@ public abstract class StubJob implements Job {
 	}
 
 	@Override
+	public void setPower(boolean power) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public JobState getState() {
 		throw new UnsupportedOperationException();
 	}

--- a/src/support/.gitignore
+++ b/src/support/.gitignore
@@ -1,0 +1,1 @@
+/eclipse/


### PR DESCRIPTION
Ensures that BMP errors do not result in success!  Also ensures that BMPs are not powered on until at least 30 seconds after they have been powered off.  This does not affect allocations; the boards will be allocated but will wait off until the 30 seconds have passed.  This won't affect most users, just those who ask for specific boards (normal users will likely be allocated other boards anyway).

Also adds some features to the UI (power on/off machine and show real user on compatibility jobs).