### PR TITLE
Simplfy the data.sqlite3 

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -260,9 +260,7 @@ public abstract class DataGatherer extends BoardLocalSupport
 					var regions = new ArrayList<List<Region>>();
 					for (int id : p.getVertex().getRecordedRegionIds()) {
 						var r = getRegion(p, id);
-						if (!r.isEmpty()) {
-							regions.add(r);
-						}
+						regions.add(r);
 						count += r.size();
 					}
 					if (!regions.isEmpty()) {

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -263,16 +263,12 @@ public abstract class DataGatherer extends BoardLocalSupport
 						regions.add(r);
 						count += r.size();
 					}
-					if (!regions.isEmpty()) {
-						workitems.add(new WorkItems(m, regions));
-					}
+					workitems.add(new WorkItems(m, regions));
 				}
 
 			}
 			// Totally empty boards can be ignored
-			if (!workitems.isEmpty()) {
-				work.put(g.asChipLocation(), workitems);
-			}
+			work.put(g.asChipLocation(), workitems);
 		}
 		log.info("found {} regions to download", count);
 		return work;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -266,7 +266,6 @@ public abstract class DataGatherer extends BoardLocalSupport
 						} else {
 							storeData(r, allocate(0));
 						}
-
 					}
 					workitems.add(new WorkItems(m, regions));
 				}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.google.errorprone.annotations.MustBeClosed;

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -132,14 +132,14 @@ public class DirectDataGatherer extends DataGatherer {
 	}
 
 	@Override
-	protected List<Region> getRegion(Placement placement, int regionID)
+	protected Region getRegion(Placement placement, int regionID)
 			throws IOException, ProcessException, InterruptedException {
 		var b = getCoreRegionTable(placement.asCoreLocation(),
 				placement.getVertex());
 		// TODO This is wrong because of shared regions!
 		int size = b.get(regionID + 1) - b.get(regionID);
-		return List.of(new Region(placement, regionID,
-				new MemoryLocation(b.get(regionID)), size));
+		return new Region(
+			placement, regionID, new MemoryLocation(b.get(regionID)), size);
 	}
 
 	@Override

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -118,11 +118,8 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 		var region = getRegions(placement).get(index);
 		log.debug("got region of {} R:{} as {}", placement.asCoreLocation(),
 				index, region);
-		if (region.size > 0) {
-			return List.of(new Region(placement, index, region.data,
-					(int) region.size));
-		}
-		return List.of();
+		return List.of(new Region(placement, index, region.data,
+				(int) region.size));
 	}
 
 	@Override

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -113,13 +113,12 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	}
 
 	@Override
-	protected List<Region> getRegion(Placement placement, int index)
+	protected Region getRegion(Placement placement, int index)
 			throws IOException, ProcessException, InterruptedException {
 		var region = getRegions(placement).get(index);
 		log.debug("got region of {} R:{} as {}", placement.asCoreLocation(),
 				index, region);
-		return List.of(new Region(placement, index, region.data,
-				(int) region.size));
+		return new Region(placement, index, region.data, (int) region.size);
 	}
 
 	@Override

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -270,6 +270,8 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 	void appendRecordingContents(Region region, byte[] contents)
 			throws StorageException;
 
+	void insertMockExtraction() throws StorageException;
+
 	/**
 	 * Adds some bytes to the database. The bytes represent part of the contents
 	 * of a recording region of a particular SpiNNaker core.

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
@@ -74,7 +74,7 @@ abstract class SQL {
 	static final String GET_REGION = "SELECT region_id FROM region WHERE "
 			+ "core_id = ? AND local_region_index = ? LIMIT 1";
 
-	//** Find the current extraction_id. */
+	/** Find the current extraction_id. */
 	@ResultColumn("max_id")
 	static final String GET_LAST_EXTRACTION_ID =
 			"SELECT max(extraction_id) as max_id "
@@ -89,7 +89,8 @@ abstract class SQL {
 	static final String ADD_REGION_DATA =
 			"INSERT INTO region_data(region_id, extraction_id, content, "
 				+ "content_len, missing_data) "
-				+ "VALUES (?, ?, CAST(? AS BLOB), ?, 0) RETURNING region_data_id";
+				+ "VALUES (?, ?, CAST(? AS BLOB), ?, 0) "
+				+ "RETURNING region_data_id";
 
 	/** Fetch the current variable state of a region record. */
 	@Parameter("region_id")

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
@@ -65,7 +65,7 @@ abstract class SQL {
 	@ResultColumn("extraction_id")
 	static final String INSERT_MOCK_EXTRACTION = "INSERT INTO "
 			+ "extraction(run_timestep, n_run, n_loop, extract_time) "
-		    + "VALUES(12345, 1, NULL, 987654) RETURNING extraction_id ";
+			+ "VALUES(12345, 1, NULL, 987654) RETURNING extraction_id ";
 
 	/** Find an existing region record. */
 	@Parameter("core_id")
@@ -76,8 +76,9 @@ abstract class SQL {
 
 	//** Find the current extraction_id. */
 	@ResultColumn("max_id")
-	static final String GET_LAST_EXTRACTION_ID = "SELECT max(extraction_id) as max_id " +
-		"FROM extraction LIMIT 1";
+	static final String GET_LAST_EXTRACTION_ID =
+			"SELECT max(extraction_id) as max_id "
+			+ "FROM extraction LIMIT 1";
 
 	/** Create a region record. */
 	@Parameter("region_id")
@@ -86,15 +87,9 @@ abstract class SQL {
 	@Parameter("content_len")
 	@ResultColumn("region_data_id")
 	static final String ADD_REGION_DATA =
-			"INSERT INTO region_data(region_id, extraction_id, content, content_len, missing_data) "
+			"INSERT INTO region_data(region_id, extraction_id, content, "
+				+ "content_len, missing_data) "
 				+ "VALUES (?, ?, CAST(? AS BLOB), ?, 0) RETURNING region_data_id";
-
-	@Parameter("region_id")
-	@ResultColumn("n_extractions")
-	@ResultColumn("region_data_id")
-	static final String COUNT_RECORDING =
-			"SELECT count(*) as n_extractions, SUM(content_len) as total_content_length	"
-				+ "FROM region_data	WHERE region_id = ?	LIMIT 1";
 
 	/** Fetch the current variable state of a region record. */
 	@Parameter("region_id")

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
@@ -49,14 +49,23 @@ abstract class SQL {
 	static final String GET_LOCATION = "SELECT core_id FROM core"
 			+ " WHERE x = ? AND y = ? AND processor = ? LIMIT 1";
 
-	/** Create an empty region record. */
+	/** Create a region record. */
 	@Parameter("core_id")
 	@Parameter("local_region_index")
-	@Parameter("address")
 	@ResultColumn("region_id")
 	static final String INSERT_REGION = "INSERT INTO "
-			+ "region(core_id, local_region_index, address)"
-			+ " VALUES (?, ?, ?) RETURNING region_id";
+			+ "region(core_id, local_region_index)"
+			+ " VALUES (?, ?) RETURNING region_id";
+
+
+	/** For testing create an extraction record.
+
+	Would normally be done by python.
+	*/
+	@ResultColumn("extraction_id")
+	static final String INSERT_MOCK_EXTRACTION = "INSERT INTO "
+			+ "extraction(run_timestep, n_run, n_loop, extract_time) "
+		    + "VALUES(12345, 1, NULL, 987654) RETURNING extraction_id ";
 
 	/** Find an existing region record. */
 	@Parameter("core_id")
@@ -65,76 +74,35 @@ abstract class SQL {
 	static final String GET_REGION = "SELECT region_id FROM region WHERE "
 			+ "core_id = ? AND local_region_index = ? LIMIT 1";
 
-	/** Append content to a region record. */
+	//** Find the current extraction_id. */
+	@ResultColumn("max_id")
+	static final String GET_LAST_EXTRACTION_ID = "SELECT max(extraction_id) as max_id " +
+		"FROM extraction LIMIT 1";
+
+	/** Create a region record. */
+	@Parameter("region_id")
+	@Parameter("extraction_id")
 	@Parameter("content_to_add")
 	@Parameter("content_len")
-	@Parameter("append_time")
-	@Parameter("region_id")
-	static final String ADD_CONTENT =
-			"UPDATE region SET content = CAST(? AS BLOB), content_len = ?, "
-					+ "fetches = 1, append_time = ? WHERE region_id = ?";
+	@ResultColumn("region_data_id")
+	static final String ADD_REGION_DATA =
+			"INSERT INTO region_data(region_id, extraction_id, content, content_len, missing_data) "
+				+ "VALUES (?, ?, CAST(? AS BLOB), ?, 0) RETURNING region_data_id";
 
-	/** Prepare a region record for handling content in the extra table. */
-	@Parameter("append_time")
 	@Parameter("region_id")
-	static final String PREP_EXTRA_CONTENT =
-			"UPDATE region SET fetches = fetches + 1, append_time = ? "
-			+ "WHERE region_id = ?";
-
-	/** Add content to a new row in the extra table. */
-	@Parameter("region_id")
-	@Parameter("content_to_add")
-	@Parameter("content_len")
-	@ResultColumn("extra_id")
-	static final String ADD_EXTRA_CONTENT =
-			"INSERT INTO region_extra(region_id, content, content_len) "
-					+ "VALUES (?, CAST(? AS BLOB), ?) RETURNING extra_id";
-
-	/**
-	 * Discover whether region in the main region table is available for storing
-	 * data.
-	 */
-	@Parameter("region_id")
-	@ResultColumn("existing")
-	static final String GET_MAIN_CONTENT_AVAILABLE =
-			"SELECT COUNT(*) AS existing FROM region "
-					+ "WHERE region_id = ? AND fetches = 0";
-
-	/**
-	 * Determine just how much content there is for a row, overall.
-	 */
-	@Parameter("region_id")
-	@ResultColumn("len")
-	static final String GET_CONTENT_TOTAL_LENGTH =
-			"SELECT r.content_len + ("
-					+ "    SELECT SUM(x.content_len) "
-					+ "    FROM region_extra AS x "
-					+ "    WHERE x.region_id = r.region_id"
-					+ ") AS len FROM region AS r WHERE region_id = ?";
+	@ResultColumn("n_extractions")
+	@ResultColumn("region_data_id")
+	static final String COUNT_RECORDING =
+			"SELECT count(*) as n_extractions, SUM(content_len) as total_content_length	"
+				+ "FROM region_data	WHERE region_id = ?	LIMIT 1";
 
 	/** Fetch the current variable state of a region record. */
-	@Parameter("x")
-	@Parameter("y")
-	@Parameter("processor")
-	@Parameter("local_region_index")
+	@Parameter("region_id")
 	@ResultColumn("content")
-	@ResultColumn("content_len")
-	@ResultColumn("fetches")
-	@ResultColumn("append_time")
-	@ResultColumn("region_id")
+	@ResultColumn("missing_data")
 	static final String FETCH_RECORDING =
-			"SELECT content, content_len, fetches, append_time, region_id "
-					+ "FROM region_view"
-					+ " WHERE x = ? AND y = ? AND processor = ?"
-					+ " AND local_region_index = ? LIMIT 1";
-
-	/** Fetch the current variable state of a region record. */
-	@Parameter("region_id")
-	@ResultColumn("content")
-	@ResultColumn("content_len")
-	static final String FETCH_EXTRA_RECORDING =
-			"SELECT content, content_len FROM region_extra"
-					+ " WHERE region_id = ? ORDER BY extra_id ASC";
+			"SELECT content, missing_data FROM region_data "
+				+ "WHERE region_id = ? ORDER BY extraction_id ASC";
 
 	/** List the cores with storage. */
 	@Parameters({})

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
@@ -41,7 +41,9 @@ import org.slf4j.Logger;
 
 import uk.ac.manchester.spinnaker.machine.CoreLocation;
 import uk.ac.manchester.spinnaker.machine.HasCoreLocation;
-import uk.ac.manchester.spinnaker.storage.*;
+import uk.ac.manchester.spinnaker.storage.BufferManagerDatabaseEngine;
+import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
+import uk.ac.manchester.spinnaker.storage.StorageException;
 
 /**
  * How to actually talk to an SQLite database.

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQLiteBufferStorage.java
@@ -126,7 +126,8 @@ public class SQLiteBufferStorage
 				"could not make or find recording region record");
 	}
 
-	private static int insertMockExtraction(Connection conn) throws SQLException {
+	private static int insertMockExtraction(Connection conn)
+			throws SQLException {
 		try (var s = conn.prepareStatement(INSERT_MOCK_EXTRACTION)) {
 			// core_id, local_region_index, address
 			try (var rs = s.executeQuery()) {
@@ -176,7 +177,8 @@ public class SQLiteBufferStorage
 			int chunkLen, ByteArrayInputStream chunk) throws SQLException {
 		try (var s = conn.prepareStatement(ADD_REGION_DATA)) {
 			// region_id, extraction_id, content, content_len,
-			setArguments(s, regionID,  extractionId, read(chunk, chunkLen), chunkLen);
+			setArguments(
+				s, regionID,  extractionId, read(chunk, chunkLen), chunkLen);
 			try (var rs = s.executeQuery()) {
 				while (rs.next()) {
 					return rs.getInt("region_data_id");
@@ -218,8 +220,8 @@ public class SQLiteBufferStorage
 			byte[] contents) throws SQLException {
 		int coreID = getRecordingCore(conn, region.core);
 		int regionID = getRecordingRegion(conn, coreID, region);
-		int last_extraction_id = getLastExtractionId(conn);
-		appendRecordingContents(conn, regionID, last_extraction_id, contents);
+		int lastExtractionId = getLastExtractionId(conn);
+		appendRecordingContents(conn, regionID, lastExtractionId, contents);
 	}
 
 	@Override

--- a/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/buffer_manager.sql
+++ b/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/buffer_manager.sql
@@ -21,11 +21,29 @@ CREATE TABLE IF NOT EXISTS core(
     core_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	x INTEGER NOT NULL,
 	y INTEGER NOT NULL,
-	processor INTEGER NOT NULL);
+	processor INTEGER NOT NULL,
+	core_name STRING);
 -- Every processor has a unique ID
 CREATE UNIQUE INDEX IF NOT EXISTS coreSanity ON core(
 	x ASC, y ASC, processor ASC);
 
+CREATE TABLE IF NOT EXISTS setup(
+    setup_id INTEGER PRIMARY KEY CHECK (setup_id = 0),
+    hardware_time_step_ms FLOAT NOT NULL,
+    time_scale_factor INTEGER);
+
+-- A table containing the metadata for an extraction run
+CREATE TABLE IF NOT EXISTS extraction(
+	extraction_id INTEGER PRIMARY KEY ASC AUTOINCREMENT,
+    run_timestep INTEGER NOT NULL,
+    n_run INTEGER NOT NULL,
+    n_loop INTEGER,
+    extract_time INTEGER
+    );
+CREATE VIEW IF NOT EXISTS extraction_view AS
+	SELECT extraction_id, run_timestep, run_timestep * hardware_time_step_ms as run_time_ms,
+	       n_run, n_loop, datetime(extract_time/1000, 'unixepoch') AS extraction_time
+    from extraction join setup;
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table describing recording regions.
@@ -43,25 +61,29 @@ CREATE TABLE IF NOT EXISTS region(
 CREATE UNIQUE INDEX IF NOT EXISTS regionSanity ON region(
 	core_id ASC, local_region_index ASC);
 
--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table containing the data which doesn't fit in the content column of the
--- region table; care must be taken with this to not exceed 1GB! We actually
--- store one per auto-pause-resume cycle as that is more efficient.
-CREATE TABLE IF NOT EXISTS region_extra(
-	extra_id INTEGER PRIMARY KEY ASC AUTOINCREMENT,
-	region_id INTEGER NOT NULL
-		REFERENCES region(region_id) ON DELETE RESTRICT,
-	content BLOB NOT NULL DEFAULT '',
-	content_len INTEGER DEFAULT 0);
-
 CREATE VIEW IF NOT EXISTS region_view AS
-	SELECT core_id, region_id, x, y, processor, local_region_index, address,
-		content, content_len, fetches, append_time,
-		(fetches > 1) AS have_extra
+	SELECT core_id, region_id, x, y, processor, local_region_index
 FROM core NATURAL JOIN region;
 
-CREATE VIEW IF NOT EXISTS extra_view AS
-    SELECT core_id, region_id, extra_id, x, y, processor, local_region_index,
-    	address, append_time, region_extra.content AS content,
-    	region_extra.content_len AS content_len
-FROM core NATURAL JOIN region NATURAL JOIN region_extra;
+CREATE TABLE IF NOT EXISTS region_data(
+    region_data_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	region_id INTEGER NOT NULL
+		REFERENCES region(region_id) ON DELETE RESTRICT,
+    extraction_id INTEGER NOT NULL
+		REFERENCES extraction(extraction_id) ON DELETE RESTRICT,
+	content BLOB NOT NULL,
+	content_len INTEGER NOT NULL,
+    missing_data INTEGER NOT NULL);
+-- Every recording region is extracted once per BefferExtractor run
+CREATE UNIQUE INDEX IF NOT EXISTS region_data_sanity ON region_data(
+	region_id ASC, extraction_id ASC);
+
+CREATE VIEW IF NOT EXISTS region_data_view AS
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+		content, content_len
+FROM region_view NATURAL JOIN region_data;
+
+CREATE VIEW IF NOT EXISTS region_data_plus_view AS
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
+FROM region_data_view NATURAL JOIN extraction_view;

--- a/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
+++ b/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
@@ -60,6 +60,7 @@ class TestSQLiteStorage {
 		assertEquals(List.of(), storage.getCoresWithStorage());
 
 		var rr = new BufferManagerStorage.Region(core, 0, NULL, 100);
+		storage.insertMockExtraction();
 		storage.appendRecordingContents(rr, bytes("def"));
 		assertArrayEquals("def".getBytes(UTF_8),
 				storage.getRecordingRegionContents(rr));
@@ -75,8 +76,11 @@ class TestSQLiteStorage {
 
 		// append creates
 		var rr = new BufferManagerStorage.Region(core, 1, NULL, 100);
+		storage.insertMockExtraction();
 		storage.appendRecordingContents(rr, bytes("ab"));
+		storage.insertMockExtraction();
 		storage.appendRecordingContents(rr, bytes("cd"));
+		storage.insertMockExtraction();
 		storage.appendRecordingContents(rr, bytes("ef"));
 		assertEquals("abcdef", str(storage.getRecordingRegionContents(rr)));
 	}


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1207

Notes:

- This now writes a row to range data table even if the data read is empty! This allows distention between successfully read data of length zero (ok) and did not read any data (an error)

- The python side normally fills in the extraction table so that i just mocked here for unittests.

- getRecordingRegionContents is simpler that python because 1. It is just used for testing, 2. ByteArrayOutputStrea does not need to be setup with size. 