### PR TITLE
Java 21 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Minimum Java version!
-        java: [17]
+        java: [21]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java }}
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        java: [17, 21]
+        java: [21, 25]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK
@@ -98,8 +98,8 @@ jobs:
         CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
         COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
       continue-on-error: true
-    - name: Upload Build (JDK 11 only)
-      if: matrix.java == 11
+    - name: Upload Build (JDK 21 only)
+      if: matrix.java == 21
       uses: actions/upload-artifact@v6
       with:
         name: spinnaker-exe.jar
@@ -107,7 +107,7 @@ jobs:
         retention-days: 5
       continue-on-error: true
     - name: Submit Dependency Snapshot
-      if: matrix.java == 11
+      if: matrix.java == 21
       uses: advanced-security/maven-dependency-submission-action@v5
       continue-on-error: true
 
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        java: [17, 21]
+        java: [21, 25]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java }}
@@ -141,11 +141,11 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v6
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v5.1.0
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 21
         cache: 'maven'
 
     - name: "Check: No FIXMEs left"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,7 +60,7 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-        version: [ 17 ]
+        version: [ 21 ]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        java: [17]
+        java: [21]
     env:
       SITE_DIR: target/staging
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,19 +23,19 @@ build:
         - pip install jq
         - curl -s https://api.github.com/repos/apache/maven/releases/latest | python -c "import jq, json, sys; print(jq.compile(\".name\").input_value(json.load(sys.stdin)).first())" > .MAVEN_VERSION
         - cat .MAVEN_VERSION
-        - curl --output jdk.tar.gz https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
+        - curl --output jdk.tar.gz https://download.java.net/java/GA/jdk25.0.1/2fbf10d8c78e40bd87641c434705079d/8/GPL/openjdk-25.0.1_linux-x64_bin.tar.gz
         - tar zxvf jdk.tar.gz
         - curl --output maven.tar.gz https://dlcdn.apache.org/maven/maven-3/$(cat .MAVEN_VERSION)/binaries/apache-maven-$(cat .MAVEN_VERSION)-bin.tar.gz
         - tar zxvf maven.tar.gz
         - mkdir -p ${READTHEDOCS_VIRTUALENV_PATH}/bin/
-        - ln -s $PWD/jdk-17.0.2/bin/java ${READTHEDOCS_VIRTUALENV_PATH}/bin/java
-        - ln -s $PWD/jdk-17.0.2/bin/javac ${READTHEDOCS_VIRTUALENV_PATH}/bin/javac
-        - ln -s $PWD/jdk-17.0.2/bin/javadoc ${READTHEDOCS_VIRTUALENV_PATH}/bin/javadoc
+        - ln -s $PWD/jdk-25.0.1/bin/java ${READTHEDOCS_VIRTUALENV_PATH}/bin/java
+        - ln -s $PWD/jdk-25.0.1/bin/javac ${READTHEDOCS_VIRTUALENV_PATH}/bin/javac
+        - ln -s $PWD/jdk-25.0.1/bin/javadoc ${READTHEDOCS_VIRTUALENV_PATH}/bin/javadoc
         - ln -s $PWD/apache-maven-$(cat .MAVEN_VERSION)/bin/mvn ${READTHEDOCS_VIRTUALENV_PATH}/bin/mvn
-        - echo "jdk-17.0.2/**" >> .gitignore
+        - echo "jdk-25.0.1/**" >> .gitignore
         - echo "apache-maven-$(cat .MAVEN_VERSION)/**" >> .gitignore
         - echo ".MAVEN_VERSION" >> .gitignore
-        - JAVA_HOME=$PWD/jdk-17.0.2/ mvn install --settings .github/settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
-        - JAVA_HOME=$PWD/jdk-17.0.2/ mvn site site:stage --settings .github/settings.xml -P "!jsp-precompile"
+        - JAVA_HOME=$PWD/jdk-25.0.1/ mvn install --settings .github/settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
+        - JAVA_HOME=$PWD/jdk-25.0.1/ mvn site site:stage --settings .github/settings.xml -P "!jsp-precompile"
         - mkdir -p ${READTHEDOCS_OUTPUT}html/
         - cp -a target/staging/* ${READTHEDOCS_OUTPUT}html/

--- a/pom.xml
+++ b/pom.xml
@@ -1147,8 +1147,8 @@ limitations under the License.
 									<configuration>
 										<compilerArgs>
 											<arg>-XDcompilePolicy=simple</arg>
-											<!-- Options to EP must go in same arg. Ugh. -->
 											<arg>--should-stop=ifError=FLOW</arg>
+											<!-- Options to EP must go in same arg. Ugh. -->
 											<arg>
 												-Xplugin:ErrorProne
 												<!-- Disable the MissingSummary check; we use an abbreviated
@@ -1177,6 +1177,7 @@ limitations under the License.
 									<configuration>
 										<compilerArgs>
 											<arg>-XDcompilePolicy=simple</arg>
+											<arg>--should-stop=ifError=FLOW</arg>
 											<!-- Options to EP must go in same arg. Ugh. -->
 											<arg>
 												-Xplugin:ErrorProne

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.release>21</maven.compiler.release>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 
@@ -59,7 +59,7 @@ limitations under the License.
 		<sqlite.version>3.51.1.0</sqlite.version>
 		<keycloak.version>26.4.7</keycloak.version>
 		<swagger.version>5.31.0</swagger.version>
-		<error-prone.version>2.18.0</error-prone.version>
+		<error-prone.version>2.45.0</error-prone.version>
 		<picocli.version>4.7.7</picocli.version>
 		<mysql.version>9.5.0</mysql.version>
 		<testcontainers.version>2.0.3</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1148,6 +1148,7 @@ limitations under the License.
 										<compilerArgs>
 											<arg>-XDcompilePolicy=simple</arg>
 											<!-- Options to EP must go in same arg. Ugh. -->
+											<arg>--should-stop=ifError=FLOW</arg>
 											<arg>
 												-Xplugin:ErrorProne
 												<!-- Disable the MissingSummary check; we use an abbreviated


### PR DESCRIPTION
A number of updated dependencies are starting to move away from Java 17 to minimum Java 21.  We already support Java 21, but this would remove support for 17 and introduce support for the latest Java LTS version 25.  I think we are already using Java 21 everywhere that matters.