### PR TITLE
Default nmpi quota fix

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -530,10 +530,8 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			String nmpiCollab, CreateDescriptor descriptor,
 			String machineName, List<String> tags, Duration keepaliveInterval,
 			byte[] originalRequest) {
-		var quotaUnits = quotaManager.mayCreateNMPISession(nmpiCollab);
-		if (quotaUnits.isEmpty()) {
-			return Optional.empty();
-		}
+		var session = quotaManager.createSession(nmpiCollab, owner);
+		var quotaUnits = session.getResourceUsage().getUnits();
 
 		// Use the Collab name as the group, as it should exist
 		var job = execute(conn -> createJobInGroup(
@@ -545,8 +543,8 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			return job;
 		}
 
-		quotaManager.associateNMPISession(
-				job.get().getId(), owner, nmpiCollab, quotaUnits.get());
+		quotaManager.associateNMPISession(job.get().getId(), session.getId(),
+				quotaUnits);
 
 		// Return the job created
 		return job;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
@@ -25,6 +25,9 @@ public class SessionResponse {
 	/** The ID of the session. */
 	private Integer id;
 
+	/** A count of how much resource has been used by the job. */
+	private ResourceUsage resourceUsage;
+
 	/**
 	 * Get the ID of the session.
 	 *
@@ -42,6 +45,25 @@ public class SessionResponse {
 	 */
 	public void setId(final Integer id) {
 		this.id = id;
+	}
+
+	/**
+	 * Get the count of how much resource has been used by the job.
+	 *
+	 * @return the resourceUsage
+	 */
+	public ResourceUsage getResourceUsage() {
+		return resourceUsage;
+	}
+
+	/**
+	 * Sets the resourceUsage.
+	 *
+	 * @param resourceUsage
+	 *            the resourceUsage to set
+	 */
+	public void setResourceUsage(final ResourceUsage resourceUsage) {
+		this.resourceUsage = resourceUsage;
 	}
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
@@ -81,6 +81,6 @@ public class SessionResponse {
 	 */
 	@JsonAnySetter
 	public void set(final String name, final Object value) {
-		System.err.println("Ignoring unknown property: " + name + " = " + value);
+		// Ignore any other values
 	}
 }

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/nmpi/SessionResponse.java
@@ -17,10 +17,13 @@
 package uk.ac.manchester.spinnaker.alloc.nmpi;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 /**
  * A NMPI session response.
  */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SessionResponse {
 	/** The ID of the session. */
 	private Integer id;
@@ -78,6 +81,6 @@ public class SessionResponse {
 	 */
 	@JsonAnySetter
 	public void set(final String name, final Object value) {
-		// Ignore any other values
+		System.err.println("Ignoring unknown property: " + name + " = " + value);
 	}
 }


### PR DESCRIPTION
Updated order of operation as requested by Andrew Davidson.  This allows it to use "default quota" when creating sessions, meaning that this doesn't have to be set up in advance.