### PR TITLE
use paths rather than directories

### DIFF
--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -302,6 +302,8 @@ public final class CommandLineInterface {
 	 *            The database that receives the output).
 	 * @param logfile
 	 *            The path where the log should write.
+	 * @param iobufDir
+	 * 			  The path to the directory where the iobuff would be written
 	 * @throws IOException
 	 *             If the communications fail.
 	 * @throws SpinnmanException
@@ -568,7 +570,8 @@ public final class CommandLineInterface {
 	 * @see Parameters
 	 */
 	public static class LogfileParam implements Supplier<File> {
-		@Parameters(description = LOGFILE, converter = Converter.class, arity = "1")
+		@Parameters(description = LOGFILE, converter = Converter.class,
+			arity = "1")
 		private ValueHolder<File> logfile = new ValueHolder<>();
 
 		/** @hidden */
@@ -588,7 +591,7 @@ public final class CommandLineInterface {
 				var f = new File(filename);
 				if (f.isDirectory()) {
 					throw new TypeConversionException(
-							"<logfile> " + filename + " must not be a directory");
+						"<logfile> " + filename + " must not be a directory");
 				}
 				return new ValueHolder<>(f);
 			}

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -27,7 +27,7 @@ import static uk.ac.manchester.spinnaker.front_end.CommandDescriptions.GATHER_DE
 import static uk.ac.manchester.spinnaker.front_end.CommandDescriptions.IOBUF_DESC;
 import static uk.ac.manchester.spinnaker.front_end.CommandDescriptions.LISTEN_DESC;
 import static uk.ac.manchester.spinnaker.front_end.Constants.PARALLEL_SIZE;
-import static uk.ac.manchester.spinnaker.front_end.LogControl.setLoggerDir;
+import static uk.ac.manchester.spinnaker.front_end.LogControl.setLogfile;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.DBFILE;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.DSFILE;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.GATHER;
@@ -35,7 +35,8 @@ import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.MACHINE;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.MAP;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.PLACEMENT;
 import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.REPORT;
-import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.RUN;
+import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.LOGFILE;
+import static uk.ac.manchester.spinnaker.front_end.ParamDescriptions.IOBUFDIR;
 import static uk.ac.manchester.spinnaker.machine.bean.MapperFactory.createMapper;
 
 import java.io.File;
@@ -152,20 +153,20 @@ public final class CommandLineInterface {
 	private void dseSystemCores(
 			@Mixin MachineParam machine,
 			@Mixin DsFileParam dsFile,
-			@Mixin RunFolderParam runFolder)
+			@Mixin LogfileParam logfile)
 			throws Exception {
 		runDSEUploadingViaClassicTransfer(machine.get(), dsFile.get(),
-				runFolder.get(), false);
+				logfile.get(), false);
 	}
 
 	@Command(name = "dse_app", description = DSE_APP_DESC)
 	private void dseApplicationCores(
 			@Mixin MachineParam machine,
 			@Mixin DsFileParam dsFile,
-			@Mixin RunFolderParam runFolder)
+			@Mixin LogfileParam logfile)
 			throws Exception {
 		runDSEUploadingViaClassicTransfer(machine.get(), dsFile.get(),
-				runFolder.get(), true);
+				logfile.get(), true);
 	}
 
 	@FunctionalInterface
@@ -204,8 +205,8 @@ public final class CommandLineInterface {
 	 *            Description of overall machine
 	 * @param dsFile
 	 *            Path to the dataspec database
-	 * @param runFolder
-	 *            Directory containing per-run information.
+	 * @param logfile
+	 *            The path where the log should write.
 	 * @param filterSystemCores
 	 *            If {@code true}, only run the DSE for application vertices. If
 	 *            {@code false}, only run the DSE for system vertices. If
@@ -224,10 +225,10 @@ public final class CommandLineInterface {
 	 *             If the proxy URI is provided but not valid.
 	 */
 	public void runDSEUploadingViaClassicTransfer(Machine machine,
-			File dsFile, File runFolder, Boolean filterSystemCores)
+			File dsFile, File logfile, Boolean filterSystemCores)
 			throws IOException, SpinnmanException, StorageException,
 			ExecutionException, InterruptedException, URISyntaxException {
-		setLoggerDir(runFolder);
+		setLogfile(logfile);
 		var db = getDataSpecDB(dsFile);
 
 		try (var dseExec = hostFactory.create(machine, db)) {
@@ -251,8 +252,8 @@ public final class CommandLineInterface {
 	 *            Description of overall machine.
 	 * @param dsFile
 	 *            Path to the dataspec database
-	 * @param runFolder
-	 *            Directory containing per-run information.
+	 * @param logfile
+	 *            The path where the log should write.
 	 * @param reportFolder
 	 *            Directory containing reports. If {@link Optional#empty()}, no
 	 *            report will be written.
@@ -274,12 +275,12 @@ public final class CommandLineInterface {
 			@Mixin GatherersParam gatherers,
 			@Mixin MachineParam machine,
 			@Mixin DsFileParam dsFile,
-			@Mixin RunFolderParam runFolder,
+			@Mixin LogfileParam logfile,
 			@Parameters(description = REPORT, arity = "0..1", index = "3")
 			Optional<File> reportFolder)
 			throws IOException, SpinnmanException, StorageException,
 			ExecutionException, InterruptedException, URISyntaxException {
-		setLoggerDir(runFolder.get());
+		setLogfile(logfile.get());
 		var db = getDataSpecDB(dsFile.get());
 
 		try (var dseExec = fastFactory.create(machine.get(),
@@ -299,8 +300,8 @@ public final class CommandLineInterface {
 	 *            IOBUFs for.
 	 * @param dbFile
 	 *            The database that receives the output).
-	 * @param runFolder
-	 *            Directory containing per-run information (i.e., where to log).
+	 * @param logfile
+	 *            The path where the log should write.
 	 * @throws IOException
 	 *             If the communications fail.
 	 * @throws SpinnmanException
@@ -312,20 +313,22 @@ public final class CommandLineInterface {
 	 * @throws StorageException
 	 *             If there is an error reading the database
 	 */
+	// see https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues/1218
 	@Command(name = "iobuf", description = IOBUF_DESC)
 	public void retrieveIOBUFs(
 			@Mixin MachineParam machine,
 			@Mixin IobufMapParam iobuf,
 			@Mixin DbFileParam dbFile,
-			@Mixin RunFolderParam runFolder)
+			@Mixin LogfileParam logfile,
+			@Mixin IobufDirParam iobufDir)
 			throws IOException, SpinnmanException, InterruptedException,
 			StorageException, URISyntaxException {
-		setLoggerDir(runFolder.get());
+		setLogfile(logfile.get());
 		var db = getBufferManagerDB(dbFile.get());
 
 		try (var r = new IobufRetriever(db, machine.get(),
 						PARALLEL_SIZE)) {
-			var result = r.retrieveIobufContents(iobuf.get(), runFolder.get());
+			var result = r.retrieveIobufContents(iobuf.get(), iobufDir.get());
 			MAPPER.writeValue(System.out, result);
 		}
 	}
@@ -339,8 +342,8 @@ public final class CommandLineInterface {
 	 *            Description of overall machine.
 	 * @param dbFile
 	 *            The database that receives the output).
-	 * @param runFolder
-	 *            Directory containing per-run information (i.e., where to log).
+	 * @param logfile
+	 *            The path where the log should write.
 	 * @throws IOException
 	 *             If the communications fail
 	 * @throws SpinnmanException
@@ -357,10 +360,10 @@ public final class CommandLineInterface {
 			@Mixin PlacementsParam placements,
 			@Mixin MachineParam machine,
 			@Mixin DbFileParam dbFile,
-			@Mixin RunFolderParam runFolder)
+			@Mixin LogfileParam logfile)
 			throws IOException, SpinnmanException, StorageException,
 			InterruptedException, URISyntaxException {
-		setLoggerDir(runFolder.get());
+		setLogfile(logfile.get());
 		var db = getBufferManagerDB(dbFile.get());
 
 		try (var r = new DataReceiver(machine.get(), db)) {
@@ -377,8 +380,8 @@ public final class CommandLineInterface {
 	 *            Description of overall machine.
 	 * @param dbFile
 	 *            The database that receives the output).
-	 * @param runFolder
-	 *            Directory containing per-run information (i.e., where to log).
+	 * @param logfile
+	 *            The path where the log should write.
 	 * @throws IOException
 	 *             If the communications fail
 	 * @throws SpinnmanException
@@ -396,10 +399,10 @@ public final class CommandLineInterface {
 			@Mixin GatherersParam gatherers,
 			@Mixin MachineParam machine,
 			@Mixin DbFileParam dbFile,
-			@Mixin RunFolderParam runFolder)
+			@Mixin LogfileParam logfile)
 			throws IOException, SpinnmanException, StorageException,
 			InterruptedException, URISyntaxException {
-		setLoggerDir(runFolder.get());
+		setLogfile(logfile.get());
 		var db = getBufferManagerDB(dbFile.get());
 
 		try (var r = new RecordingRegionDataGatherer(machine.get(),	db)) {
@@ -557,26 +560,25 @@ public final class CommandLineInterface {
 	}
 
 	/**
-	 * Argument handler for the {@code <runFolder>} parameter.
+	 * Argument handler for the {@code <logfile>} parameter.
 	 * <p>
 	 * Do not make instances of this class yourself; leave that to picocli.
 	 *
-	 * @author Donal Fellows
 	 * @see ArgGroup
 	 * @see Parameters
 	 */
-	public static class RunFolderParam implements Supplier<File> {
-		@Parameters(description = RUN, converter = Converter.class, arity = "1")
-		private ValueHolder<File> runFolder = new ValueHolder<>();
+	public static class LogfileParam implements Supplier<File> {
+		@Parameters(description = LOGFILE, converter = Converter.class, arity = "1")
+		private ValueHolder<File> logfile = new ValueHolder<>();
 
 		/** @hidden */
-		public RunFolderParam() {
+		public LogfileParam() {
 		}
 
 		/** @return The folder for the run. */
 		@Override
 		public File get() {
-			return runFolder.getValue();
+			return logfile.getValue();
 		}
 
 		static class Converter implements ITypeConverter<ValueHolder<File>> {
@@ -584,9 +586,45 @@ public final class CommandLineInterface {
 			public ValueHolder<File> convert(String filename)
 					throws IOException {
 				var f = new File(filename);
+				if (f.isDirectory()) {
+					throw new TypeConversionException(
+							"<logfile> " + filename + " must not be a directory");
+				}
+				return new ValueHolder<>(f);
+			}
+		}
+	}
+
+	/**
+	 * Argument handler for the {@code <iobufDir>} parameter.
+	 * <p>
+	 * Do not make instances of this class yourself; leave that to picocli.
+	 *
+	 * @see ArgGroup
+	 * @see Parameters
+	 */
+	public static class IobufDirParam implements Supplier<File> {
+		@Parameters(description = IOBUFDIR, converter = Converter.class, arity = "1")
+		private ValueHolder<File> iobufDir = new ValueHolder<>();
+
+		/** @hidden */
+		public IobufDirParam() {
+		}
+
+		/** @return The folder for the run. */
+		@Override
+		public File get() {
+			return iobufDir.getValue();
+		}
+
+		static class Converter implements ITypeConverter<ValueHolder<File>> {
+			@Override
+			public ValueHolder<File> convert(String filename)
+				throws IOException {
+				var f = new File(filename);
 				if (!f.isDirectory()) {
 					throw new TypeConversionException(
-							"<runFolder> must be a directory");
+						"<iobufDir> must be a directory");
 				}
 				return new ValueHolder<>(f);
 			}
@@ -750,6 +788,9 @@ interface ParamDescriptions {
 	/** Description of {@code dsFile} parameter. */
 	String DSFILE = "The path of the dataspec database.";
 
-	/** Description of {@code runFolder} parameter. */
-	String RUN = "The name of the run data folder.";
+	/** Description of {@code logfile} parameter. */
+	String LOGFILE = "The name of the logfile path.";
+
+	/** Description of {@code iobufDir} parameter. */
+	String IOBUFDIR = "The name of the iobuf folder.";
 }

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/CommandLineInterface.java
@@ -607,7 +607,8 @@ public final class CommandLineInterface {
 	 * @see Parameters
 	 */
 	public static class IobufDirParam implements Supplier<File> {
-		@Parameters(description = IOBUFDIR, converter = Converter.class, arity = "1")
+		@Parameters(description = IOBUFDIR, converter = Converter.class,
+			arity = "1")
 		private ValueHolder<File> iobufDir = new ValueHolder<>();
 
 		/** @hidden */

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/LogControl.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuild
  * @author Donal Fellows
  */
 public final class LogControl {
-	private static final String LOG_FILE = "jspin.log";
 
 	/** The names of appenders. */
 	private interface Loggers {
@@ -187,16 +186,15 @@ public final class LogControl {
 	}
 
 	/**
-	 * Initialise the logging subsystem to log to the correct directory.
+	 * Initialise the logging subsystem to log to the correct file.
 	 * <p>
 	 * Note that this reads system properties, and probably should only be
 	 * called once.
 	 *
-	 * @param directory
-	 *            The directory where the log should written inside.
+	 * @param logfile
+	 *            The path where the log should write.
 	 */
-	public static void setLoggerDir(File directory) {
-		var logfile = new File(directory, LOG_FILE);
+	public static void setLogfile(File logfile) {
 		var level = getProperty(Props.LOGGING_LEVEL_NAME, "info");
 		var lc = new LogControl();
 		reconfigure(lc.configuration(logfile, level));

--- a/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
+++ b/SpiNNaker-front-end/src/main/java/uk/ac/manchester/spinnaker/front_end/iobuf/IobufRetriever.java
@@ -123,6 +123,7 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	 * @throws RuntimeException
 	 *             If an unexpected exception happens.
 	 */
+	// see https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues/1218
 	public NotableMessages retrieveIobufContents(IobufRequest request,
 			File provenanceDir)
 			throws IOException, ProcessException, InterruptedException {
@@ -173,6 +174,7 @@ public class IobufRetriever extends BoardLocalSupport implements AutoCloseable {
 	 * @throws RuntimeException
 	 *             If an unexpected exception happens.
 	 */
+	// see https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues/1218
 	public NotableMessages retrieveIobufContents(CoreSubsets cores,
 			File binaryFile, File provenanceDir)
 			throws IOException, ProcessException, InterruptedException {

--- a/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
+++ b/SpiNNaker-front-end/src/test/java/uk/ac/manchester/spinnaker/front_end/TestFrontEnd.java
@@ -110,7 +110,7 @@ class TestFrontEnd {
 			runMainExpecting(0, "help");
 		});
 		var requiredSubcommands = List.of("dse_app_mon", "gather");
-		var requiredArgs = List.of("<machineFile>", "<runFolder>");
+		var requiredArgs = List.of("<machineFile>", "<logfile>");
 		for (var cmd: requiredSubcommands) {
 			assertContainsInOrder(msg, cmd);
 			var msg2 = tapSystemOutNormalized(() -> {
@@ -136,8 +136,7 @@ class TestFrontEnd {
 	void testSimpleDSE(String cmd) throws Exception {
 		var machineFile = getClass().getResource("/machine.json").getFile();
 		var dsFile = getClass().getResource("/ds.sqlite3").getFile();
-		var runFolder = "target/test/SimpleDSE";
-		new File(runFolder).mkdirs();
+		var logfile = "target/test/SimpleDSE/jspin.log";
 
 		var saved = CommandLineInterface.hostFactory;
 		var called = new ValueHolder<>("none");
@@ -157,19 +156,19 @@ class TestFrontEnd {
 			var msg = tapSystemErrNormalized(() -> {
 				runMainExpecting(2, cmd);
 			});
-			assertContainsInOrder(msg, "<machineFile>", "<runFolder>");
+			assertContainsInOrder(msg, "<machineFile>", "<logfile>");
 
 			tapSystemErrNormalized(() -> {
 				runMainExpecting(2, cmd, machineFile);
 			});
 
 			tapSystemErrNormalized(() -> {
-				runMainExpecting(2, cmd, machineFile, dsFile, runFolder,
+				runMainExpecting(2, cmd, machineFile, dsFile, logfile,
 						"gorp");
 			});
 
 			assertEquals("none", called.getValue());
-			runMainExpecting(0, cmd, machineFile, dsFile, runFolder);
+			runMainExpecting(0, cmd, machineFile, dsFile, logfile);
 			assertEquals(cmd, called.getValue());
 		} finally {
 			CommandLineInterface.hostFactory = saved;
@@ -183,8 +182,7 @@ class TestFrontEnd {
 		var gatherFile = cls.getResource("/gather.json").getFile();
 		var machineFile = cls.getResource("/machine.json").getFile();
 		var dsFile = getClass().getResource("/ds.sqlite3").getFile();
-		var runFolder = "target/test/AdvancedDSE";
-		new File(runFolder).mkdirs();
+		var logfile = "target/test/AdvancedDSE/jspin.log";
 
 		var saved = CommandLineInterface.fastFactory;
 		var called = new ValueHolder<>("none");
@@ -207,11 +205,11 @@ class TestFrontEnd {
 				runMainExpecting(2, "dse_app_mon");
 			});
 			assertContainsInOrder(msg, "<gatherFile>", "<machineFile>",
-					"<runFolder>", "[<reportFolder>]");
+					"<logfile>", "[<reportFolder>]");
 
 			assertEquals("none", called.getValue());
 			runMainExpecting(0, "dse_app_mon", gatherFile, machineFile, dsFile,
-					runFolder);
+					logfile);
 			assertEquals("mon", called.getValue());
 		} finally {
 			CommandLineInterface.fastFactory = saved;
@@ -224,7 +222,7 @@ class TestFrontEnd {
 			runMainExpecting(2, "download");
 		});
 		assertContainsInOrder(msg, "<placementFile>", "<machineFile>",
-				"<runFolder>");
+				"<logfile");
 	}
 
 	@Test
@@ -233,7 +231,7 @@ class TestFrontEnd {
 			runMainExpecting(2, "gather");
 		});
 		assertContainsInOrder(msg, "<gatherFile>", "<machineFile>",
-				"<runFolder>");
+				"<logfile>");
 	}
 }
 


### PR DESCRIPTION
part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1276

Instead of passing in RunFolderParam
now uses
LogfileParam
IobufDirParam

warning IOBUFF stuff not tested see
https://github.com/SpiNNakerManchester/JavaSpiNNaker/issues/1218
But less broken than before