### PR TITLE
Emergency stop

### DIFF
--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/SpallocProperties.java
@@ -590,6 +590,9 @@ public class SpallocProperties {
 		/** Name of user that system-generated reports are done by. */
 		private String systemReportUser;
 
+		/** Command code to accept for an emergency shutdown. */
+		private String emergencyStopCommandCode;
+
 		/**
 		 * @param period
 		 *            Time between runs of the main allocation algorithm.
@@ -603,17 +606,21 @@ public class SpallocProperties {
 		 *            taken out of service.
 		 * @param systemReportUser
 		 *            Name of user that system-generated reports are done by.
+		 * @param emergencyStopCommandCode
+		 *           Command code to accept for an emergency stop.
 		 */
 		public AllocatorProperties(@DefaultValue("5s") Duration period,
 				@DefaultValue("10000") int importanceSpan,
 				@DefaultValue PriorityScale priorityScale,
 				@DefaultValue("2") int reportActionThreshold,
-				@DefaultValue("") String systemReportUser) {
+				@DefaultValue("") String systemReportUser,
+				@DefaultValue String emergencyStopCommandCode) {
 			this.period = period;
 			this.importanceSpan = importanceSpan;
 			this.priorityScale = priorityScale;
 			this.reportActionThreshold = reportActionThreshold;
 			this.systemReportUser = systemReportUser;
+			this.emergencyStopCommandCode = emergencyStopCommandCode;
 		}
 
 		/**
@@ -682,6 +689,18 @@ public class SpallocProperties {
 
 		void setSystemReportUser(String systemReportUser) {
 			this.systemReportUser = systemReportUser;
+		}
+
+		/**
+		 * @return Command code to accept for an emergency stop.
+		 */
+		@NotBlank
+		public String getEmergencyStopCommandCode() {
+			return emergencyStopCommandCode;
+		}
+
+		void setEmergencyStopCommandCode(String emergencyStopCommandCode) {
+			this.emergencyStopCommandCode = emergencyStopCommandCode;
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -1514,8 +1514,11 @@ public class AllocatorTask extends DatabaseAwareBean
 
 			@Override
 			public void restartAfterStop() {
-				AllocatorTask.this.emergencyStop = false;
-				AllocatorTask.this.init();
+				synchronized (AllocatorTask.this.futures) {
+					AllocatorTask.this.emergencyStop = false;
+					AllocatorTask.this.futures.clear();
+					AllocatorTask.this.init();
+				}
 			}
 		};
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -132,7 +132,7 @@ public class AllocatorTask extends DatabaseAwareBean
 	@Autowired
 	private TaskScheduler scheduler;
 
-	@GuardedBy("self")
+	@GuardedBy("itself")
 	private final List<ScheduledFuture<?>> futures = new ArrayList<>();
 
 	@GuardedBy("futures")

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
@@ -54,6 +55,7 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
 
 import com.google.errorprone.annotations.RestrictedApi;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import uk.ac.manchester.spinnaker.alloc.ForTestingOnly;
 import uk.ac.manchester.spinnaker.alloc.ServiceMasterControl;
@@ -130,6 +132,15 @@ public class AllocatorTask extends DatabaseAwareBean
 	@Autowired
 	private TaskScheduler scheduler;
 
+	@GuardedBy("self")
+	private final List<ScheduledFuture<?>> futures = new ArrayList<>();
+
+	@GuardedBy("futures")
+	private ScheduledFuture<?> allocateFuture = null;
+
+	@GuardedBy("futures")
+	private boolean emergencyStop = false;
+
 	// Note can't be autowired as circular;
 	// instead set by setter in postconstruct of BMPController
 	private BMPController bmpController;
@@ -141,11 +152,14 @@ public class AllocatorTask extends DatabaseAwareBean
 	@PostConstruct
 	@SuppressWarnings("FutureReturnValueIgnored")
 	private void init() {
-		scheduler.scheduleAtFixedRate(() -> allocate(),	allocProps.getPeriod());
-		scheduler.scheduleAtFixedRate(() -> expireJobs(),
-				keepAliveProps.getExpiryPeriod());
-		scheduler.schedule(() -> tombstone(),
-				new CronTrigger(historyProps.getSchedule()));
+		synchronized (futures) {
+			futures.add(scheduler.scheduleAtFixedRate(() -> allocate(),
+					allocProps.getPeriod()));
+			futures.add(scheduler.scheduleAtFixedRate(() -> expireJobs(),
+					keepAliveProps.getExpiryPeriod()));
+			futures.add(scheduler.schedule(() -> tombstone(),
+					new CronTrigger(historyProps.getSchedule())));
+		}
 	}
 
 	/**
@@ -160,8 +174,18 @@ public class AllocatorTask extends DatabaseAwareBean
 	 */
 	public void updateJob(int jobId, JobState sourceState,
 			JobState targetState) {
-		scheduler.schedule(() -> updateJobNow(jobId, sourceState, targetState),
-				Instant.now());
+		synchronized (futures) {
+			// No need to update the job in emergency stop mode, as we are
+			// going to cancel them all!  This is non-critical though; anything
+			// that gets through here should be OK.
+			if (emergencyStop) {
+				log.warn("emergency stop; not updating job {}", jobId);
+				return;
+			}
+			scheduler.schedule(
+					() -> updateJobNow(jobId, sourceState, targetState),
+					Instant.now());
+		}
 	}
 
 	private void updateJobNow(int jobId, JobState sourceState,
@@ -223,9 +247,18 @@ public class AllocatorTask extends DatabaseAwareBean
 				}
 
 				// If the job was not ready, we need to re-queue and reallocate
-				// boards
-				scheduler.schedule(() -> setPower(jobId, OFF, QUEUED),
-						Instant.now());
+				// boards, but not if in emergency stop mode
+				synchronized (futures) {
+					if (emergencyStop) {
+						log.warn("emergency stop; not requeuing job {}", jobId);
+						return false;
+					}
+					// The power request will get through here, but will be
+					// stopped later.  This is a request for off anyway, so non
+					// critical.
+					scheduler.schedule(() -> setPower(jobId, OFF, QUEUED),
+							Instant.now());
+				}
 				return false;
 			} else if (status.nChanges > 0) {
 				// There are still changes happening - let them finish first
@@ -258,6 +291,20 @@ public class AllocatorTask extends DatabaseAwareBean
 
 			return setJobState.call(targetState, jobId) > 0;
 		}
+	}
+
+	public void emergencyStop() {
+		synchronized (futures) {
+			emergencyStop = true;
+			for (var future : futures) {
+				future.cancel(true);
+			}
+			if (allocateFuture != null) {
+				allocateFuture.cancel(true);
+			}
+		}
+		bmpController.emergencyStop();
+		destroyAllJobs();
 	}
 
 	/**
@@ -298,7 +345,13 @@ public class AllocatorTask extends DatabaseAwareBean
 	 * Ask for allocation to happen now.
 	 */
 	public void scheduleAllocateNow() {
-		scheduler.schedule(this::allocate, Instant.now());
+		synchronized (futures) {
+			if (emergencyStop) {
+				log.warn("emergency stop; not scheduling allocation");
+				return;
+			}
+			allocateFuture = scheduler.schedule(this::allocate, Instant.now());
+		}
 	}
 
 	/**
@@ -477,6 +530,7 @@ public class AllocatorTask extends DatabaseAwareBean
 
 	/** Encapsulates the queries and updates used in deletion. */
 	private final class DestroySQL extends PowerSQL {
+
 		/** Get basic information about a specific job. */
 		private final Query getJob = conn.query(GET_JOB);
 
@@ -947,6 +1001,21 @@ public class AllocatorTask extends DatabaseAwareBean
 		allocations.updateBMPs();
 	}
 
+	private void destroyAllJobs() {
+		var allocations = new Allocations();
+		allocations.jobIds.addAll(execute(conn -> {
+			try (var getAll = conn.query(GET_ALL_LIVE_JOBS);
+					var destroyAll = conn.update(DESTROY_ALL_LIVE_JOBS);
+					var killAllAllocs = conn.update(KILL_ALL_JOB_ALLOC_TASK)) {
+				var jobs = getAll.call(integer("job_id"));
+				killAllAllocs.call();
+				destroyAll.call(
+						"The machine has been shut down due to an emergency");
+				return jobs;
+			}}));
+		allocations.updateEpochs();
+	}
+
 	/**
 	 * Destroy a job.
 	 *
@@ -1382,6 +1451,11 @@ public class AllocatorTask extends DatabaseAwareBean
 		 * @return The BMPs updated by the expiry.
 		 */
 		Allocations expireJobs();
+
+		/**
+		 * Stop the allocator.
+		 */
+		void emergencyStop();
 	}
 
 	/** Operations for testing historical database only. */
@@ -1425,6 +1499,11 @@ public class AllocatorTask extends DatabaseAwareBean
 			@Override
 			public Allocations expireJobs() {
 				return AllocatorTask.this.expireJobs(conn);
+			}
+
+			@Override
+			public void emergencyStop() {
+				AllocatorTask.this.emergencyStop();
 			}
 		};
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -1012,7 +1012,8 @@ public class AllocatorTask extends DatabaseAwareBean
 				destroyAll.call(
 						"The machine has been shut down due to an emergency");
 				return jobs;
-			}}));
+			}
+		}));
 		allocations.updateEpochs();
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTask.java
@@ -1457,6 +1457,11 @@ public class AllocatorTask extends DatabaseAwareBean
 		 * Stop the allocator.
 		 */
 		void emergencyStop();
+
+		/**
+		 * Restart allocations after stopping, to allow more tests!
+		 */
+		void restartAfterStop();
 	}
 
 	/** Operations for testing historical database only. */
@@ -1505,6 +1510,12 @@ public class AllocatorTask extends DatabaseAwareBean
 			@Override
 			public void emergencyStop() {
 				AllocatorTask.this.emergencyStop();
+			}
+
+			@Override
+			public void restartAfterStop() {
+				AllocatorTask.this.emergencyStop = false;
+				AllocatorTask.this.init();
 			}
 		};
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -907,10 +907,10 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 	}
 
 	public void emergencyStop(String commandCode) {
-		if (commandCode != props.getEmergencyStopCommandCode()) {
+		if (!commandCode.equals(props.getEmergencyStopCommandCode())) {
 			throw new IllegalArgumentException("Invalid emergency stop code");
 		}
-		// TODO: Stop!
+		allocator.emergencyStop();
 		emergencyStop = true;
 		log.warn("Emergency stop requested!");
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/Spalloc.java
@@ -143,6 +143,8 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 	private transient Map<String, List<DownLink>> downLinksCache =
 			new HashMap<>();
 
+	private boolean emergencyStop = false;
+
 	@Override
 	public Map<String, Machine> getMachines(boolean allowOutOfService) {
 		return executeRead(c -> getMachines(c, allowOutOfService));
@@ -432,6 +434,10 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 			CreateDescriptor descriptor, String machineName, List<String> tags,
 			Duration keepaliveInterval, byte[] req)
 					throws IllegalArgumentException {
+		if (emergencyStop) {
+			throw new IllegalStateException(
+					"The Server has been stopped due to an emergency.");
+		}
 		return execute(conn -> {
 			int user = getUser(conn, owner).orElseThrow(
 					() -> new RuntimeException("no such user: " + owner));
@@ -898,6 +904,15 @@ public class Spalloc extends DatabaseAwareBean implements SpallocAPI {
 				row.getInteger("board_2_b"), row.getString("board_2_addr"));
 		return new DownLink(board1, row.getEnum("dir_1", Direction.class),
 				board2, row.getEnum("dir_2", Direction.class));
+	}
+
+	public void emergencyStop(String commandCode) {
+		if (commandCode != props.getEmergencyStopCommandCode()) {
+			throw new IllegalArgumentException("Invalid emergency stop code");
+		}
+		// TODO: Stop!
+		emergencyStop = true;
+		log.warn("Emergency stop requested!");
 	}
 
 	private class MachineImpl implements Machine {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/allocator/SpallocAPI.java
@@ -333,6 +333,8 @@ public interface SpallocAPI {
 	void reportProblem(@IPAddress String address, HasChipLocation coreLocation,
 			String description, Permit permit);
 
+	void emergencyStop(String commandCode);
+
 	/**
 	 * Describes what sort of request to create a job this is.
 	 *

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -248,8 +248,7 @@ public class BMPController extends DatabaseAwareBean {
 			for (var worker : workers.values()) {
 				try {
 					worker.getControl().powerOff(worker.boards.keySet());
-				} catch (ProcessException | InterruptedException
-						| IOException e) {
+				} catch (Throwable e) {
 					log.warn("Error when stopping", e);
 				}
 			}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
@@ -112,7 +111,10 @@ public class BMPController extends DatabaseAwareBean {
 	@Autowired
 	private AllocatorTask allocator;
 
-	private TaskScheduler scheduler;
+	@GuardedBy("self")
+	private ThreadPoolTaskScheduler scheduler;
+
+	private boolean emergencyStop = false;
 
 	/**
 	 * Synchronizer for power request access to the database (as otherwise
@@ -159,31 +161,33 @@ public class BMPController extends DatabaseAwareBean {
 	@PostConstruct
 	private void init() {
 		// Set up scheduler
-		var sched = new ThreadPoolTaskScheduler();
-		scheduler = sched;
-		sched.setThreadGroupName("BMP");
+		scheduler = new ThreadPoolTaskScheduler();
+		synchronized (scheduler) {
+			scheduler.setThreadGroupName("BMP");
 
-		controllerFactory = controllerFactoryBean::getObject;
-		allocator.setBMPController(this);
+			controllerFactory = controllerFactoryBean::getObject;
+			allocator.setBMPController(this);
 
-		// We do the making of workers later in tests
-		List<Worker> madeWorkers = null;
-		if (!serviceControl.isUseDummyBMP()) {
-			madeWorkers = makeWorkers();
-		}
+			// We do the making of workers later in tests
+			List<Worker> madeWorkers = null;
+			if (!serviceControl.isUseDummyBMP()) {
+				madeWorkers = makeWorkers();
+			}
 
-		// Set the pool size to match the number of workers
-		if (workers.size() > 1) {
-			sched.setPoolSize(workers.size());
-		}
+			// Set the pool size to match the number of workers
+			if (workers.size() > 1) {
+				scheduler.setPoolSize(workers.size());
+			}
 
-		// Launch the scheduler now it is all set up
-		sched.initialize();
+			// Launch the scheduler now it is all set up
+			scheduler.initialize();
 
-		// And now use the scheduler
-		if (madeWorkers != null) {
-			for (var worker : madeWorkers) {
-				scheduler.scheduleAtFixedRate(worker, allocProps.getPeriod());
+			// And now use the scheduler
+			if (madeWorkers != null) {
+				for (var worker : madeWorkers) {
+					scheduler.scheduleAtFixedRate(worker,
+							allocProps.getPeriod());
+				}
 			}
 		}
 	}
@@ -219,13 +223,40 @@ public class BMPController extends DatabaseAwareBean {
 	 *            A list of BMPs that have changed.
 	 */
 	public void triggerSearch(Collection<Integer> bmps) {
-		for (var b : bmps) {
-			var worker = workers.get(b);
-			if (worker != null) {
-				scheduler.schedule(() -> worker.run(), Instant.now());
-			} else {
-				log.error("Could not find worker for BMP {}", b);
+		synchronized (scheduler) {
+			if (emergencyStop) {
+				log.warn("Emergency stop; not triggering workers");
+				return;
 			}
+			for (var b : bmps) {
+				var worker = workers.get(b);
+				if (worker != null) {
+					scheduler.schedule(() -> worker.run(), Instant.now());
+				} else {
+					log.error("Could not find worker for BMP {}", b);
+				}
+			}
+		}
+	}
+
+	public void emergencyStop() {
+		synchronized (scheduler) {
+			emergencyStop = true;
+			scheduler.shutdown();
+			for (var worker : workers.values()) {
+				try {
+					worker.getControl().powerOff(worker.boards.keySet());
+				} catch (ProcessException | InterruptedException
+						| IOException e) {
+					log.warn("Error when stopping", e);
+				};
+			}
+			execute(conn -> {
+				try (var setAllOff = conn.update(SET_ALL_BOARDS_OFF)) {
+					setAllOff.call();
+				}
+				return null;
+			});
 		}
 	}
 

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -249,7 +249,7 @@ public class BMPController extends DatabaseAwareBean {
 				} catch (ProcessException | InterruptedException
 						| IOException e) {
 					log.warn("Error when stopping", e);
-				};
+				}
 			}
 			execute(conn -> {
 				try (var setAllOff = conn.update(SET_ALL_BOARDS_OFF)) {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -111,7 +111,7 @@ public class BMPController extends DatabaseAwareBean {
 	@Autowired
 	private AllocatorTask allocator;
 
-	@GuardedBy("self")
+	@GuardedBy("itself")
 	private ThreadPoolTaskScheduler scheduler;
 
 	private boolean emergencyStop = false;

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/BMPController.java
@@ -239,6 +239,9 @@ public class BMPController extends DatabaseAwareBean {
 		}
 	}
 
+	/**
+	 * Stops execution immediately.
+	 */
 	public void emergencyStop() {
 		synchronized (scheduler) {
 			emergencyStop = true;
@@ -1271,6 +1274,11 @@ public class BMPController extends DatabaseAwareBean {
 		 * Clear the last BMP exception.
 		 */
 		void clearBmpException();
+
+		/**
+		 * Resume after emergency stop.
+		 */
+		void emergencyResume();
 	}
 
 	/**
@@ -1329,6 +1337,15 @@ public class BMPController extends DatabaseAwareBean {
 			public void clearBmpException() {
 				synchronized (BMPController.this) {
 					bmpProcessingException = null;
+				}
+			}
+
+			@Override
+			public void emergencyResume() {
+				synchronized (scheduler) {
+					emergencyStop = false;
+					workers.clear();
+					init();
 				}
 			}
 		};

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
@@ -21,6 +21,7 @@ import static uk.ac.manchester.spinnaker.messages.model.FPGAMainRegisters.FLAG;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -315,7 +316,7 @@ class SpiNNaker1 implements SpiNNakerControl {
 	}
 
 	@Override
-	public void powerOff(List<BMPBoard> boards)
+	public void powerOff(Collection<BMPBoard> boards)
 			throws ProcessException, InterruptedException, IOException {
 		txrx.powerOff(boards);
 	}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNaker1.java
@@ -44,7 +44,6 @@ import uk.ac.manchester.spinnaker.messages.model.FPGA;
 import uk.ac.manchester.spinnaker.transceiver.BMPTransceiverInterface;
 import uk.ac.manchester.spinnaker.transceiver.ProcessException;
 import uk.ac.manchester.spinnaker.transceiver.SpinnmanException;
-import uk.ac.manchester.spinnaker.utils.Ping;
 import uk.ac.manchester.spinnaker.utils.UsedInJavadocOnly;
 
 /**
@@ -349,7 +348,7 @@ class SpiNNaker1 implements SpiNNakerControl {
 	public void ping(List<BMPBoard> boards) {
 		boards.parallelStream().forEach(id -> {
 			var address = boardAddresses.get(id);
-			if (Ping.ping(address) != 0) {
+			if (txrx.pingBoard(address) != 0) {
 				log.warn(
 						"ARP fault? Board with address {} might not have "
 								+ "come up correctly", address);

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControl.java
@@ -16,6 +16,7 @@
 package uk.ac.manchester.spinnaker.alloc.bmp;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +89,7 @@ public interface SpiNNakerControl {
 	 * @throws InterruptedException
 	 *             If we're interrupted.
 	 */
-	void powerOff(List<BMPBoard> boards)
+	void powerOff(Collection<BMPBoard> boards)
 			throws ProcessException, InterruptedException, IOException;
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControlDummy.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/SpiNNakerControlDummy.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.spinnaker.alloc.bmp;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import uk.ac.manchester.spinnaker.machine.board.BMPBoard;
+import uk.ac.manchester.spinnaker.messages.model.ADCInfo;
+import uk.ac.manchester.spinnaker.messages.model.Blacklist;
+import uk.ac.manchester.spinnaker.transceiver.ProcessException;
+
+/**
+ * Dummy implementation of the SpiNNakerControl interface.
+ */
+public class SpiNNakerControlDummy implements SpiNNakerControl {
+
+	private static final String DUMMY_SERIAL = "00000000";
+
+	private final Map<BMPBoard, Blacklist> blacklists = new HashMap<>();
+
+	@Override
+	public void powerOnAndCheck(List<BMPBoard> boards) throws ProcessException,
+			InterruptedException, IOException {
+		// Do Nothing
+	}
+
+	@Override
+	public void setLinkOff(Link link) throws ProcessException, IOException,
+			InterruptedException {
+		// Do Nothing
+	}
+
+	@Override
+	public void powerOff(Collection<BMPBoard> boards) throws ProcessException,
+			InterruptedException, IOException {
+		// Do Nothing
+
+	}
+
+	@Override
+	public String readSerial(BMPBoard board) throws ProcessException,
+			InterruptedException, IOException {
+		return DUMMY_SERIAL;
+	}
+
+	@Override
+	public ADCInfo readTemp(BMPBoard board) throws ProcessException,
+			IOException, InterruptedException {
+		return new ADCInfo(ByteBuffer.wrap(new byte[ADCInfo.SIZE]));
+	}
+
+	@Override
+	public Blacklist readBlacklist(BMPBoard board) throws ProcessException,
+			InterruptedException, IOException {
+		if (blacklists.containsKey(board)) {
+			return blacklists.get(board);
+		}
+		return new Blacklist(ByteBuffer.wrap(new byte[Integer.BYTES]));
+	}
+
+	@Override
+	public void writeBlacklist(BMPBoard board, Blacklist blacklist)
+			throws ProcessException, InterruptedException, IOException {
+		blacklists.put(board, blacklist);
+	}
+
+	@Override
+	public void ping(List<BMPBoard> boards) {
+		// Do Nothing
+	}
+
+}

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/bmp/TransceiverFactory.java
@@ -157,7 +157,7 @@ public class TransceiverFactory
 			BMPCoords bmp) {
 		var connData = makeConnectionData(machineDescription, bmp);
 		try {
-			if (control.isUseDummyBMP()) {
+			if (testFactory != null) {
 				return testFactory.create(machineDescription.getName(),
 						connData, setBlacklist);
 			} else {

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/db/SQLQueries.java
@@ -178,6 +178,17 @@ public abstract class SQLQueries {
 					+ "FROM jobs WHERE job_state != 4 " // DESTROYED
 					+ "ORDER BY job_id DESC LIMIT :limit OFFSET :offset";
 
+	/** Select all live jobs. */
+	@ResultColumn("job_id")
+	protected static final String GET_ALL_LIVE_JOBS =
+			"SELECT job_id FROM jobs WHERE job_state != 4";
+
+	/** Destroy all live jobs. */
+	@Parameter("death_reason")
+	protected static final String DESTROY_ALL_LIVE_JOBS =
+			"UPDATE jobs SET job_state = 4, death_reason = :death_reason, "
+			+ "death_timestamp = UNIX_TIMESTAMP() WHERE job_state != 4";
+
 	/** Get basic information about a specific job. */
 	@Parameter("job_id")
 	@ResultColumn("job_id")
@@ -765,6 +776,13 @@ public abstract class SQLQueries {
 					+ "WHERE board_id = :board_id";
 
 	/**
+	 * Set all boards to off.
+	 */
+	protected static final String SET_ALL_BOARDS_OFF =
+			"UPDATE boards SET board_power = 0, "
+					+ "power_off_timestamp = UNIX_TIMESTAMP()";
+
+	/**
 	 * Find jobs that have expired their keepalive interval.
 	 *
 	 * @see AllocatorTask
@@ -801,6 +819,10 @@ public abstract class SQLQueries {
 	@Parameter("job_id")
 	protected static final String KILL_JOB_ALLOC_TASK =
 			"DELETE FROM job_request WHERE job_id = :job_id";
+
+	/** Delete all requests to allocate resources for a job. */
+	protected static final String KILL_ALL_JOB_ALLOC_TASK =
+			"DELETE FROM job_request";
 
 	/**
 	 * Delete a request to change the power of a board. Used once the change has

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
@@ -16,6 +16,7 @@
 package uk.ac.manchester.spinnaker.alloc.web;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -270,6 +271,18 @@ public interface SpallocServiceAPI {
 			@Positive(message = "job ID must be positive") int id,
 			@Context UriInfo ui, @Context HttpServletRequest request,
 			@Context SecurityContext security);
+
+
+
+	@DELETE
+	@Description("Immediately stop all jobs and power down all boards,"
+			+ " and stop accepting new jobs.")
+	@Operation(parameters = @Parameter(in = QUERY, name = "commandCode",
+			description = "The command code to validate the request.",
+			schema = @Schema(implementation = String.class)))
+	@Path("/emergencyStop")
+	void emergencyStop(@QueryParam("commandCode") String commandCode,
+			@Suspended AsyncResponse response);
 
 	/**
 	 * Interface to a particular machine.

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
@@ -272,8 +272,12 @@ public interface SpallocServiceAPI {
 			@Context UriInfo ui, @Context HttpServletRequest request,
 			@Context SecurityContext security);
 
-
-
+	/**
+	 * Immediately stop all jobs and power down all boards.
+	 *
+	 * @param commandCode
+	 * @param response
+	 */
 	@DELETE
 	@Description("Immediately stop all jobs and power down all boards,"
 			+ " and stop accepting new jobs.")

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceAPI.java
@@ -16,7 +16,6 @@
 package uk.ac.manchester.spinnaker.alloc.web;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
-import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -278,14 +277,12 @@ public interface SpallocServiceAPI {
 	 * @param commandCode
 	 * @param response
 	 */
-	@DELETE
+	@GET
 	@Description("Immediately stop all jobs and power down all boards,"
 			+ " and stop accepting new jobs.")
-	@Operation(parameters = @Parameter(in = QUERY, name = "commandCode",
-			description = "The command code to validate the request.",
-			schema = @Schema(implementation = String.class)))
 	@Path("/emergencyStop")
-	void emergencyStop(@QueryParam("commandCode") String commandCode,
+	void emergencyStop(@Description("Code to validate the request.")
+			@QueryParam("commandCode") String commandCode,
 			@Suspended AsyncResponse response);
 
 	/**

--- a/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceImpl.java
+++ b/SpiNNaker-allocserv/src/main/java/uk/ac/manchester/spinnaker/alloc/web/SpallocServiceImpl.java
@@ -367,4 +367,12 @@ public class SpallocServiceImpl extends BackgroundSupport
 			return new CreateNumBoards(1, 0);
 		}
 	}
+
+	@Override
+	public void emergencyStop(String commandCode, AsyncResponse response) {
+		bgAction(response, () -> {
+			core.emergencyStop(commandCode);
+			return ok().build();
+		});
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorFailTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorFailTest.java
@@ -123,6 +123,7 @@ public class AllocatorFailTest extends TestSupport {
 
 				// Make a transceiver that *doesn't* fail the requests
 				MockTransceiver.installIntoFactory(txrxFactory);
+				MockTransceiver.fpgaResults.clear();
 				this.bmpCtrl.resetTransceivers();
 
 				// So we should be able to reallocate the job to a new board

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorFailTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorFailTest.java
@@ -66,7 +66,7 @@ public class AllocatorFailTest extends TestSupport {
 		setupDB3();
 		this.txrxFactory = txrxFactory;
 		this.bmpCtrl = bmpCtrl.getTestAPI();
-		this.bmpCtrl.prepare();
+		this.bmpCtrl.prepare(false);
 		this.bmpCtrl.clearBmpException();
 	}
 

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
@@ -458,6 +458,9 @@ class AllocatorTest extends TestSupport {
 			getAllocTester().emergencyStop();
 
 			assertState(job, DESTROYED, 0, 0);
+
+			getAllocTester().restartAfterStop();
+			bmpCtrl.emergencyResume();
 		});
 	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
@@ -69,7 +69,7 @@ class AllocatorTest extends TestSupport {
 		killDB();
 		setupDB3();
 		this.bmpCtrl = bmpCtrl.getTestAPI();
-		this.bmpCtrl.prepare();
+		this.bmpCtrl.prepare(true);
 		this.bmpCtrl.clearBmpException();
 	}
 

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/AllocatorTest.java
@@ -443,4 +443,21 @@ class AllocatorTest extends TestSupport {
 			}
 		});
 	}
+
+	@Test
+	public void emergencyStop() throws Exception {
+		doTransactionalTest(() -> {
+			int job = makeQueuedJob(1);
+			getAllocTester().allocate();
+			makeAllocBySizeRequest(job, 1);
+			snooze1s();
+			snooze1s();
+
+			assumeState(job, QUEUED, 1, 0);
+
+			getAllocTester().emergencyStop();
+
+			assertState(job, DESTROYED, 0, 0);
+		});
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
@@ -67,7 +67,7 @@ class FirmwareLoaderTest extends TestSupport {
 		killDB();
 		setupDB1();
 		this.bmpCtrl = bmpCtrl.getTestAPI();
-		this.bmpCtrl.prepare();
+		this.bmpCtrl.prepare(true);
 		this.bmpCtrl.clearBmpException();
 	}
 

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/allocator/FirmwareLoaderTest.java
@@ -180,6 +180,7 @@ class FirmwareLoaderTest extends TestSupport {
 		 * FPGA_ALL is a bogus value for the result of the particular
 		 * readFPGARegister() call we care about.
 		 */
+		MockTransceiver.fpgaResults.clear();
 		MockTransceiver.fpgaResults.add(FPGA.FPGA_ALL);
 		try (var c = db.getConnection()) {
 			this.conn = c;
@@ -204,6 +205,7 @@ class FirmwareLoaderTest extends TestSupport {
 		 * Two failures trigger a the reloading of the firmware. This is slow
 		 * (even slower in reality).
 		 */
+		MockTransceiver.fpgaResults.clear();
 		MockTransceiver.fpgaResults.add(FPGA.FPGA_ALL);
 		MockTransceiver.fpgaResults.add(FPGA.FPGA_ALL);
 		try (var c = db.getConnection()) {

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/BlacklistCommsTest.java
@@ -80,7 +80,8 @@ class BlacklistCommsTest extends TestSupport {
 		this.txrxFactory = txrxFactory.getTestAPI();
 		exec = newSingleThreadExecutor();
 		this.bmpCtrl = bmpCtrl.getTestAPI();
-		this.bmpCtrl.prepare();
+		this.bmpCtrl.prepare(false);
+		this.bmpCtrl.resetTransceivers();
 		this.bmpCtrl.clearBmpException();
 	}
 

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
@@ -291,4 +291,10 @@ public final class MockTransceiver extends UnimplementedBMPTransceiver {
 		crc.update(slice(flash, baseAddress.address, length));
 		return (int) (crc.getValue() & CRC_MASK);
 	}
+
+	@Override
+	public int pingBoard(String address) {
+		log.info("pingBoard({})", address);
+		return 0;
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/bmp/MockTransceiver.java
@@ -159,8 +159,10 @@ public final class MockTransceiver extends UnimplementedBMPTransceiver {
 		log.info("readFPGARegister({},{},{},{})", fpga, register, bmp, board);
 		var r = fpgaResults.pollFirst();
 		if (r != null) {
+			log.info("Returning {} from queue", r.value);
 			return r.value;
 		}
+		log.info("Returning {} from FPGA", fpga.value);
 		return fpga.value;
 	}
 

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DMLTest.java
@@ -1038,4 +1038,37 @@ class DMLTest extends SimpleDBTestBase {
 			});
 		}
 	}
+
+	@Test
+	void destroyAllLiveJobs() {
+		assumeWritable(c);
+		try (var u = c.update(DESTROY_ALL_LIVE_JOBS)) {
+			c.transaction(() -> {
+				assertEquals(List.of("death_reason"), u.getParameters());
+				assertEquals(0, u.call(""));
+			});
+		}
+	}
+
+	@Test
+	void killAllJobAllocTask() {
+		assumeWritable(c);
+		try (var u = c.update(KILL_ALL_JOB_ALLOC_TASK)) {
+			c.transaction(() -> {
+				assertEquals(List.of(), u.getParameters());
+				assertEquals(0, u.call());
+			});
+		}
+	}
+
+	@Test
+	void setAllBoardsOff() {
+		assumeWritable(c);
+		try (var u = c.update(SET_ALL_BOARDS_OFF)) {
+			c.transaction(() -> {
+				assertEquals(List.of(), u.getParameters());
+				assertEquals(0, u.call());
+			});
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
+++ b/SpiNNaker-allocserv/src/test/java/uk/ac/manchester/spinnaker/alloc/db/DQLTest.java
@@ -1336,4 +1336,16 @@ class DQLTest extends SimpleDBTestBase {
 			});
 		}
 	}
+
+	@Test
+	void getAllLiveJobs() {
+		try (var q = c.query(GET_ALL_LIVE_JOBS)) {
+			c.transaction(() -> {
+				assertEquals(List.of(), q.getParameters());
+				assertEquals(List.of("job_id"),	q.getColumns());
+				// No jobs right now
+				assertEquals(empty(), q.call1(integer("job_id")));
+			});
+		}
+	}
 }

--- a/SpiNNaker-allocserv/src/test/resources/application-unittest.yml
+++ b/SpiNNaker-allocserv/src/test/resources/application-unittest.yml
@@ -39,3 +39,5 @@ spalloc:
   historical-data:
     datasource:
       jdbc-url: jdbc:tc:mysql:8.2.0:///;databaseName=spallochistory?user=root&password=test
+  allocator:
+    emergencyStopCommandCode: TestingTesting123

--- a/SpiNNaker-allocserv/src/test/resources/application-unittest.yml
+++ b/SpiNNaker-allocserv/src/test/resources/application-unittest.yml
@@ -29,8 +29,6 @@ spalloc:
       domain: file:/there-is-no-such-file.txt
       introspection: file:/there-is-no-such-file.txt
       userinfo: file:/there-is-no-such-file.txt
-  transceiver:
-    dummy: true
   sqlite:
     performance-log: true
     performance-threshold: 1e2

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/BMPTransceiverInterface.java
@@ -1864,6 +1864,15 @@ public interface BMPTransceiverInterface extends AutoCloseable {
 
 	@Override
 	void close() throws IOException;
+
+	/**
+	 * Ping a board.
+	 *
+	 * @param address The board IP address.
+	 * @return 0 on success, other values on failure (reflecting the result of
+	 *         the OS subprocess).
+	 */
+	int pingBoard(String address);
 }
 
 interface BMPConstants {

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/Transceiver.java
@@ -168,6 +168,7 @@ import uk.ac.manchester.spinnaker.protocols.download.Downloader;
 import uk.ac.manchester.spinnaker.storage.BufferManagerStorage;
 import uk.ac.manchester.spinnaker.storage.StorageException;
 import uk.ac.manchester.spinnaker.utils.MappableIterable;
+import uk.ac.manchester.spinnaker.utils.Ping;
 
 /**
  * An encapsulation of various communications with the SpiNNaker board. Acts as
@@ -2780,5 +2781,10 @@ public class Transceiver extends UDPTransceiver
 	@Override
 	public BMPCoords getBoundBMP() {
 		return boundBMP;
+	}
+
+	@Override
+	public int pingBoard(String address) {
+		return Ping.ping(address);
 	}
 }

--- a/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UnimplementedBMPTransceiver.java
+++ b/SpiNNaker-comms/src/main/java/uk/ac/manchester/spinnaker/transceiver/UnimplementedBMPTransceiver.java
@@ -209,4 +209,9 @@ public abstract class UnimplementedBMPTransceiver
 	@Override
 	public void close() throws IOException {
 	}
+
+	@Override
+	public int pingBoard(String address) {
+		throw new UnsupportedOperationException();
+	}
 }


### PR DESCRIPTION
Contributes to SpiNNakerManchester/SpiNNaker_hardware_tests#3

Adds the ability to shut down the machine from the outside by sending a command.  Theoretically any logged in user can do this, but in reality it requires knowledge of an additional "command code" to do so.  This allows us to have a non-admin user password stored somewhere to enact this automatically, but also protect it from "any old user" doing it.

Note that the changes here also let a developer run the allocation code without having to have a SpiNNaker machine available for testing.  This is useful for testing non-machine changes e.g. user interface updates, or things like this where what the machine actually does doesn't matter.