### PR TITLE
Allow starting with faulty BMPs

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -1079,7 +1079,8 @@ public class BMPController extends DatabaseAwareBean {
 				try {
 					control = controllerFactory.create(machine, coords, boards);
 				} catch (Exception e) {
-					log.error("Could not create control for BMP '{}'", bmpId, e);
+					log.error("Could not create control for BMP '{}'",
+							bmpId, e);
 				}
 			}
 			return control;

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/messages/Constants.java
@@ -105,7 +105,7 @@ public abstract class Constants {
 	public static final double BMP_POWER_ON_TIMEOUT = 10.0;
 
 	/** Timeout for other BMP commands to reply (in seconds). */
-	public static final double BMP_TIMEOUT = 0.75;
+	public static final double BMP_TIMEOUT = 2.0;
 
 	/** Time to sleep after powering on boards (in seconds). */
 	public static final double BMP_POST_POWER_ON_SLEEP_TIME = 5.0;


### PR DESCRIPTION
If a BMP fails, the server will not start at present.  This allows the start to happen.  The creation of the transceiver is delayed until needed, but note this can then result in NullPointerException on the board.  This is OK though since it just works like the board fails (which is a different issue to fix later).
