### PR TITLE
recording data fixes

### DIFF
--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/ReadMemoryProcess.java
@@ -357,6 +357,6 @@ class ReadMemoryProcess extends TxrxProcess {
 		var buffer = new byte[region.size];
 		readMemory(region.core.asChipLocation(), region.startAddress,
 				region.size, new BufferAccumulator(buffer));
-		storage.appendRecordingContents(region, buffer);
+		storage.extractRecordingContents(region, buffer);
 	}
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
@@ -166,8 +166,9 @@ class BufferedReceivingData {
 	 * @throws StorageException
 	 *             If there is a problem storing the data.
 	 */
-	public void flushingDataFromRegion(RegionLocation location, ByteBuffer data,
-									   boolean isRecording)	throws StorageException {
+	public void flushingDataFromRegion(
+		RegionLocation location, ByteBuffer data, boolean isRecording)
+			throws StorageException {
 		storeDataInRegionBuffer(location, data, isRecording);
 		isFlushed.put(location, true);
 	}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/BufferedReceivingData.java
@@ -136,18 +136,21 @@ class BufferedReceivingData {
 	 *            The X, Y, P and Region
 	 * @param data
 	 *            data to be stored
+	 * @param isRecording
+	 *            If this is a recording region
 	 * @throws StorageException
 	 *             If there is a problem storing the data.
 	 */
 	public void storeDataInRegionBuffer(RegionLocation location,
-			ByteBuffer data) throws StorageException {
+			ByteBuffer data, boolean isRecording) throws StorageException {
 		if (log.isInfoEnabled()) {
 			log.info("retrieved {} bytes from region {} of {}",
 					data.remaining(), location.region,
 					location.asCoreLocation());
 		}
-		storage.appendRecordingContents(
-				new Region(location, location.region, NULL, 0), data);
+		storage.extractRecordingContents(
+				new Region(location, location.region, NULL, 0, isRecording),
+				data);
 	}
 
 	/**
@@ -158,12 +161,14 @@ class BufferedReceivingData {
 	 *            The X, Y, P and Region
 	 * @param data
 	 *            data to be stored
+	 * @param isRecording
+	 * 			  if this is a recording region
 	 * @throws StorageException
 	 *             If there is a problem storing the data.
 	 */
-	public void flushingDataFromRegion(RegionLocation location, ByteBuffer data)
-			throws StorageException {
-		storeDataInRegionBuffer(location, data);
+	public void flushingDataFromRegion(RegionLocation location, ByteBuffer data,
+									   boolean isRecording)	throws StorageException {
+		storeDataInRegionBuffer(location, data, isRecording);
 		isFlushed.put(location, true);
 	}
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -493,7 +493,7 @@ public abstract class DataGatherer extends BoardLocalSupport
 
 	/**
 	 * Store the data retrieved from a region. Called (at most) once for each
-	 * element in the list returned by {@link #getRegion(Placement,int)
+	 * element in the list returned by {@link #getRecordingRegion(Placement, int)}
 	 * getRegion(...)}, <i>in order</i>. No guarantee is made about which thread
 	 * will call this method.
 	 *

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -492,10 +492,9 @@ public abstract class DataGatherer extends BoardLocalSupport
 			InterruptedException;
 
 	/**
-	 * Store the data retrieved from a region. Called (at most) once for each
-	 * element in the list returned by {@link #getRecordingRegion(Placement, int)}
-	 * getRegion(...)}, <i>in order</i>. No guarantee is made about which thread
-	 * will call this method.
+	 * Store the data retrieved from a region
+	 *
+	 * No guarantee is made about which thread will call this method.
 	 *
 	 * @param r
 	 *            Where the data came from.

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataGatherer.java
@@ -259,7 +259,7 @@ public abstract class DataGatherer extends BoardLocalSupport
 				for (var p : m.getPlacements()) {
 					var regions = new ArrayList<Region>();
 					for (int id : p.getVertex().getRecordedRegionIds()) {
-						var r = getRegion(p, id);
+						var r = getRecordingRegion(p, id);
 						if (r.size > 0) {
 							regions.add(r);
 							count += 1;
@@ -269,7 +269,7 @@ public abstract class DataGatherer extends BoardLocalSupport
 					}
 					for (var dr : p.getVertex().getDownloadRegions()) {
 						regions.add(new Region(p, dr.getIndex(),
-								dr.getAddress(), dr.getSize()));
+								dr.getAddress(), dr.getSize(), false));
 						count++;
 					}
 					workitems.add(new WorkItems(m, regions));
@@ -486,7 +486,8 @@ public abstract class DataGatherer extends BoardLocalSupport
 	 */
 	@UsedInJavadocOnly(BufferManagerStorage.class)
 	@ForOverride
-	protected abstract Region getRegion(Placement placement, int regionID)
+	protected abstract Region getRecordingRegion(
+			Placement placement, int regionID)
 			throws IOException, ProcessException, StorageException,
 			InterruptedException;
 

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
@@ -146,7 +146,7 @@ public class DataReceiver extends BoardLocalSupport {
 					var location = new RegionLocation(placement,
 							region.getIndex());
 					readSomeData(location, region.getAddress(),
-							region.getSize());
+							region.getSize(), false);
 				}
 			}
 		}
@@ -172,7 +172,7 @@ public class DataReceiver extends BoardLocalSupport {
 
 		// Read the data
 		var region = receivedData.getRecordingRegion(location);
-		readSomeData(location, region.data, region.size);
+		readSomeData(location, region.data, region.size, true);
 	}
 
 	private static final long MAX_UINT = 0xFFFFFFFFL;
@@ -182,7 +182,7 @@ public class DataReceiver extends BoardLocalSupport {
 	}
 
 	private void readSomeData(RegionLocation location, MemoryLocation address,
-			long length) throws IOException, StorageException, ProcessException,
+			long length, boolean isRecording) throws IOException, StorageException, ProcessException,
 			InterruptedException {
 		if (!is32bit(length)) {
 			throw new IllegalArgumentException("non-32-bit argument");
@@ -192,7 +192,7 @@ public class DataReceiver extends BoardLocalSupport {
 					address);
 		}
 		var data = requestData(location, address, (int) length);
-		receivedData.flushingDataFromRegion(location, data);
+		receivedData.flushingDataFromRegion(location, data, isRecording);
 	}
 
 	/**

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DataReceiver.java
@@ -182,8 +182,8 @@ public class DataReceiver extends BoardLocalSupport {
 	}
 
 	private void readSomeData(RegionLocation location, MemoryLocation address,
-			long length, boolean isRecording) throws IOException, StorageException, ProcessException,
-			InterruptedException {
+			long length, boolean isRecording) throws IOException,
+			StorageException, ProcessException,	InterruptedException {
 		if (!is32bit(length)) {
 			throw new IllegalArgumentException("non-32-bit argument");
 		}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -138,7 +138,8 @@ public class DirectDataGatherer extends DataGatherer {
 		// TODO This is wrong because of shared regions!
 		int size = b.get(regionID + 1) - b.get(regionID);
 		return new Region(
-			placement, regionID, new MemoryLocation(b.get(regionID)), size, true);
+			placement, regionID, new MemoryLocation(b.get(regionID)), size,
+			true);
 	}
 
 	@Override

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/DirectDataGatherer.java
@@ -131,14 +131,14 @@ public class DirectDataGatherer extends DataGatherer {
 	}
 
 	@Override
-	protected Region getRegion(Placement placement, int regionID)
+	protected Region getRecordingRegion(Placement placement, int regionID)
 			throws IOException, ProcessException, InterruptedException {
 		var b = getCoreRegionTable(placement.asCoreLocation(),
 				placement.getVertex());
 		// TODO This is wrong because of shared regions!
 		int size = b.get(regionID + 1) - b.get(regionID);
 		return new Region(
-			placement, regionID, new MemoryLocation(b.get(regionID)), size);
+			placement, regionID, new MemoryLocation(b.get(regionID)), size, true);
 	}
 
 	@Override

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -113,12 +113,13 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 	}
 
 	@Override
-	protected Region getRegion(Placement placement, int index)
+	protected Region getRecordingRegion(
+			Placement placement, int index)
 			throws IOException, ProcessException, InterruptedException {
 		var region = getRegions(placement).get(index);
 		log.debug("got region of {} R:{} as {}", placement.asCoreLocation(),
 				index, region);
-		return new Region(placement, index, region.data, (int) region.size);
+		return new Region(placement, index, region.data, (int) region.size, true);
 	}
 
 	@Override
@@ -132,7 +133,7 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 			log.info("storing region data for {} R:{} from {} as {} bytes",
 					r.core, r.regionIndex, r.startAddress, data.remaining());
 			try {
-				database.appendRecordingContents(r, data);
+				database.extractRecordingContents(r, data);
 				numWrites++;
 			} catch (StorageException e) {
 				log.error("failed to write to database", e);

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/download/RecordingRegionDataGatherer.java
@@ -119,7 +119,8 @@ public class RecordingRegionDataGatherer extends DataGatherer {
 		var region = getRegions(placement).get(index);
 		log.debug("got region of {} R:{} as {}", placement.asCoreLocation(),
 				index, region);
-		return new Region(placement, index, region.data, (int) region.size, true);
+		return new Region(placement, index, region.data, (int) region.size,
+				true);
 	}
 
 	@Override

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -166,6 +166,14 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 		public final int finalIgnore;
 
 		/**
+		 * States is a recording region
+		 * True if this region is appended after every run/loop.
+		 * False is this region is overwritten aevery run.
+		 */
+		@NotNull
+		public final boolean isRecording;
+
+		/**
 		 * Create a region descriptor.
 		 *
 		 * @param core
@@ -180,9 +188,14 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 		 * @param size
 		 *            How much data should be downloaded? <em>This is not
 		 *            necessarily the size of the region.</em>
+		 * @param isRecording
+		 *            States is a recording region
+		 *            True if this region is appended after every run/loop.
+		 *            False is this region is overwritten aevery run.
+		 *
 		 */
 		public Region(HasCoreLocation core, int regionIndex,
-				MemoryLocation startLocation, int size) {
+				MemoryLocation startLocation, int size, boolean isRecording) {
 			this.core = core.asCoreLocation();
 			this.regionIndex = regionIndex;
 			realSize = size;
@@ -193,6 +206,7 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 			finalIgnore = (INT_SIZE - (size % INT_SIZE)) % INT_SIZE;
 			size += finalIgnore;
 			this.size = size;
+			this.isRecording = isRecording;
 		}
 
 		/**
@@ -257,7 +271,7 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 	}
 
 	/**
-	 * Adds some bytes to the database. The bytes represent part of the contents
+	 * Extract some bytes to the database. The bytes represent the contents
 	 * of a recording region of a particular SpiNNaker core.
 	 *
 	 * @param region
@@ -267,26 +281,27 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 	 * @throws StorageException
 	 *             If anything goes wrong.
 	 */
-	void appendRecordingContents(Region region, byte[] contents)
+	void extractRecordingContents(Region region, byte[] contents)
 			throws StorageException;
+
 
 	void insertMockExtraction() throws StorageException;
 
 	/**
-	 * Adds some bytes to the database. The bytes represent part of the contents
+	 * Extract some bytes to the database. The bytes represent the contents
 	 * of a recording region of a particular SpiNNaker core.
 	 *
 	 * @param region
 	 *            The recording region that is being recorded.
 	 * @param contents
-	 *            The contents to append.
+	 *            The contents to extract.
 	 * @throws StorageException
 	 *             If anything goes wrong.
 	 */
-	default void appendRecordingContents(Region region, ByteBuffer contents)
+	default void extractRecordingContents(Region region, ByteBuffer contents)
 			throws StorageException {
 		var ary = new byte[contents.remaining()];
 		contents.slice().get(ary);
-		appendRecordingContents(region, ary);
+		extractRecordingContents(region, ary);
 	}
 }

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -286,7 +286,6 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 
 
 	void insertMockExtraction() throws StorageException;
-
 	/**
 	 * Extract some bytes to the database. The bytes represent the contents
 	 * of a recording region of a particular SpiNNaker core.

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/BufferManagerStorage.java
@@ -284,8 +284,8 @@ public interface BufferManagerStorage extends ProxyAwareStorage {
 	void extractRecordingContents(Region region, byte[] contents)
 			throws StorageException;
 
-
 	void insertMockExtraction() throws StorageException;
+
 	/**
 	 * Extract some bytes to the database. The bytes represent the contents
 	 * of a recording region of a particular SpiNNaker core.

--- a/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
+++ b/SpiNNaker-storage/src/main/java/uk/ac/manchester/spinnaker/storage/sqlite/SQL.java
@@ -52,10 +52,11 @@ abstract class SQL {
 	/** Create a region record. */
 	@Parameter("core_id")
 	@Parameter("local_region_index")
+	@Parameter("is_recording")
 	@ResultColumn("region_id")
 	static final String INSERT_REGION = "INSERT INTO "
-			+ "region(core_id, local_region_index)"
-			+ " VALUES (?, ?) RETURNING region_id";
+			+ "region(core_id, local_region_index, is_recording)"
+			+ " VALUES (?, ?, ?) RETURNING region_id";
 
 
 	/** For testing create an extraction record.

--- a/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/buffer_manager.sql
+++ b/SpiNNaker-storage/src/main/resources/uk/ac/manchester/spinnaker/storage/sqlite/buffer_manager.sql
@@ -52,17 +52,13 @@ CREATE TABLE IF NOT EXISTS region(
 	core_id INTEGER NOT NULL
 		REFERENCES core(core_id) ON DELETE RESTRICT,
 	local_region_index INTEGER NOT NULL,
-	address INTEGER,
-	content BLOB NOT NULL DEFAULT '',
-	content_len INTEGER DEFAULT 0,
-	fetches INTEGER NOT NULL DEFAULT 0,
-	append_time INTEGER);
+	is_recording INTEGER NOT NULL);
 -- Every recording region has a unique vertex and index
 CREATE UNIQUE INDEX IF NOT EXISTS regionSanity ON region(
 	core_id ASC, local_region_index ASC);
 
 CREATE VIEW IF NOT EXISTS region_view AS
-	SELECT core_id, region_id, x, y, processor, local_region_index
+SELECT core_id, region_id, x, y, processor, local_region_index, is_recording
 FROM core NATURAL JOIN region;
 
 CREATE TABLE IF NOT EXISTS region_data(
@@ -79,11 +75,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS region_data_sanity ON region_data(
 	region_id ASC, extraction_id ASC);
 
 CREATE VIEW IF NOT EXISTS region_data_view AS
-	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len
+SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+	content, content_len, is_recording
 FROM region_view NATURAL JOIN region_data;
 
 CREATE VIEW IF NOT EXISTS region_data_plus_view AS
-	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
+SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+	content, content_len, is_recording, run_timestep, run_time_ms, n_run, n_loop, extraction_time
 FROM region_data_view NATURAL JOIN extraction_view;

--- a/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
+++ b/SpiNNaker-storage/src/test/java/uk/ac/manchester/spinnaker/storage/TestSQLiteStorage.java
@@ -59,9 +59,9 @@ class TestSQLiteStorage {
 
 		assertEquals(List.of(), storage.getCoresWithStorage());
 
-		var rr = new BufferManagerStorage.Region(core, 0, NULL, 100);
+		var rr = new BufferManagerStorage.Region(core, 0, NULL, 100, true);
 		storage.insertMockExtraction();
-		storage.appendRecordingContents(rr, bytes("def"));
+		storage.extractRecordingContents(rr, bytes("def"));
 		assertArrayEquals("def".getBytes(UTF_8),
 				storage.getRecordingRegionContents(rr));
 
@@ -75,13 +75,13 @@ class TestSQLiteStorage {
 		var core = new CoreLocation(0, 0, 0);
 
 		// append creates
-		var rr = new BufferManagerStorage.Region(core, 1, NULL, 100);
+		var rr = new BufferManagerStorage.Region(core, 1, NULL, 100, true);
 		storage.insertMockExtraction();
-		storage.appendRecordingContents(rr, bytes("ab"));
+		storage.extractRecordingContents(rr, bytes("ab"));
 		storage.insertMockExtraction();
-		storage.appendRecordingContents(rr, bytes("cd"));
+		storage.extractRecordingContents(rr, bytes("cd"));
 		storage.insertMockExtraction();
-		storage.appendRecordingContents(rr, bytes("ef"));
+		storage.extractRecordingContents(rr, bytes("ef"));
 		assertEquals("abcdef", str(storage.getRecordingRegionContents(rr)));
 	}
 


### PR DESCRIPTION
part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1209

The decision of which placements to record based on last/only loop vs middle auto pause loop is handled by Python.

The main changes here are for the creation of the record row in the data based on if the region is_recording or not

- appendRecordingContents renamed extractRecordingContents as the method handles both regions that append (is_recording) and the ones that record the new region state.
- isRecording param added to Region class and methods that create a region for both is_recording and not
- isRecording added to database replacing unused columns (identical to python changes)
- SQL and calling method adapted for isRecording
- getRegion renamed getRecordingRegion to reflect it should only be called when isRecording is True
